### PR TITLE
Used WordPress function edit_post_link() instead of astra_edit_post_link()

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -596,30 +596,6 @@ if ( ! function_exists( 'ast_body_font_family' ) ) {
 }
 
 /**
- * Function to get Edit Post Link
- */
-if ( ! function_exists( 'astra_edit_post_link' ) ) {
-
-	/**
-	 * Function to get Edit Post Link
-	 *
-	 * @since 1.0.0
-	 * @param string $text 		Anchor Text.
-	 * @param string $before 	Anchor Text.
-	 * @param string $after 	Anchor Text.
-	 * @param int    $id           Anchor Text.
-	 * @param string $class 	Anchor Text.
-	 * @return void
-	 */
-	function astra_edit_post_link( $text, $before = '', $after = '', $id = 0, $class = 'post-edit-link' ) {
-
-		if ( apply_filters( 'ast_edit_post_link', false ) ) {
-			edit_post_link( $text, $before, $after, $id, $class );
-		}
-	}
-}
-
-/**
  * Function to get Header Classes
  */
 if ( ! function_exists( 'ast_header_classes' ) ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -25,8 +25,7 @@ if ( ! function_exists( 'ast_entry_footer' ) ) :
 			echo '</span>';
 		}
 
-		astra_edit_post_link(
-
+		edit_post_link(
 			sprintf(
 				/* translators: %s: Name of current post */
 				esc_html__( 'Edit %s', 'astra' ),

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -52,8 +52,7 @@
 	</div><!-- .entry-content .clear -->
 
 	<?php
-		astra_edit_post_link(
-
+		edit_post_link(
 			sprintf(
 				/* translators: %s: Name of current post */
 				esc_html__( 'Edit %s', 'astra' ),

--- a/template-parts/single/single-layout.php
+++ b/template-parts/single/single-layout.php
@@ -26,11 +26,11 @@
 		<?php endif; ?>
 
 		<?php ast_the_title( '<h1 class="entry-title" itemprop="headline">', '</h1>' ); ?>
-		
+
 		<?php ast_single_header_bottom(); ?>
 
 	</header><!-- .entry-header -->
-	
+
 	<?php ast_single_header_after(); ?>
 
 	<div class="entry-content clear" itemprop="text">
@@ -40,8 +40,7 @@
 		<?php the_content(); ?>
 
 		<?php
-			astra_edit_post_link(
-
+			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
 					esc_html__( 'Edit %s', 'astra' ),


### PR DESCRIPTION
- Removed function `astra_edit_post_link()` and used `edit_post_link()`.
- To disable the edit link on page builder. We can use the filter `edit_post_link`.