### PR TITLE
Deprecated astra_sigle_post_navigation_enabled filter.

### DIFF
--- a/inc/blog/single-blog.php
+++ b/inc/blog/single-blog.php
@@ -206,7 +206,7 @@ if ( ! function_exists( 'astra_single_post_navigation_markup' ) ) {
 	 */
 	function astra_single_post_navigation_markup() {
 
-		$single_post_navigation_enabled = apply_filters( 'astra_sigle_post_navigation_enabled', true );
+		$single_post_navigation_enabled = apply_filters( 'astra_single_post_navigation_enabled', true );
 
 		if ( is_single() && $single_post_navigation_enabled ) {
 

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -29,3 +29,21 @@ function deprecated_astra_color_palette( $color_palette ) {
 
 	return $color_palette;
 }
+
+
+// Deprecating astra_sigle_post_navigation_enabled filter.
+add_filter( 'astra_single_post_navigation_enabled', 'deprecated_astra_sigle_post_navigation_enabled', 10, 1 );
+
+/**
+ * Astra Single Post Navigation
+ *
+ * @since 1.0.27
+ * @param boolean $post_nav true | false.
+ * @return boolean $post_nav true for enabled | false for disable.
+ */
+function deprecated_astra_sigle_post_navigation_enabled( $post_nav ) {
+
+	$post_nav = apply_filters_deprecated( 'astra_sigle_post_navigation_enabled', array( $post_nav ), '1.0.27', 'astra_single_post_navigation_enabled', '' );
+
+	return $post_nav;
+}


### PR DESCRIPTION
Issue : Deprecate `astra_sigle_post_navigation_enabled` filter

Fix : `astra_sigle_post_navigation_enabled` filter deprecated. Added `astra_single_post_navigation_enabled` filter added