### PR TITLE
Fix: add width to the svg logo's so that they are visible.

### DIFF
--- a/assets/js/unminified/customizer-preview.js
+++ b/assets/js/unminified/customizer-preview.js
@@ -207,7 +207,7 @@ function astra_add_dynamic_css( control, style ) {
 	wp.customize( 'astra-settings[ast-header-logo-width]', function( setting ) {
 		setting.bind( function( logo_width ) {
 			if ( logo_width != '' ) {
-				var dynamicStyle = '#masthead .site-logo-img .custom-logo-link img {max-width: ' + logo_width + 'px;}';
+				var dynamicStyle = '#masthead .site-logo-img .custom-logo-link img {max-width: ' + logo_width + 'px;} .astra-logo-svg{width: ' + logo_width + 'px;} ';
 				astra_add_dynamic_css( 'ast-header-logo-width', dynamicStyle );
 			}
 			else{

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -188,6 +188,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				'#masthead .site-logo-img .custom-logo-link img' => array(
 					'max-width' => astra_get_css_value( $header_logo_width, 'px' ),
 				),
+				'.astra-logo-svg'                         => array(
+					'width' => astra_get_css_value( $header_logo_width, 'px' ),
+				),
 				'.ast-archive-description .ast-archive-title' => array(
 					'font-size' => astra_responsive_font( $archive_summary_title_font_size, 'desktop' ),
 				),

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1219,11 +1219,27 @@ if ( ! function_exists( 'astra_replace_header_attr' ) ) :
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		if ( $custom_logo_id == $attachment->ID ) {
 
+			$attach_data = array();
 			if ( ! is_customize_preview() ) {
 				$attach_data = wp_get_attachment_image_src( $attachment->ID, 'ast-logo-size' );
+
 				if ( isset( $attach_data[0] ) ) {
 					$attr['src'] = $attach_data[0];
 				}
+			} else {
+				$attach_data = wp_get_attachment_image_src( $attachment->ID );
+
+				if ( isset( $attach_data[0] ) ) {
+					$attr['src'] = $attach_data[0];
+				}
+			}
+
+			$image_url      = isset( $attach_data[0] ) ? $attach_data[0] : false;
+			$file_type      = wp_check_filetype( $attach_data[0] );
+			$file_extension = $file_type['ext'];
+
+			if ( 'svg' == $file_extension ) {
+				$attr['class'] = 'astra-logo-svg';
 			}
 
 			$retina_logo = astra_get_option( 'ast-header-retina-logo' );


### PR DESCRIPTION
This keeps the CSS weight of the new CSS low so that anyone who has added any custom CSS solution will keep overriding this new CSS