### PR TITLE
New filter to enable / disable automatic page builder compatibility.

### DIFF
--- a/inc/compatibility/class-astra-beaver-builder.php
+++ b/inc/compatibility/class-astra-beaver-builder.php
@@ -55,6 +55,12 @@ if ( ! class_exists( 'Astra_Beaver_Builder' ) ) :
 		 */
 		function beaver_builder_default_setting() {
 
+			$page_builder_compatibility = apply_filters( 'astra_enable_page_builder_compatibility', true );
+
+			if ( false == $page_builder_compatibility ) {
+				return;
+			}
+
 			global $post;
 			$id = astra_get_post_id();
 

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -57,6 +57,12 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 		 */
 		function elementor_default_setting() {
 
+			$page_builder_compatibility = apply_filters( 'astra_enable_page_builder_compatibility', true );
+
+			if ( false == $page_builder_compatibility ) {
+				return;
+			}
+
 			global $post;
 			$id = astra_get_post_id();
 


### PR DESCRIPTION
Astra automatically sets up page meta options for layout when using a page builder. This helps to reduce the number of clicks when setting up a new page.

Although if someone wants to disable this functionality. `astra_enable_page_builder_compatibility` filter can be used.

eg - 
```
add_filter( 'astra_enable_page_builder_compatibility', '__return_false' );
```