### PR TITLE
Version 1.0.31

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v1.0.31
+# New: Filter `astra_enable_page_builder_compatibility` added to disable default page builder compatibility meta settings.
+# Fixed: Some SVG logos being not displayed.
+# Fixed: Thumbnail image not visible on blog page.
+
 v1.0.30
 # Fixed: Regression in v1.0.29 which caused site logo to be full width.
 

--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,7 @@
 /**
  * Define Constants
  */
-define( 'ASTRA_THEME_VERSION', '1.0.30' );
+define( 'ASTRA_THEME_VERSION', '1.0.31' );
 define( 'ASTRA_THEME_SETTINGS', 'astra-settings' );
 define( 'ASTRA_THEME_DIR', get_template_directory() . '/' );
 define( 'ASTRA_THEME_URI', get_template_directory_uri() . '/' );

--- a/languages/astra.pot
+++ b/languages/astra.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra 1.0.30\n"
+"Project-Id-Version: Astra 1.0.31\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/style\n"
-"POT-Creation-Date: 2017-11-30 06:37:06+00:00\n"
+"POT-Creation-Date: 2017-11-30 13:07:42+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "A very lightweight and beautiful theme made to work with Page Builders.",
   "main": "Gruntfile.js",
   "repository": {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wpastra.com/
 Author: Brainstorm Force
 Author URI: http://wpastra.com/about/
 Description: Astra is the fastest, fully customizable & beautiful theme suitable for blogs, personal portfolios and business websites. It is very lightweight (less than 50KB on frontend) and offers unparalleled speed. Built with SEO in mind, Astra comes with schema.org code integrated so search engines will love your site. Astra offers plenty of sidebar options and widget areas giving you a full control for customizations. Furthermore, we have included special features and templates so feel free to choose any of your favorite page builder plugin to create pages flexibly. Some of the other features: # WooCommerce Ready # Responsive # Compatible with major plugins # Translation Ready # Extendible with premium addons # Regularly updated # Designed, Developed, Maintained & Supported by Brainstorm Force. Looking for a perfect base theme? Look no further. Astra is fast, fully customizable and beautiful theme!
-Version: 1.0.30
+Version: 1.0.31
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: astra


### PR DESCRIPTION
**v1.0.31**
New: Filter `astra_enable_page_builder_compatibility` added to disable default page builder compatibility meta settings.
Fixed: Some SVG logos being not displayed.
Fixed: Thumbnail image not visible on a blog page.