### PR TITLE
Astra filters deprecated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v1.1.1
 # New: Added filter `astra_enqueue_theme_assets` to disable loading of Astra's CSS and JS.
 # Fixed: PHP notice in the small footer on PHP 7.2
 # Fixed: Updated woocommerce Related products design for responsive devices.
+# Fixed: Deprecated filter fatal error in WordPress 4.5 & below.
 
 v1.1.0
 # New: Added Woocommerce complete support.

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -25,7 +25,7 @@ add_filter( 'astra_color_palettes', 'deprecated_astra_color_palette', 10, 1 );
  */
 function deprecated_astra_color_palette( $color_palette ) {
 
-	$color_palette = apply_astra_filters_deprecated( 'astra_color_palletes', array( $color_palette ), '1.0.22', 'astra_color_palettes', '' );
+	$color_palette = astra_apply_filters_deprecated( 'astra_color_palletes', array( $color_palette ), '1.0.22', 'astra_color_palettes', '' );
 
 	return $color_palette;
 }
@@ -43,12 +43,12 @@ add_filter( 'astra_single_post_navigation_enabled', 'deprecated_astra_sigle_post
  */
 function deprecated_astra_sigle_post_navigation_enabled( $post_nav ) {
 
-	$post_nav = apply_astra_filters_deprecated( 'astra_sigle_post_navigation_enabled', array( $post_nav ), '1.0.27', 'astra_single_post_navigation_enabled', '' );
+	$post_nav = astra_apply_filters_deprecated( 'astra_sigle_post_navigation_enabled', array( $post_nav ), '1.0.27', 'astra_single_post_navigation_enabled', '' );
 
 	return $post_nav;
 }
 
-if ( ! function_exists( 'apply_astra_filters_deprecated' ) ) {
+if ( ! function_exists( 'astra_apply_filters_deprecated' ) ) {
 	/**
 	 * Astra Filter Deprecated
 	 *
@@ -59,7 +59,7 @@ if ( ! function_exists( 'apply_astra_filters_deprecated' ) ) {
 	 * @param string $replacement Optional. The hook that should have been used. Default false.
 	 * @param string $message     Optional. A message regarding the change. Default null.
 	 */
-	function apply_astra_filters_deprecated( $tag, $args, $version, $replacement = false, $message = null ) {
+	function astra_apply_filters_deprecated( $tag, $args, $version, $replacement = false, $message = null ) {
 		if ( function_exists( 'apply_filters_deprecated' ) ) { /* WP >= 4.6 */
 			return apply_filters_deprecated( $tag, $args, $version, $replacement, $message );
 		} else {

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -48,18 +48,17 @@ function deprecated_astra_sigle_post_navigation_enabled( $post_nav ) {
 	return $post_nav;
 }
 
-
-/**
- * Astra Filter Deprecated
- *
- * @since 1.1.1
- * @param string $tag         The name of the filter hook.
- * @param array  $args        Array of additional function arguments to be passed to apply_filters().
- * @param string $version     The version of WordPress that deprecated the hook.
- * @param string $replacement Optional. The hook that should have been used. Default false.
- * @param string $message     Optional. A message regarding the change. Default null.
- */
 if ( ! function_exists( 'apply_astra_filters_deprecated' ) ) {
+	/**
+	 * Astra Filter Deprecated
+	 *
+	 * @since 1.1.1
+	 * @param string $tag         The name of the filter hook.
+	 * @param array  $args        Array of additional function arguments to be passed to apply_filters().
+	 * @param string $version     The version of WordPress that deprecated the hook.
+	 * @param string $replacement Optional. The hook that should have been used. Default false.
+	 * @param string $message     Optional. A message regarding the change. Default null.
+	 */
 	function apply_astra_filters_deprecated( $tag, $args, $version, $replacement = false, $message = null ) {
 		if ( function_exists( 'apply_filters_deprecated' ) ) { /* WP >= 4.6 */
 			return apply_filters_deprecated( $tag, $args, $version, $replacement, $message );

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -25,7 +25,7 @@ add_filter( 'astra_color_palettes', 'deprecated_astra_color_palette', 10, 1 );
  */
 function deprecated_astra_color_palette( $color_palette ) {
 
-	$color_palette = apply_filters_deprecated( 'astra_color_palletes', array( $color_palette ), '1.0.22', 'astra_color_palettes', '' );
+	$color_palette = apply_astra_filters_deprecated( 'astra_color_palletes', array( $color_palette ), '1.0.22', 'astra_color_palettes', '' );
 
 	return $color_palette;
 }
@@ -43,7 +43,28 @@ add_filter( 'astra_single_post_navigation_enabled', 'deprecated_astra_sigle_post
  */
 function deprecated_astra_sigle_post_navigation_enabled( $post_nav ) {
 
-	$post_nav = apply_filters_deprecated( 'astra_sigle_post_navigation_enabled', array( $post_nav ), '1.0.27', 'astra_single_post_navigation_enabled', '' );
+	$post_nav = apply_astra_filters_deprecated( 'astra_sigle_post_navigation_enabled', array( $post_nav ), '1.0.27', 'astra_single_post_navigation_enabled', '' );
 
 	return $post_nav;
+}
+
+
+/**
+ * Astra Filter Deprecated
+ *
+ * @since 1.1.1
+ * @param string $tag         The name of the filter hook.
+ * @param array  $args        Array of additional function arguments to be passed to apply_filters().
+ * @param string $version     The version of WordPress that deprecated the hook.
+ * @param string $replacement Optional. The hook that should have been used. Default false.
+ * @param string $message     Optional. A message regarding the change. Default null.
+ */
+if ( ! function_exists( 'apply_astra_filters_deprecated' ) ) {
+	function apply_astra_filters_deprecated( $tag, $args, $version, $replacement = false, $message = null ) {
+		if ( function_exists( 'apply_filters_deprecated' ) ) { /* WP >= 4.6 */
+			return apply_filters_deprecated( $tag, $args, $version, $replacement, $message );
+		} else {
+			return apply_filters_ref_array( $tag, $args );
+		}
+	}
 }


### PR DESCRIPTION
- Fixed: Deprecated filter fatal error in WordPress 4.5 & below.