### PR TITLE
remove post nav on LifterLMS quizzes

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -125,6 +125,10 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 				add_action( 'astra_entry_after', 'lifterlms_template_lesson_navigation' );
 			}
 
+			if ( is_quiz() ) {
+				remove_action( 'astra_entry_after', 'astra_single_post_navigation_markup' );
+			}
+
 			remove_action( 'lifterlms_single_course_after_summary', 'lifterlms_template_single_reviews', 100 );
 			add_action( 'lifterlms_single_course_after_summary', array( $this, 'single_reviews' ), 100 );
 


### PR DESCRIPTION
Remove the hooked `astra_single_post_navigation_markup()` for LifterLMS quizzes.

It's pretty clear that this kind of navigation is intended for blog posts (and maybe pages) but causes a poor user experience when displayed on quizzes.