### PR TITLE
add LifterLMS course builder layout option compatibility

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			add_filter( 'lifterlms_loop_columns', array( $this, 'course_grid' ) );
 			add_filter( 'llms_get_loop_list_classes', array( $this, 'course_responsive_grid' ), 999 );
 
-			// Course builder custom fields
+			// Course builder custom fields.
 			add_filter( 'llms_get_quiz_theme_settings', array( $this, 'quiz_layout_fields' ) );
 
 		}
@@ -589,22 +589,22 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 		 * Add layout settings for LifterLMS quizzes
 		 *
 		 * @since [version]
-		 * @param array $settings layout settings
-		 * @return array $settings layout settings
+		 * @param array $settings layout settings.
+		 * @return array $settings layout settings.
 		 */
 		function quiz_layout_fields( $settings ) {
 
 			$settings['layout'] = array(
-				'id' => 'site-content-layout',
-				'name' => __( 'Content Layout', 'astra' ),
+				'id'      => 'site-content-layout',
+				'name'    => __( 'Content Layout', 'astra' ),
 				'options' => array(
-					'default' => esc_html__( 'Customizer Setting', 'astra' ),
-					'boxed-container' => esc_html__( 'Boxed', 'astra' ),
+					'default'                 => esc_html__( 'Customizer Setting', 'astra' ),
+					'boxed-container'         => esc_html__( 'Boxed', 'astra' ),
 					'content-boxed-container' => esc_html__( 'Content Boxed', 'astra' ),
-					'plain-container' => esc_html__( 'Full Width / Contained', 'astra' ),
-					'page-builder' => esc_html__( 'Full Width / Stretched', 'astra' ),
+					'plain-container'         => esc_html__( 'Full Width / Contained', 'astra' ),
+					'page-builder'            => esc_html__( 'Full Width / Stretched', 'astra' ),
 				),
-				'type' => 'select',
+				'type'    => 'select',
 			);
 
 			return $settings;

--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -66,6 +66,10 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			// Grid.
 			add_filter( 'lifterlms_loop_columns', array( $this, 'course_grid' ) );
 			add_filter( 'llms_get_loop_list_classes', array( $this, 'course_responsive_grid' ), 999 );
+
+			// Course builder custom fields
+			add_filter( 'llms_get_quiz_theme_settings', array( $this, 'quiz_layout_fields' ) );
+
 		}
 
 		/**
@@ -486,6 +490,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 		 * @return   void
 		 */
 		function add_theme_support() {
+			add_theme_support( 'lifterlms-quizzes' );
 			add_theme_support( 'lifterlms-sidebars' );
 		}
 
@@ -578,6 +583,32 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			}
 
 			return $layout;
+		}
+
+		/**
+		 * Add layout settings for LifterLMS quizzes
+		 *
+		 * @since [version]
+		 * @param array $settings layout settings
+		 * @return array $settings layout settings
+		 */
+		function quiz_layout_fields( $settings ) {
+
+			$settings['layout'] = array(
+				'id' => 'site-content-layout',
+				'name' => __( 'Content Layout', 'astra' ),
+				'options' => array(
+					'default' => esc_html__( 'Customizer Setting', 'astra' ),
+					'boxed-container' => esc_html__( 'Boxed', 'astra' ),
+					'content-boxed-container' => esc_html__( 'Content Boxed', 'astra' ),
+					'plain-container' => esc_html__( 'Full Width / Contained', 'astra' ),
+					'page-builder' => esc_html__( 'Full Width / Stretched', 'astra' ),
+				),
+				'type' => 'select',
+			);
+
+			return $settings;
+
 		}
 
 	}


### PR DESCRIPTION
This adds Astra layout post options to LifterLMS quizzes via the [course builder theme compatibility API](https://lifterlms.com/docs/quiz-theme-compatibility-developers/).

This allows users to select alternate layout options on LifterLMS quizzes via the builder.

![course_builder_ _llms-72_dev_ _wordpress](https://user-images.githubusercontent.com/1290739/37309273-9fe11a34-25fd-11e8-9884-ce2c43617dc3.jpg)

Currently we only have support for a single field so possibly we could add support for the sidebar fields (as well as many of the other layout/post options available in Astra. However, at this moment I wanted to make this available to you if you were interested in using it.

<3