### PR TITLE
Fixes issues related to video embeds due to ast-oembed-container class

### DIFF
--- a/assets/css/unminified/editor-style-rtl.css
+++ b/assets/css/unminified/editor-style-rtl.css
@@ -2039,8 +2039,7 @@ textarea {
 /* Astra Respnosive oEmbed Video container */
 .ast-oembed-container {
   position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 30px;
+  padding-top: 56.25%;
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/assets/css/unminified/editor-style.css
+++ b/assets/css/unminified/editor-style.css
@@ -2039,8 +2039,7 @@ textarea {
 /* Astra Respnosive oEmbed Video container */
 .ast-oembed-container {
   position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 30px;
+  padding-top: 56.25%;
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/assets/css/unminified/style-rtl.css
+++ b/assets/css/unminified/style-rtl.css
@@ -2098,8 +2098,7 @@ textarea {
 /* Astra Respnosive oEmbed Video container */
 .ast-oembed-container {
   position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 30px;
+  padding-top: 56.25%;
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/assets/css/unminified/style.css
+++ b/assets/css/unminified/style.css
@@ -2098,8 +2098,7 @@ textarea {
 /* Astra Respnosive oEmbed Video container */
 .ast-oembed-container {
   position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 30px;
+  padding-top: 56.25%;
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 			$add_astra_oembed_wrapper = apply_filters( 'astra_responsive_oembed_wrapper_enable', true );
 
 			$allowed_providers = apply_filters(
-				'astra_allowed_fullwidth_providers', array(
+				'astra_allowed_fullwidth_oembed_providers', array(
 					'vimeo.com',
 					'youtube.com',
 					'youtu.be',

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 			$add_astra_oembed_wrapper = apply_filters( 'astra_responsive_oembed_wrapper_enable', true );
 
 			$allowed_providers = apply_filters(
-				'astra_allowed_fullwidth_embeds', array(
+				'astra_allowed_fullwidth_providers', array(
 					'vimeo.com',
 					'youtube.com',
 					'youtu.be',

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -158,15 +158,26 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 		 * Adds a responsive embed wrapper around oEmbed content
 		 *
 		 * @param  string $html The oEmbed markup.
-		 * @param  string $url  The URL being embedded.
+		 * @param  string $url The URL being embedded.
 		 * @param  array  $attr An array of attributes.
+		 *
 		 * @return string       Updated embed markup.
 		 */
 		function responsive_oembed_wrapper( $html, $url, $attr ) {
 
 			$add_astra_oembed_wrapper = apply_filters( 'astra_responsive_oembed_wrapper_enable', true );
 
-			if ( false !== strpos( $url, 'vimeo.com' ) || false !== strpos( $url, 'youtube.com' ) || false !== strpos( $url, 'youtu.be' ) ) {
+			$allowed_providers = apply_filters(
+				'astra_allowed_fullwidth_embeds', array(
+					'vimeo.com',
+					'youtube.com',
+					'youtu.be',
+					'wistia.com',
+					'wistia.net',
+				)
+			);
+
+			if ( astra_strposa( $url, $allowed_providers ) ) {
 				if ( $add_astra_oembed_wrapper ) {
 					$html = ( '' !== $html ) ? '<div class="ast-oembed-container">' . $html . '</div>' : '';
 				}

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -147,6 +147,7 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 			if ( apply_filters( 'astra_fullwidth_oembed', true ) ) {
 				// Filters the oEmbed process to run the responsive_oembed_wrapper() function.
 				add_filter( 'embed_oembed_html', array( $this, 'responsive_oembed_wrapper' ), 10, 3 );
+				add_filter( 'oembed_result', array( $this, 'responsive_oembed_wrapper' ), 10, 3 );
 			}
 
 			// WooCommerce.
@@ -170,6 +171,7 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 					$html = ( '' !== $html ) ? '<div class="ast-oembed-container">' . $html . '</div>' : '';
 				}
 			}
+
 			return $html;
 		}
 	}

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1368,7 +1368,7 @@ if ( ! function_exists( 'astra_strposa' ) ) :
 	/**
 	 * Strpos over an array.
 	 *
-	 * @since  1.2.1
+	 * @since  1.2.4
 	 * @param  String  $haystack The string to search in.
 	 * @param  Array   $needles  Array of needles to be passed to strpos().
 	 * @param  integer $offset   If specified, search will start this number of characters counted from the beginning of the string. If the offset is negative, the search will start this number of characters counted from the end of the string.

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1360,4 +1360,36 @@ if ( ! function_exists( 'astra_get_theme_name' ) ) :
 
 		return apply_filters( 'astra_theme_name', $theme_name );
 	}
+
+endif;
+
+if ( ! function_exists( 'astra_strposa' ) ) :
+
+	/**
+	 * Strpos over an array.
+	 *
+	 * @since  1.2.1
+	 * @param  String  $haystack The string to search in.
+	 * @param  Array   $needles  Array of needles to be passed to strpos().
+	 * @param  integer $offset   If specified, search will start this number of characters counted from the beginning of the string. If the offset is negative, the search will start this number of characters counted from the end of the string.
+	 *
+	 * @return bool            True if haystack if part of any of the $needles.
+	 */
+	function astra_strposa( $haystack, $needles, $offset = 0 ) {
+
+		if ( ! is_array( $needles ) ) {
+			$needles = array( $needles );
+		}
+
+		foreach ( $needles as $query ) {
+
+			if ( strpos( $haystack, $query, $offset ) !== false ) {
+				// stop on first true result.
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 endif;

--- a/sass/site/media/_galleries.scss
+++ b/sass/site/media/_galleries.scss
@@ -36,8 +36,7 @@
 
 .ast-oembed-container {
     position: relative;
-    padding-bottom: 56.25%;
-    padding-top: 30px;
+    padding-top: 56.25%;
     height: 0;
     overflow: hidden;
     max-width: 100%;


### PR DESCRIPTION
- Fixed black bars when the video is made full width using the `ast-oembed-container` class
- Allow the `oembed` container class to pass through the filter `oembed_result` so that videos added through `wp_oembed_get()` will also get the wrapper.
- Introduces filter `astra_allowed_fullwidth_oembed_providers ` of providers to be made full width.