### PR TITLE
Remove Single product cart form wrapper

### DIFF
--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -575,10 +575,6 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_show_product_loop_sale_flash', 10 );
 			// Checkout Page.
 			remove_action( 'woocommerce_checkout_shipping', array( WC()->checkout(), 'checkout_form_shipping' ) );
-
-			// Add wrapper to Single Product Add To Aart button.
-			add_action( 'woocommerce_before_add_to_cart_quantity', 'astra_single_product_add_to_cart_button_wrap', 999 );
-			add_action( 'woocommerce_after_add_to_cart_button', 'astra_woocommerce_div_wrapper_close', 1 );
 		}
 
 		/**

--- a/inc/compatibility/woocommerce/woocommerce-common-functions.php
+++ b/inc/compatibility/woocommerce/woocommerce-common-functions.php
@@ -275,22 +275,6 @@ if ( ! function_exists( 'astra_widget_product_tag_cloud_args' ) ) {
 
 }
 
-
-/**
- * Single Product Add To Cart button Wrapper
- */
-if ( ! function_exists( 'astra_single_product_add_to_cart_button_wrap' ) ) :
-
-	/**
-	 * Single Product Add To Cart button Wrapper
-	 *
-	 * @return void
-	 */
-	function astra_single_product_add_to_cart_button_wrap() {
-		echo '<div class="ast-woo-single-cart-button-wrap">';
-	}
-endif;
-
 /**
  * Woocommerce shop/product div close tag.
  */


### PR DESCRIPTION
- Fixed: WooCommerce composite products plugin conflict on Single Product Page.