### PR TITLE
Fix fatal error when older version of Elementor Pro is installed

### DIFF
--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -8,7 +8,7 @@
 namespace Elementor;
 
 // If plugin - 'Elementor' not exist then return.
-if ( ! class_exists( '\Elementor\Plugin' ) ) {
+if ( ! class_exists( '\Elementor\Plugin' ) || ! class_exists( 'ElementorPro\Modules\ThemeBuilder\Module' ) ) {
 	return;
 }
 


### PR DESCRIPTION
Fix: check if Elementor pro's method actually exists before loading the compatibility class