### PR TITLE
Fix: weights for google fonts not displayed in the list

### DIFF
--- a/inc/customizer/class-astra-font-families.php
+++ b/inc/customizer/class-astra-font-families.php
@@ -148,15 +148,17 @@ if ( ! class_exists( 'Astra_Font_Families' ) ) :
 					$name = key( $font );
 					foreach ( $font[ $name ] as $font_key => $single_font ) {
 
-						$variant  = astar( $single_font, 'variants' );
-						$category = astar( $single_font, 'category' );
+						if ( 'variants' === $font_key ) {
 
-						if ( stristr( $variant, 'italic' ) ) {
-							unset( $font[ $name ][ $font_key ] );
-						}
+							foreach ( $single_font as $variant_key => $variant ) {
+								if ( stristr( $variant, 'italic' ) ) {
+									unset( $font[ $name ][ $font_key ][ $variant_key ] );
+								}
 
-						if ( 'regular' == $variant ) {
-							$font[ $name ][ $font_key ] = '400';
+								if ( 'regular' == $variant ) {
+									$font[ $name ][ $font_key ][ $variant_key ] = '400';
+								}
+							}
 						}
 
 						self::$google_fonts[ $name ] = array_values( $font[ $name ] );

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -85,8 +85,8 @@
 		{
 			if ( ! fontValue.includes(',') ) return fontValue;
 
-			var splitFont = fontValue.split(',');
-			var pattern = new RegExp("'", 'gi');
+			var splitFont 	= fontValue.split(',');
+			var pattern 	= new RegExp("'", 'gi');
 
 			return splitFont[0].replace(pattern, '');
 		},

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -75,22 +75,26 @@
 		/**
 		 * Clean font name.
 		 *
+		 * Google Fonts are saved as {'Font Name', Category}. This function cleanes this up to retreive only the {Font Name}.
+		 *
 		 * @since  1.3.0
-		 * Removes commas and singel inverted commas from the font name. This is required for Google Fonts.
 		 * @param  {String} fontValue Name of the font.
 		 * 
-		 * @return {String}           Font name where commas and inverted commas are removed.
+		 * @return {String}  Font name where commas and inverted commas are removed if the font is a Google Font.
 		 */
 		_cleanGoogleFonts: function(fontValue)
 		{
+			// Bail if fontVAlue does not contain a comma.
 			if ( ! fontValue.includes(',') ) return fontValue;
+
 			var splitFont 	= fontValue.split(',');
 			var pattern 	= new RegExp("'", 'gi');
 
+			// Check if the cleaned font exists in the Google fonts array. Return if it exists.
 			var googleFontValue = splitFont[0].replace(pattern, '');
-			if ( 'undefined' != typeof AstFontFamilies.google[ googleFontValue ] ) {
-				fontValue = googleFontValue;
-			}
+			if ( 'undefined' != typeof AstFontFamilies.google[ googleFontValue ] ) return googleFontValue;
+
+			// By default return unchanged fontValue if the value does not exist in Google Fonts array.
 			return fontValue;
 		},
 

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -72,6 +72,16 @@
 			AstTypography._setFontWeightOptions.apply( this, [ false ] );
 		},
 
+		_cleanGoogleFonts: function(fontValue)
+		{
+			if ( ! fontValue.includes(',') ) return fontValue;
+
+			var splitFont = fontValue.split(',');
+			var pattern = new RegExp("'", 'gi');
+
+			return splitFont[0].replace(pattern, '');
+		},
+
 		/**
 		 * Sets the options for a font weight control when a
 		 * font family control changes.
@@ -100,12 +110,14 @@
 				weightValue     = init ? weightSelect.val() : 'inherit';
 			}
 
+			var fontValue = AstTypography._cleanGoogleFonts(fontValue);
+
 			if ( fontValue == 'inherit' ) {
 				weightObject = [ '400','500','600','700' ];
 			} else if ( 'undefined' != typeof AstFontFamilies.system[ fontValue ] ) {
 				weightObject = AstFontFamilies.system[ fontValue ].weights;
 			} else if ( 'undefined' != typeof AstFontFamilies.google[ fontValue ] ) {
-				weightObject = AstFontFamilies.google[ fontValue ];
+				weightObject = AstFontFamilies.google[ fontValue ][0];
 			} else if ( 'undefined' != typeof AstFontFamilies.custom[ fontValue.split(',')[0] ] ) {
 				weightObject = AstFontFamilies.custom[ fontValue.split(',')[0] ].weights;
 			}

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -90,11 +90,12 @@
 			var splitFont 	= fontValue.split(',');
 			var pattern 	= new RegExp("'", 'gi');
 
-			// Check if the cleaned font exists in the Google fonts array. Return if it exists.
+			// Check if the cleaned font exists in the Google fonts array.
 			var googleFontValue = splitFont[0].replace(pattern, '');
-			if ( 'undefined' != typeof AstFontFamilies.google[ googleFontValue ] ) return googleFontValue;
+			if ( 'undefined' != typeof AstFontFamilies.google[ googleFontValue ] ) {
+				fontValue = googleFontValue;
+			}
 
-			// By default return unchanged fontValue if the value does not exist in Google Fonts array.
 			return fontValue;
 		},
 

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -84,11 +84,14 @@
 		_cleanGoogleFonts: function(fontValue)
 		{
 			if ( ! fontValue.includes(',') ) return fontValue;
-
 			var splitFont 	= fontValue.split(',');
 			var pattern 	= new RegExp("'", 'gi');
 
-			return splitFont[0].replace(pattern, '');
+			var googleFontValue = splitFont[0].replace(pattern, '');
+			if ( 'undefined' != typeof AstFontFamilies.google[ googleFontValue ] ) {
+				fontValue = googleFontValue;
+			}
+			return fontValue;
 		},
 
 		/**

--- a/inc/customizer/custom-controls/typography/typography.js
+++ b/inc/customizer/custom-controls/typography/typography.js
@@ -72,6 +72,15 @@
 			AstTypography._setFontWeightOptions.apply( this, [ false ] );
 		},
 
+		/**
+		 * Clean font name.
+		 *
+		 * @since  1.3.0
+		 * Removes commas and singel inverted commas from the font name. This is required for Google Fonts.
+		 * @param  {String} fontValue Name of the font.
+		 * 
+		 * @return {String}           Font name where commas and inverted commas are removed.
+		 */
 		_cleanGoogleFonts: function(fontValue)
 		{
 			if ( ! fontValue.includes(',') ) return fontValue;
@@ -118,6 +127,9 @@
 				weightObject = AstFontFamilies.system[ fontValue ].weights;
 			} else if ( 'undefined' != typeof AstFontFamilies.google[ fontValue ] ) {
 				weightObject = AstFontFamilies.google[ fontValue ][0];
+				weightObject = Object.keys(weightObject).map(function(k) {
+				  return weightObject[k];
+				});
 			} else if ( 'undefined' != typeof AstFontFamilies.custom[ fontValue.split(',')[0] ] ) {
 				weightObject = AstFontFamilies.custom[ fontValue.split(',')[0] ].weights;
 			}


### PR DESCRIPTION
This needs to be tested with the [Custom Fonts](https://wordpress.org/plugins/custom-fonts/) plugin.
What happens if the font name has `'` or `,` in it.

Fixes #512 