### PR TITLE
add astra theme fields to LifterLMS builder settings

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			add_filter( 'llms_get_loop_list_classes', array( $this, 'course_responsive_grid' ), 999 );
 
 			// Course builder custom fields.
-			add_filter( 'llms_get_quiz_theme_settings', array( $this, 'quiz_layout_fields' ) );
+			add_filter( 'llms_builder_register_custom_fields', array( $this, 'register_builder_fields' ) );
 
 		}
 
@@ -495,7 +495,6 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 		 * @return   void
 		 */
 		function add_theme_support() {
-			add_theme_support( 'lifterlms-quizzes' );
 			add_theme_support( 'lifterlms-sidebars' );
 		}
 
@@ -591,28 +590,102 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 		}
 
 		/**
-		 * Add layout settings for LifterLMS quizzes
+		 * Register theme postmeta fields with the LifterLMS Builder
 		 *
 		 * @since [version]
-		 * @param array $settings layout settings.
-		 * @return array $settings layout settings.
+		 * @param string $default_fields Default custom field definitions.
+		 * @return string $default_fields Updated custom field definitions.
 		 */
-		function quiz_layout_fields( $settings ) {
+		function register_builder_fields( $default_fields ) {
 
-			$settings['layout'] = array(
-				'id'      => 'site-content-layout',
-				'name'    => __( 'Content Layout', 'astra' ),
-				'options' => array(
-					'default'                 => esc_html__( 'Customizer Setting', 'astra' ),
-					'boxed-container'         => esc_html__( 'Boxed', 'astra' ),
-					'content-boxed-container' => esc_html__( 'Content Boxed', 'astra' ),
-					'plain-container'         => esc_html__( 'Full Width / Contained', 'astra' ),
-					'page-builder'            => esc_html__( 'Full Width / Stretched', 'astra' ),
+			$disable_fields = array();
+			$show_meta_field = ! Astra_Meta_Boxes::is_bb_themer_layout();
+
+			$disable_fields[] = array(
+				'attribute' => 'ast-main-header-display',
+				'id' => 'ast-main-header-display',
+				'label' => esc_html__( 'Disable Primary Header', 'astra' ),
+				'switch_on' => 'disabled',
+				'type' => 'switch',
+ 			);
+
+			if ( $show_meta_field ) {
+				$disable_fields[] = array(
+					'attribute' => 'site-post-title',
+					'id' => 'site-post-title',
+					'label' => esc_html__( 'Disable Title', 'astra' ),
+					'switch_on' => 'disabled',
+					'type' => 'switch',
+				);
+				$disable_fields[] = array(
+					'attribute' => 'ast-featured-img',
+					'id' => 'ast-featured-img',
+					'label' => esc_html__( 'Disable Featured Image', 'astra' ),
+					'switch_on' => 'disabled',
+					'type' => 'switch',
+				);
+			}
+
+			if ( $show_meta_field && 'disabled' != astra_get_option( 'footer-adv' ) ) {
+				$disable_fields[] = array(
+					'attribute' => 'footer-adv-display',
+					'id' => 'footer-adv-display',
+					'label' => esc_html__( 'Disable Footer Widgets', 'astra' ),
+					'switch_on' => 'disabled',
+					'type' => 'switch',
+				);
+			}
+
+			if ( 'disabled' != astra_get_option( 'footer-sml-layout' ) ) {
+				$disable_fields[] = array(
+					'attribute' => 'footer-sml-layout',
+					'id' => 'footer-sml-layout',
+					'label' => esc_html__( 'Disable Footer Bar', 'astra' ),
+					'switch_on' => 'disabled',
+					'type' => 'switch',
+				);
+			}
+
+			$fields['astra_theme_settings'] = array(
+				'title' => __( 'Astra Settings', 'my-text-domain' ),
+				'toggleable' => true,
+				'fields' => array(
+					array(
+						array(
+							'attribute' => 'site-sidebar-layout',
+							'id' => 'site-sidebar-layout',
+							'label' => esc_html__( 'Sidebar', 'astra' ),
+							'type' => 'select',
+							'options' => array(
+								'default'       => esc_html__( 'Customizer Setting', 'astra' ),
+								'left-sidebar'  => esc_html__( 'Left Sidebar', 'astra' ),
+								'right-sidebar' => esc_html__( 'Right Sidebar', 'astra' ),
+								'no-sidebar'    => esc_html__( 'No Sidebar', 'astra' ),
+							),
+						),
+						array(
+							'attribute' => 'site-content-layout',
+							'id' => 'site-content-layout',
+							'label' => esc_html__( 'Content Layout', 'astra' ),
+							'type' => 'select',
+							'options' => array(
+								'default'                 => esc_html__( 'Customizer Setting', 'astra' ),
+								'boxed-container'         => esc_html__( 'Boxed', 'astra' ),
+								'content-boxed-container' => esc_html__( 'Content Boxed', 'astra' ),
+								'plain-container'         => esc_html__( 'Full Width / Contained', 'astra' ),
+								'page-builder'            => esc_html__( 'Full Width / Stretched', 'astra' ),
+							),
+						),
+					),
+					$disable_fields,
 				),
-				'type'    => 'select',
 			);
 
-			return $settings;
+			$default_fields['assignment'] = $fields;
+			$default_fields['lesson'] = $fields;
+			$default_fields['quiz'] = $fields;
+
+			return $default_fields;
 
 		}
 


### PR DESCRIPTION
Per my note on #477 and your feedback we rebuilt our custom fields api to ensure themes could add a lot more custom fields to the builder.

I used Astra as one of the themes I tested against during development of a better set of functions and settings to allow more theme settings to be added to the builder. After getting everything working and debugging a bit I wanted to make this available to Astra and our shared users.

This will add support for Lessons and Quizzes and if LifterLMS Assignments is enabled it will add the theme fields to assignments as well. I didn't add any dependency checks for assignments as it's all in the filter and the array or data will be ignored if assignments don't exist.

Here's a screencap of what it looks like for a lesson:

![course_builder_ _llms-72_dev_ _wordpress](https://user-images.githubusercontent.com/1290739/39455805-550d776c-4c97-11e8-859f-95cb81e7dd35.jpg)

Thanks for the beautiful theme as always and let me know if you have any questions or concerns with this!
