### PR TITLE
remove post navigation from LifterLMS Assignments single posts

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -133,6 +133,10 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 				remove_action( 'astra_entry_after', 'astra_single_post_navigation_markup' );
 			}
 
+			if ( is_singular( 'llms_assignment' ) ) {
+				remove_action( 'astra_entry_after', 'astra_single_post_navigation_markup' );
+			}
+
 			remove_action( 'lifterlms_single_course_after_summary', 'lifterlms_template_single_reviews', 100 );
 			add_action( 'lifterlms_single_course_after_summary', array( $this, 'single_reviews' ), 100 );
 


### PR DESCRIPTION
Like #476 this removes post nav from "Assignments" which are available via the LifterLMS Assignments add-on.

This was reported to me as a bug in LifterLMS today and I'd rather have this fixed in Astra core if you're okay with it instead of providing custom code snippets or CSS hacks when this is reported to us as a bug

Thanks as always!