### PR TITLE
add official lifterlms theme support

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -495,6 +495,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 		 * @return   void
 		 */
 		function add_theme_support() {
+			add_theme_support( 'lifterlms' );
 			add_theme_support( 'lifterlms-quizzes' );
 			add_theme_support( 'lifterlms-sidebars' );
 		}


### PR DESCRIPTION
In an effort to make it simpler for themes to integrate with LifterLMS we're moving towards a single declaration of theme support.

This declares Astra as supporting LifterLMS because you do actually support LifterLMS very well!

After this I will stop spamming with PRs (at least for a few weeks).

Thanks as always