### PR TITLE
Fix: WooCommerce categories with , in name not displayed correctly

### DIFF
--- a/inc/compatibility/woocommerce/woocommerce-common-functions.php
+++ b/inc/compatibility/woocommerce/woocommerce-common-functions.php
@@ -49,13 +49,14 @@ if ( ! function_exists( 'astra_woo_shop_parent_category' ) ) :
 			<span class="ast-woo-product-category">
 				<?php
 				global $product;
-				$product_categories = function_exists( 'wc_get_product_category_list' ) ? wc_get_product_category_list( get_the_ID(), ',', '', '' ) : $product->get_categories( ',', '', '' );
+				$product_categories = function_exists( 'wc_get_product_category_list' ) ? wc_get_product_category_list( get_the_ID(), ';', '', '' ) : $product->get_categories( ';', '', '' );
 
 				$product_categories = strip_tags( $product_categories );
 				if ( $product_categories ) {
-					list( $parent_cat ) = explode( ',', $product_categories );
+					list( $parent_cat ) = explode( ';', $product_categories );
 					echo esc_html( $parent_cat );
 				}
+
 				?>
 			</span> 
 			<?php


### PR DESCRIPTION
Change the WooCommerce categories list separator to allow category names with a comma in them to be displayed correctly