### PR TITLE
Include 'wp-admin/includes/image.php' file

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Unreleased
+- Fix: PHP error when using plugin 'customizer-export-import' and import images is selected.
+
 v1.3.4
 - Improvement: Updated the theme screenshot.
 - Fix: WooCommerce categories with `,` in the category name not displayed correctly in product grid.

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -331,6 +331,10 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 
 					if ( false !== $fullsizepath || file_exists( $fullsizepath ) ) {
 
+						if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+							require_once ABSPATH . 'wp-admin/includes/image.php';
+						}
+
 						$metadata = wp_generate_attachment_metadata( $image->ID, $fullsizepath );
 
 						if ( ! is_wp_error( $metadata ) && ! empty( $metadata ) ) {


### PR DESCRIPTION
when function wp_generate_attachment_metadata() does not exist.