### PR TITLE
Delay migrating astra settings on theme version update until action wp

### DIFF
--- a/inc/theme-update/class-astra-pb-compatibility.php
+++ b/inc/theme-update/class-astra-pb-compatibility.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'Astra_PB_Compatibility' ) ) {
 
 			// Theme Updates.
 			add_action( 'do_meta_boxes', array( $this, 'page_builder_compatibility' ) );
-			add_action( 'wp', array( $this, 'page_builder_compatibility', 25 ) );
+			add_action( 'wp', array( $this, 'page_builder_compatibility' ), 25 );
 		}
 
 		/**

--- a/inc/theme-update/class-astra-pb-compatibility.php
+++ b/inc/theme-update/class-astra-pb-compatibility.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'Astra_PB_Compatibility' ) ) {
 
 			// Theme Updates.
 			add_action( 'do_meta_boxes', array( $this, 'page_builder_compatibility' ) );
-			add_action( 'wp', array( $this, 'page_builder_compatibility' ) );
+			add_action( 'wp', array( $this, 'page_builder_compatibility', 25 ) );
 		}
 
 		/**

--- a/inc/theme-update/class-astra-theme-update.php
+++ b/inc/theme-update/class-astra-theme-update.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Astra_Theme_Update' ) ) {
 		public function __construct() {
 
 			// Theme Updates.
-			add_action( 'wp', __CLASS__ . '::init' );
+			add_action( 'wp', __CLASS__ . '::init', 5 );
 			add_action( 'init', __CLASS__ . '::astra_pro_compatibility' );
 		}
 

--- a/inc/theme-update/class-astra-theme-update.php
+++ b/inc/theme-update/class-astra-theme-update.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Astra_Theme_Update' ) ) {
 		public function __construct() {
 
 			// Theme Updates.
-			add_action( 'init', __CLASS__ . '::init' );
+			add_action( 'wp', __CLASS__ . '::init' );
 			add_action( 'init', __CLASS__ . '::astra_pro_compatibility' );
 		}
 
@@ -57,7 +57,7 @@ if ( ! class_exists( 'Astra_Theme_Update' ) ) {
 			// Get auto saved version number.
 			$saved_version = astra_get_option( 'theme-auto-version', false );
 
-			if ( ! $saved_version ) {
+			if ( false === $saved_version ) {
 
 				// Get all customizer options.
 				$customizer_options = get_option( ASTRA_THEME_SETTINGS );


### PR DESCRIPTION
Strictly check if version number is not set when updating the saved version number.