### PR TITLE
Change default thumbnail size

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1206,7 +1206,7 @@ if ( ! function_exists( 'astra_get_post_thumbnail' ) ) {
 
 				$post_thumb = get_the_post_thumbnail(
 					get_the_ID(),
-					apply_filters( 'astra_post_thumbnail_default_size', 'full' ),
+					apply_filters( 'astra_post_thumbnail_default_size', 'large' ),
 					array(
 						'itemprop' => 'image',
 					)


### PR DESCRIPTION
Default thumbnail size being pulled for blog archives when set to full results in image size penalties on Google pagespeed for archive pages (below 40%)

For a short term fix the thumbnail size being fetched in "function astra_get_post_thumbnail" was set to large to reach a balance between pagespeed ranking and image quality of post thumbnail being displayed on archive pages.