### PR TITLE
Prevent duplicate lesson navigation templates in LifterLMS 3.25.0 and WP Core 5.0

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -126,7 +126,9 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			if ( is_lesson() ) {
 				remove_action( 'lifterlms_single_lesson_after_summary', 'lifterlms_template_lesson_navigation', 20 );
 				remove_action( 'astra_entry_after', 'astra_single_post_navigation_markup' );
-				add_action( 'astra_entry_after', 'lifterlms_template_lesson_navigation' );
+				if ( 'yes' !== get_post_meta( get_the_ID(), '_llms_blocks_migrated', true ) ) {
+					add_action( 'astra_entry_after', 'lifterlms_template_lesson_navigation' );
+				}
 			}
 
 			if ( is_quiz() ) {


### PR DESCRIPTION
In an effort to improve templating in LifterLMS core LifterLMS templates previously output automatically by action hooks are being transitioned to being output by blocks.

Without this PR, anyone using 3.25.0 of LifterLMS and WP 5.0 (or the Gutenberg plugin and 4.9 or earlier) will see two lesson navigation:

![new_lesson_-_llms-72_test](https://user-images.githubusercontent.com/1290739/49829522-8624e080-fd43-11e8-82df-dd83b1b591fd.jpg)

After this update, users will see the template part _only_ if the block has been added to the lesson.

It also ensures that any user who has not yet migrated to 5.0 & 3.25.0 will still have the navigation in the correct area without issue.