### PR TITLE
Update _layout.scss

### DIFF
--- a/sass/site/layout/_layout.scss
+++ b/sass/site/layout/_layout.scss
@@ -19,6 +19,10 @@ body{
 }
 #primary{
 	margin: 4em 0;
+	// Remove top margin to accommodate transparent header
+	.ast-theme-transparent-header &{
+		margin-top: 0;
+	}
 }
 
 #secondary{
@@ -288,6 +292,10 @@ body{
 	#secondary {
 		padding: 1.5em 0;
 		margin: 0;
+		// Remove top padding to accommodate transparent header
+		.ast-theme-transparent-header &{
+			padding-top: 0;
+		}
 	}
 
 	.ast-left-sidebar {


### PR DESCRIPTION
I added a parent selector to the layout sass that removes top padding and margin from #primary and #secondary containers to accommodate transparent headers. There are two cases, one with the medium media query and one general. Without these you have a large gap under the transparent header.