### PR TITLE
Fix: Gutenberg content width same as the frontend

### DIFF
--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -475,10 +475,25 @@ html {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
+#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
+  font-size: 1.1rem;
+  line-height: 1.8571428571;
+}
+
+#wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
+  padding-right: 43px;
+  padding-left: 43px;
+}
+
 #wpwrap .edit-post-visual-editor .editor-post-title__block,
 #wpwrap .edit-post-visual-editor .editor-default-block-appender,
 #wpwrap .edit-post-visual-editor .editor-block-list__block {
-  max-width: 1200px;
+  max-width: 1256px;
 }
 
 #wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=full] {
@@ -528,11 +543,6 @@ html {
 
 #wpwrap .edit-post-visual-editor .mce-widget i {
   font-style: normal;
-}
-
-#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
-  font-size: 1.1rem;
-  line-height: 1.8571428571;
 }
 
 #wpwrap .edit-post-visual-editor #elementor-editor-button {

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -468,42 +468,43 @@ p,
   font-weight: normal;
 }
 
-.editor-block-list__block {
+.edit-post-visual-editor .editor-block-list__block {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
 @media (min-width: 600px) {
-  .editor-block-list__block {
+  .edit-post-visual-editor .editor-block-list__block {
     padding-right: 0;
     padding-left: 0;
   }
 }
 
-.editor-block-list__block blockquote p {
+.edit-post-visual-editor .editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
 }
 
-.editor-block-list__block .editor-block-list__block-edit {
+.edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
   margin-right: 0;
   margin-left: 0;
 }
 
 @media (min-width: 600px) {
-  .editor-block-list__block .editor-block-list__block-edit {
+  .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
     padding-right: 28px;
     padding-left: 28px;
   }
 }
 
-.editor-block-list__block > .editor-block-mover {
+.edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
   right: -50px;
   top: -5px;
 }
 
 .editor-post-title__block .editor-post-title__input {
-  padding-right: 43px;
-  padding-left: 43px;
+  padding-right: 28px;
+  padding-left: 28px;
+  font-weight: normal;
 }
 
 .editor-post-title__block,

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -1,87 +1,91 @@
+html {
+  font-size: 93.75%;
+}
+
 /* Variables */
 /*----------  Media Query min-width Structure   ----------*/
 /*----------  Media Query max-width Structure   ----------*/
 /*----------  Break-point min-width Structure   ----------*/
 /*----------  Break-point max-width Structure   ----------*/
-/*
- * Button mixin- creates 3d-ish button effect with correct
- * highlights/shadows, based on a base color.
- */
-html {
-  font-size: 93.75%;
-}
-
 /*----------  Font Size  ----------*/
 /*----------  Line Height  ----------*/
 /*----------  Site Basic Structure  ----------*/
 /*----------  z-index Structure   ----------*/
-html {
+/*
+ * Button mixin- creates 3d-ish button effect with correct
+ * highlights/shadows, based on a base color.
+ */
+.edit-post-visual-editor {
+  /* must have higher specificity than alternative color schemes inline styles */
+}
+
+.edit-post-visual-editor html {
   box-sizing: border-box;
 }
 
-*,
-*:before,
-*:after {
+.edit-post-visual-editor *,
+.edit-post-visual-editor *:before,
+.edit-post-visual-editor *:after {
   /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
   box-sizing: inherit;
 }
 
-body {
+.edit-post-visual-editor body {
   color: #808285;
   background: #ffffff;
   /* Fallback for when there is no custom background color defined. */
   font-style: normal;
 }
 
-ul, ol {
+.edit-post-visual-editor ul, .edit-post-visual-editor ol {
   margin: 0 3em 1.5em 0;
 }
 
-ul {
+.edit-post-visual-editor ul {
   list-style: disc;
 }
 
-ol {
+.edit-post-visual-editor ol {
   list-style: decimal;
 }
 
-li > ul,
-li > ol {
+.edit-post-visual-editor li > ul,
+.edit-post-visual-editor li > ol {
   margin-bottom: 0;
   margin-right: 1.5em;
 }
 
-dt {
+.edit-post-visual-editor dt {
   font-weight: bold;
 }
 
-dd {
+.edit-post-visual-editor dd {
   margin: 0 1.5em 1.5em;
 }
 
-b, strong {
+.edit-post-visual-editor b, .edit-post-visual-editor strong {
   font-weight: bold;
 }
 
-dfn,
-cite,
-em,
-i {
+.edit-post-visual-editor dfn,
+.edit-post-visual-editor cite,
+.edit-post-visual-editor em,
+.edit-post-visual-editor i {
   font-style: italic;
 }
 
-blockquote,
-q {
+.edit-post-visual-editor blockquote,
+.edit-post-visual-editor q {
   quotes: "" "";
 }
 
-blockquote:before, blockquote:after,
-q:before,
-q:after {
+.edit-post-visual-editor blockquote:before, .edit-post-visual-editor blockquote:after,
+.edit-post-visual-editor q:before,
+.edit-post-visual-editor q:after {
   content: "";
 }
 
-blockquote {
+.edit-post-visual-editor blockquote {
   border-right: 5px solid rgba(0, 0, 0, 0.05);
   padding: 20px;
   font-size: 1.2em;
@@ -90,21 +94,21 @@ blockquote {
   position: relative;
 }
 
-blockquote p:last-child {
+.edit-post-visual-editor blockquote p:last-child {
   margin: 0;
 }
 
-address {
+.edit-post-visual-editor address {
   margin: 0 0 1.5em;
 }
 
-abbr,
-acronym {
+.edit-post-visual-editor abbr,
+.edit-post-visual-editor acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
 
-pre {
+.edit-post-visual-editor pre {
   background: #eee;
   font-family: "Courier 10 Pitch", Courier, monospace;
   margin-bottom: 1.6em;
@@ -113,33 +117,33 @@ pre {
   padding: 1.6em;
 }
 
-code,
-kbd,
-tt,
-var {
+.edit-post-visual-editor code,
+.edit-post-visual-editor kbd,
+.edit-post-visual-editor tt,
+.edit-post-visual-editor var {
   font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
-img {
+.edit-post-visual-editor img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;
   /* Adhere to container width. */
 }
 
-hr {
+.edit-post-visual-editor hr {
   background-color: #ccc;
   border: 0;
   height: 1px;
   margin-bottom: 1.5em;
 }
 
-.ast-button,
-.button,
-button,
-input,
-select,
-textarea {
+.edit-post-visual-editor .ast-button,
+.edit-post-visual-editor .button,
+.edit-post-visual-editor button,
+.edit-post-visual-editor input,
+.edit-post-visual-editor select,
+.edit-post-visual-editor textarea {
   color: #808285;
   font-weight: normal;
   font-size: 100%;
@@ -150,53 +154,53 @@ textarea {
   /* Improves appearance and consistency in all browsers */
 }
 
-button,
-input {
+.edit-post-visual-editor button,
+.edit-post-visual-editor input {
   line-height: normal;
   /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
-big {
+.edit-post-visual-editor big {
   font-size: 125%;
 }
 
-mark,
-ins {
+.edit-post-visual-editor mark,
+.edit-post-visual-editor ins {
   background: transparent;
   text-decoration: none;
 }
 
-ul, ol {
+.edit-post-visual-editor ul, .edit-post-visual-editor ol {
   margin: 0 3em 1.5em 0;
 }
 
-ul {
+.edit-post-visual-editor ul {
   list-style: disc;
 }
 
-ol {
+.edit-post-visual-editor ol {
   list-style: decimal;
 }
 
-li > ul,
-li > ol {
+.edit-post-visual-editor li > ul,
+.edit-post-visual-editor li > ol {
   margin-bottom: 0;
   margin-right: 1.5em;
 }
 
-dt {
+.edit-post-visual-editor dt {
   font-weight: bold;
 }
 
-dd {
+.edit-post-visual-editor dd {
   margin: 0 1.5em 1.5em;
 }
 
-table, th, td {
+.edit-post-visual-editor table, .edit-post-visual-editor th, .edit-post-visual-editor td {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-table {
+.edit-post-visual-editor table {
   border-collapse: separate;
   border-spacing: 0;
   border-width: 1px 1px 0 0;
@@ -204,72 +208,72 @@ table {
   width: 100%;
 }
 
-th {
+.edit-post-visual-editor th {
   font-weight: bold;
 }
 
-th, td {
+.edit-post-visual-editor th, .edit-post-visual-editor td {
   padding: 8px;
   text-align: right;
   border-width: 0 0 1px 1px;
 }
 
-::selection {
+.edit-post-visual-editor ::selection {
   color: #fff;
   background: royalblue;
 }
 
-html {
+.edit-post-visual-editor html {
   overflow-y: scroll;
 }
 
-body {
+.edit-post-visual-editor body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-body:not(.logged-in) {
+.edit-post-visual-editor body:not(.logged-in) {
   position: relative;
 }
 
-#page {
+.edit-post-visual-editor #page {
   position: relative;
 }
 
-a,
-a:focus {
+.edit-post-visual-editor a,
+.edit-post-visual-editor a:focus {
   text-decoration: none;
 }
 
-a,
-.site-header a *,
-.site-footer a *,
-.secondary a * {
+.edit-post-visual-editor a,
+.edit-post-visual-editor .site-header a *,
+.edit-post-visual-editor .site-footer a *,
+.edit-post-visual-editor .secondary a * {
   transition: all 0.2s linear;
 }
 
-.capitalize {
+.edit-post-visual-editor .capitalize {
   text-transform: uppercase;
 }
 
-img {
+.edit-post-visual-editor img {
   vertical-align: middle;
 }
 
-.entry-content h1,
-.entry-content h2,
-.entry-content h3,
-.entry-content h4,
-.entry-content h5,
-.entry-content h6 {
+.edit-post-visual-editor .entry-content h1,
+.edit-post-visual-editor .entry-content h2,
+.edit-post-visual-editor .entry-content h3,
+.edit-post-visual-editor .entry-content h4,
+.edit-post-visual-editor .entry-content h5,
+.edit-post-visual-editor .entry-content h6 {
   margin-bottom: 20px;
 }
 
-p {
+.edit-post-visual-editor p {
   margin-bottom: 1.75em;
 }
 
-blockquote {
+.edit-post-visual-editor blockquote {
   margin: 1.5em 3em 1.5em 1em;
   padding: 1.2em;
   font-size: 1.1em;
@@ -277,10 +281,10 @@ blockquote {
   position: relative;
 }
 
-.ast-button,
-.button,
-input[type="button"],
-input[type="submit"] {
+.edit-post-visual-editor .ast-button,
+.edit-post-visual-editor .button,
+.edit-post-visual-editor input[type="button"],
+.edit-post-visual-editor input[type="submit"] {
   border-radius: 0;
   padding: 18px 30px;
   border: 0;
@@ -288,78 +292,78 @@ input[type="submit"] {
   text-shadow: none;
 }
 
-.ast-button:hover,
-.button:hover,
-input[type="button"]:hover,
-input[type="submit"]:hover {
+.edit-post-visual-editor .ast-button:hover,
+.edit-post-visual-editor .button:hover,
+.edit-post-visual-editor input[type="button"]:hover,
+.edit-post-visual-editor input[type="submit"]:hover {
   box-shadow: none;
 }
 
-.ast-button:active, .ast-button:focus,
-.button:active,
-.button:focus,
-input[type="button"]:active,
-input[type="button"]:focus,
-input[type="submit"]:active,
-input[type="submit"]:focus {
+.edit-post-visual-editor .ast-button:active, .edit-post-visual-editor .ast-button:focus,
+.edit-post-visual-editor .button:active,
+.edit-post-visual-editor .button:focus,
+.edit-post-visual-editor input[type="button"]:active,
+.edit-post-visual-editor input[type="button"]:focus,
+.edit-post-visual-editor input[type="submit"]:active,
+.edit-post-visual-editor input[type="submit"]:focus {
   box-shadow: none;
 }
 
-.site-title {
+.edit-post-visual-editor .site-title {
   font-weight: normal;
 }
 
-.site-title,
-.site-description {
+.edit-post-visual-editor .site-title,
+.edit-post-visual-editor .site-description {
   margin-bottom: 0;
 }
 
-.site-title a,
-.site-title:hover a,
-.site-title:focus a,
-.site-description a,
-.site-description:hover a,
-.site-description:focus a {
+.edit-post-visual-editor .site-title a,
+.edit-post-visual-editor .site-title:hover a,
+.edit-post-visual-editor .site-title:focus a,
+.edit-post-visual-editor .site-description a,
+.edit-post-visual-editor .site-description:hover a,
+.edit-post-visual-editor .site-description:focus a {
   transition: all 0.2s linear;
 }
 
-.site-title a,
-.site-title a:focus,
-.site-title a:hover,
-.site-title a:visited {
+.edit-post-visual-editor .site-title a,
+.edit-post-visual-editor .site-title a:focus,
+.edit-post-visual-editor .site-title a:hover,
+.edit-post-visual-editor .site-title a:visited {
   color: #222;
 }
 
-.site-description a,
-.site-description a:focus,
-.site-description a:hover,
-.site-description a:visited {
+.edit-post-visual-editor .site-description a,
+.edit-post-visual-editor .site-description a:focus,
+.edit-post-visual-editor .site-description a:hover,
+.edit-post-visual-editor .site-description a:visited {
   color: #999;
 }
 
-.search-form .search-field {
+.edit-post-visual-editor .search-form .search-field {
   outline: none;
 }
 
-.ast-search-menu-icon {
+.edit-post-visual-editor .ast-search-menu-icon {
   position: relative;
 }
 
-.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
   margin-left: 1em;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
   display: none;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
   width: 100%;
   padding-left: 5.5em;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
   display: block;
   position: absolute;
   height: 100%;
@@ -369,14 +373,13 @@ input[type="submit"]:focus {
   border-radius: 0;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
   padding: 0;
   display: block;
   overflow: hidden;
 }
 
-/* must have higher specificity than alternative color schemes inline styles */
-.site .skip-link {
+.edit-post-visual-editor .site .skip-link {
   background-color: #f1f1f1;
   box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
   color: #21759b;
@@ -392,7 +395,7 @@ input[type="submit"]:focus {
   top: -9999em;
 }
 
-.site .skip-link:focus {
+.edit-post-visual-editor .site .skip-link:focus {
   clip: auto;
   height: auto;
   right: 6px;
@@ -401,52 +404,52 @@ input[type="submit"]:focus {
   z-index: 100000;
 }
 
-.logged-in .site .skip-link {
+.logged-in .edit-post-visual-editor .site .skip-link {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.2);
   font-family: "Open Sans", sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 {
+.edit-post-visual-editor h1, .edit-post-visual-editor h2, .edit-post-visual-editor h3, .edit-post-visual-editor h4, .edit-post-visual-editor h5, .edit-post-visual-editor h6 {
   clear: both;
 }
 
-h1,
-.entry-content h1 {
+.edit-post-visual-editor h1,
+.edit-post-visual-editor .entry-content h1 {
   color: #808285;
   font-size: 2em;
   line-height: 1.2;
 }
 
-h2,
-.entry-content h2 {
+.edit-post-visual-editor h2,
+.edit-post-visual-editor .entry-content h2 {
   color: #808285;
   font-size: 1.7em;
   line-height: 1.3;
 }
 
-h3,
-.entry-content h3 {
+.edit-post-visual-editor h3,
+.edit-post-visual-editor .entry-content h3 {
   color: #808285;
   font-size: 1.5em;
   line-height: 1.4;
 }
 
-h4,
-.entry-content h4 {
+.edit-post-visual-editor h4,
+.edit-post-visual-editor .entry-content h4 {
   color: #808285;
   line-height: 1.5;
   font-size: 1.3em;
 }
 
-h5,
-.entry-content h5 {
+.edit-post-visual-editor h5,
+.edit-post-visual-editor .entry-content h5 {
   color: #808285;
   line-height: 1.6;
   font-size: 1.2em;
 }
 
-h6,
-.entry-content h6 {
+.edit-post-visual-editor h6,
+.edit-post-visual-editor .entry-content h6 {
   color: #808285;
   line-height: 1.7;
   font-size: 1.1em;

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -455,7 +455,7 @@ html {
   font-size: 1.1em;
 }
 
-p,
+.edit-post-visual-editor p,
 .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -455,6 +455,30 @@ html {
   font-size: 1.1em;
 }
 
+.edit-post-visual-editor .wp-block-heading h1 {
+  line-height: 1.2;
+}
+
+.edit-post-visual-editor .wp-block-heading h2 {
+  line-height: 1.3;
+}
+
+.edit-post-visual-editor .wp-block-heading h3 {
+  line-height: 1.4;
+}
+
+.edit-post-visual-editor .wp-block-heading h4 {
+  line-height: 1.5;
+}
+
+.edit-post-visual-editor .wp-block-heading h5 {
+  line-height: 1.6;
+}
+
+.edit-post-visual-editor .wp-block-heading h6 {
+  line-height: 1.7;
+}
+
 .edit-post-visual-editor p,
 .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -11,81 +11,77 @@ html {
   font-size: 93.75%;
 }
 
-#wpwrap .edit-post-visual-editor {
-  /*----------  Font Size  ----------*/
-  /*----------  Line Height  ----------*/
-  /*----------  Site Basic Structure  ----------*/
-  /*----------  z-index Structure   ----------*/
-  /* must have higher specificity than alternative color schemes inline styles */
-}
-
-#wpwrap .edit-post-visual-editor html {
+/*----------  Font Size  ----------*/
+/*----------  Line Height  ----------*/
+/*----------  Site Basic Structure  ----------*/
+/*----------  z-index Structure   ----------*/
+html {
   box-sizing: border-box;
 }
 
-#wpwrap .edit-post-visual-editor *,
-#wpwrap .edit-post-visual-editor *:before,
-#wpwrap .edit-post-visual-editor *:after {
+*,
+*:before,
+*:after {
   /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
   box-sizing: inherit;
 }
 
-#wpwrap .edit-post-visual-editor body {
+body {
   color: #808285;
   background: #ffffff;
   /* Fallback for when there is no custom background color defined. */
   font-style: normal;
 }
 
-#wpwrap .edit-post-visual-editor ul, #wpwrap .edit-post-visual-editor ol {
+ul, ol {
   margin: 0 3em 1.5em 0;
 }
 
-#wpwrap .edit-post-visual-editor ul {
+ul {
   list-style: disc;
 }
 
-#wpwrap .edit-post-visual-editor ol {
+ol {
   list-style: decimal;
 }
 
-#wpwrap .edit-post-visual-editor li > ul,
-#wpwrap .edit-post-visual-editor li > ol {
+li > ul,
+li > ol {
   margin-bottom: 0;
   margin-right: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor dt {
+dt {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dd {
+dd {
   margin: 0 1.5em 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor b, #wpwrap .edit-post-visual-editor strong {
+b, strong {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dfn,
-#wpwrap .edit-post-visual-editor cite,
-#wpwrap .edit-post-visual-editor em,
-#wpwrap .edit-post-visual-editor i {
+dfn,
+cite,
+em,
+i {
   font-style: italic;
 }
 
-#wpwrap .edit-post-visual-editor blockquote,
-#wpwrap .edit-post-visual-editor q {
+blockquote,
+q {
   quotes: "" "";
 }
 
-#wpwrap .edit-post-visual-editor blockquote:before, #wpwrap .edit-post-visual-editor blockquote:after,
-#wpwrap .edit-post-visual-editor q:before,
-#wpwrap .edit-post-visual-editor q:after {
+blockquote:before, blockquote:after,
+q:before,
+q:after {
   content: "";
 }
 
-#wpwrap .edit-post-visual-editor blockquote {
+blockquote {
   border-right: 5px solid rgba(0, 0, 0, 0.05);
   padding: 20px;
   font-size: 1.2em;
@@ -94,21 +90,21 @@ html {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor blockquote p:last-child {
+blockquote p:last-child {
   margin: 0;
 }
 
-#wpwrap .edit-post-visual-editor address {
+address {
   margin: 0 0 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor abbr,
-#wpwrap .edit-post-visual-editor acronym {
+abbr,
+acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
 
-#wpwrap .edit-post-visual-editor pre {
+pre {
   background: #eee;
   font-family: "Courier 10 Pitch", Courier, monospace;
   margin-bottom: 1.6em;
@@ -117,33 +113,33 @@ html {
   padding: 1.6em;
 }
 
-#wpwrap .edit-post-visual-editor code,
-#wpwrap .edit-post-visual-editor kbd,
-#wpwrap .edit-post-visual-editor tt,
-#wpwrap .edit-post-visual-editor var {
+code,
+kbd,
+tt,
+var {
   font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
-#wpwrap .edit-post-visual-editor img {
+img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;
   /* Adhere to container width. */
 }
 
-#wpwrap .edit-post-visual-editor hr {
+hr {
   background-color: #ccc;
   border: 0;
   height: 1px;
   margin-bottom: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button,
-#wpwrap .edit-post-visual-editor .button,
-#wpwrap .edit-post-visual-editor button,
-#wpwrap .edit-post-visual-editor input,
-#wpwrap .edit-post-visual-editor select,
-#wpwrap .edit-post-visual-editor textarea {
+.ast-button,
+.button,
+button,
+input,
+select,
+textarea {
   color: #808285;
   font-weight: normal;
   font-size: 100%;
@@ -154,53 +150,53 @@ html {
   /* Improves appearance and consistency in all browsers */
 }
 
-#wpwrap .edit-post-visual-editor button,
-#wpwrap .edit-post-visual-editor input {
+button,
+input {
   line-height: normal;
   /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
-#wpwrap .edit-post-visual-editor big {
+big {
   font-size: 125%;
 }
 
-#wpwrap .edit-post-visual-editor mark,
-#wpwrap .edit-post-visual-editor ins {
+mark,
+ins {
   background: transparent;
   text-decoration: none;
 }
 
-#wpwrap .edit-post-visual-editor ul, #wpwrap .edit-post-visual-editor ol {
+ul, ol {
   margin: 0 3em 1.5em 0;
 }
 
-#wpwrap .edit-post-visual-editor ul {
+ul {
   list-style: disc;
 }
 
-#wpwrap .edit-post-visual-editor ol {
+ol {
   list-style: decimal;
 }
 
-#wpwrap .edit-post-visual-editor li > ul,
-#wpwrap .edit-post-visual-editor li > ol {
+li > ul,
+li > ol {
   margin-bottom: 0;
   margin-right: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor dt {
+dt {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dd {
+dd {
   margin: 0 1.5em 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor table, #wpwrap .edit-post-visual-editor th, #wpwrap .edit-post-visual-editor td {
+table, th, td {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-#wpwrap .edit-post-visual-editor table {
+table {
   border-collapse: separate;
   border-spacing: 0;
   border-width: 1px 1px 0 0;
@@ -208,72 +204,72 @@ html {
   width: 100%;
 }
 
-#wpwrap .edit-post-visual-editor th {
+th {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor th, #wpwrap .edit-post-visual-editor td {
+th, td {
   padding: 8px;
   text-align: right;
   border-width: 0 0 1px 1px;
 }
 
-#wpwrap .edit-post-visual-editor ::selection {
+::selection {
   color: #fff;
   background: royalblue;
 }
 
-#wpwrap .edit-post-visual-editor html {
+html {
   overflow-y: scroll;
 }
 
-#wpwrap .edit-post-visual-editor body {
+body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#wpwrap .edit-post-visual-editor body:not(.logged-in) {
+body:not(.logged-in) {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor #page {
+#page {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor a,
-#wpwrap .edit-post-visual-editor a:focus {
+a,
+a:focus {
   text-decoration: none;
 }
 
-#wpwrap .edit-post-visual-editor a,
-#wpwrap .edit-post-visual-editor .site-header a *,
-#wpwrap .edit-post-visual-editor .site-footer a *,
-#wpwrap .edit-post-visual-editor .secondary a * {
+a,
+.site-header a *,
+.site-footer a *,
+.secondary a * {
   transition: all 0.2s linear;
 }
 
-#wpwrap .edit-post-visual-editor .capitalize {
+.capitalize {
   text-transform: uppercase;
 }
 
-#wpwrap .edit-post-visual-editor img {
+img {
   vertical-align: middle;
 }
 
-#wpwrap .edit-post-visual-editor .entry-content h1,
-#wpwrap .edit-post-visual-editor .entry-content h2,
-#wpwrap .edit-post-visual-editor .entry-content h3,
-#wpwrap .edit-post-visual-editor .entry-content h4,
-#wpwrap .edit-post-visual-editor .entry-content h5,
-#wpwrap .edit-post-visual-editor .entry-content h6 {
+.entry-content h1,
+.entry-content h2,
+.entry-content h3,
+.entry-content h4,
+.entry-content h5,
+.entry-content h6 {
   margin-bottom: 20px;
 }
 
-#wpwrap .edit-post-visual-editor p {
+p {
   margin-bottom: 1.75em;
 }
 
-#wpwrap .edit-post-visual-editor blockquote {
+blockquote {
   margin: 1.5em 3em 1.5em 1em;
   padding: 1.2em;
   font-size: 1.1em;
@@ -281,10 +277,10 @@ html {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button,
-#wpwrap .edit-post-visual-editor .button,
-#wpwrap .edit-post-visual-editor input[type="button"],
-#wpwrap .edit-post-visual-editor input[type="submit"] {
+.ast-button,
+.button,
+input[type="button"],
+input[type="submit"] {
   border-radius: 0;
   padding: 18px 30px;
   border: 0;
@@ -292,78 +288,78 @@ html {
   text-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button:hover,
-#wpwrap .edit-post-visual-editor .button:hover,
-#wpwrap .edit-post-visual-editor input[type="button"]:hover,
-#wpwrap .edit-post-visual-editor input[type="submit"]:hover {
+.ast-button:hover,
+.button:hover,
+input[type="button"]:hover,
+input[type="submit"]:hover {
   box-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button:active, #wpwrap .edit-post-visual-editor .ast-button:focus,
-#wpwrap .edit-post-visual-editor .button:active,
-#wpwrap .edit-post-visual-editor .button:focus,
-#wpwrap .edit-post-visual-editor input[type="button"]:active,
-#wpwrap .edit-post-visual-editor input[type="button"]:focus,
-#wpwrap .edit-post-visual-editor input[type="submit"]:active,
-#wpwrap .edit-post-visual-editor input[type="submit"]:focus {
+.ast-button:active, .ast-button:focus,
+.button:active,
+.button:focus,
+input[type="button"]:active,
+input[type="button"]:focus,
+input[type="submit"]:active,
+input[type="submit"]:focus {
   box-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .site-title {
+.site-title {
   font-weight: normal;
 }
 
-#wpwrap .edit-post-visual-editor .site-title,
-#wpwrap .edit-post-visual-editor .site-description {
+.site-title,
+.site-description {
   margin-bottom: 0;
 }
 
-#wpwrap .edit-post-visual-editor .site-title a,
-#wpwrap .edit-post-visual-editor .site-title:hover a,
-#wpwrap .edit-post-visual-editor .site-title:focus a,
-#wpwrap .edit-post-visual-editor .site-description a,
-#wpwrap .edit-post-visual-editor .site-description:hover a,
-#wpwrap .edit-post-visual-editor .site-description:focus a {
+.site-title a,
+.site-title:hover a,
+.site-title:focus a,
+.site-description a,
+.site-description:hover a,
+.site-description:focus a {
   transition: all 0.2s linear;
 }
 
-#wpwrap .edit-post-visual-editor .site-title a,
-#wpwrap .edit-post-visual-editor .site-title a:focus,
-#wpwrap .edit-post-visual-editor .site-title a:hover,
-#wpwrap .edit-post-visual-editor .site-title a:visited {
+.site-title a,
+.site-title a:focus,
+.site-title a:hover,
+.site-title a:visited {
   color: #222;
 }
 
-#wpwrap .edit-post-visual-editor .site-description a,
-#wpwrap .edit-post-visual-editor .site-description a:focus,
-#wpwrap .edit-post-visual-editor .site-description a:hover,
-#wpwrap .edit-post-visual-editor .site-description a:visited {
+.site-description a,
+.site-description a:focus,
+.site-description a:hover,
+.site-description a:visited {
   color: #999;
 }
 
-#wpwrap .edit-post-visual-editor .search-form .search-field {
+.search-form .search-field {
   outline: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-search-menu-icon {
+.ast-search-menu-icon {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
+.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
   margin-left: 1em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
   display: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
   width: 100%;
   padding-left: 5.5em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
   display: block;
   position: absolute;
   height: 100%;
@@ -373,13 +369,14 @@ html {
   border-radius: 0;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
   padding: 0;
   display: block;
   overflow: hidden;
 }
 
-#wpwrap .edit-post-visual-editor .site .skip-link {
+/* must have higher specificity than alternative color schemes inline styles */
+.site .skip-link {
   background-color: #f1f1f1;
   box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
   color: #21759b;
@@ -395,7 +392,7 @@ html {
   top: -9999em;
 }
 
-#wpwrap .edit-post-visual-editor .site .skip-link:focus {
+.site .skip-link:focus {
   clip: auto;
   height: auto;
   right: 6px;
@@ -404,167 +401,174 @@ html {
   z-index: 100000;
 }
 
-.logged-in #wpwrap .edit-post-visual-editor .site .skip-link {
+.logged-in .site .skip-link {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.2);
   font-family: "Open Sans", sans-serif;
 }
 
-#wpwrap .edit-post-visual-editor h1, #wpwrap .edit-post-visual-editor h2, #wpwrap .edit-post-visual-editor h3, #wpwrap .edit-post-visual-editor h4, #wpwrap .edit-post-visual-editor h5, #wpwrap .edit-post-visual-editor h6 {
+h1, h2, h3, h4, h5, h6 {
   clear: both;
 }
 
-#wpwrap .edit-post-visual-editor h1,
-#wpwrap .edit-post-visual-editor .entry-content h1 {
+h1,
+.entry-content h1 {
   color: #808285;
   font-size: 2em;
   line-height: 1.2;
 }
 
-#wpwrap .edit-post-visual-editor h2,
-#wpwrap .edit-post-visual-editor .entry-content h2 {
+h2,
+.entry-content h2 {
   color: #808285;
   font-size: 1.7em;
   line-height: 1.3;
 }
 
-#wpwrap .edit-post-visual-editor h3,
-#wpwrap .edit-post-visual-editor .entry-content h3 {
+h3,
+.entry-content h3 {
   color: #808285;
   font-size: 1.5em;
   line-height: 1.4;
 }
 
-#wpwrap .edit-post-visual-editor h4,
-#wpwrap .edit-post-visual-editor .entry-content h4 {
+h4,
+.entry-content h4 {
   color: #808285;
   line-height: 1.5;
   font-size: 1.3em;
 }
 
-#wpwrap .edit-post-visual-editor h5,
-#wpwrap .edit-post-visual-editor .entry-content h5 {
+h5,
+.entry-content h5 {
   color: #808285;
   line-height: 1.6;
   font-size: 1.2em;
 }
 
-#wpwrap .edit-post-visual-editor h6,
-#wpwrap .edit-post-visual-editor .entry-content h6 {
+h6,
+.entry-content h6 {
   color: #808285;
   line-height: 1.7;
   font-size: 1.1em;
 }
 
-#wpwrap .edit-post-visual-editor p,
-#wpwrap .edit-post-visual-editor .editor-block-list__block p,
-#wpwrap .edit-post-visual-editor .editor-default-block-appender textarea.editor-default-block-appender__content {
+p,
+.editor-block-list__block p,
+.editor-default-block-appender textarea.editor-default-block-appender__content {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
   font-weight: inherit;
   font-size: 15px;
   font-size: 1rem;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
+.editor-post-title__block .editor-post-title__input {
   font-size: 30px;
   font-size: 2rem;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
   font-weight: normal;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block {
+.editor-block-list__block {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
 @media (min-width: 600px) {
-  #wpwrap .edit-post-visual-editor .editor-block-list__block {
+  .editor-block-list__block {
     padding-right: 0;
     padding-left: 0;
   }
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
+.editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+.editor-block-list__block .editor-block-list__block-edit {
   margin-right: 0;
   margin-left: 0;
 }
 
 @media (min-width: 600px) {
-  #wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+  .editor-block-list__block .editor-block-list__block-edit {
     padding-right: 28px;
     padding-left: 28px;
   }
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
+.editor-block-list__block > .editor-block-mover {
   right: -50px;
   top: -5px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
-  padding-right: 26px;
-  padding-left: 26px;
+.editor-post-title__block .editor-post-title__input {
+  padding-right: 43px;
+  padding-left: 43px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block,
-#wpwrap .edit-post-visual-editor .editor-default-block-appender,
-#wpwrap .edit-post-visual-editor .editor-block-list__block {
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
   max-width: 1256px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=full] {
+.editor-block-list__block[data-align=full] {
   max-width: none;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=wide] {
+@media (min-width: 600px) {
+  .editor-block-list__block[data-align=full] .editor-block-list__block-edit {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+.editor-block-list__block[data-align=wide] {
   max-width: 1400px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__layout .editor-block-list__layout {
+.editor-block-list__layout .editor-block-list__layout {
   padding: 0;
 }
 
-#wpwrap .edit-post-visual-editor .editor-default-block-appender__content {
+.editor-default-block-appender__content {
   margin-top: 32px;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts.is-grid {
+.wp-block-latest-posts.is-grid {
   list-style: none;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-gallery {
+.wp-block-gallery {
   margin: 0;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-gallery.is-cropped .blocks-gallery-item img {
+.wp-block-gallery.is-cropped .blocks-gallery-item img {
   height: 100%;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts {
+.wp-block-latest-posts {
   margin-right: 0;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts li {
+.wp-block-latest-posts li {
   list-style: none;
 }
 
-#wpwrap .edit-post-visual-editor h1,
-#wpwrap .edit-post-visual-editor h2,
-#wpwrap .edit-post-visual-editor h3,
-#wpwrap .edit-post-visual-editor h4,
-#wpwrap .edit-post-visual-editor h5,
-#wpwrap .edit-post-visual-editor h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: inherit;
 }
 
-#wpwrap .edit-post-visual-editor .mce-widget i {
+.mce-widget i {
   font-style: normal;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button {
+#elementor-editor-button {
   background: #0073aa;
   border-color: #005177 #003f5e #003f5e;
   color: #fff;
@@ -584,49 +588,49 @@ html {
   box-shadow: 0 2px 0 #006799;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:hover, #wpwrap .edit-post-visual-editor #elementor-editor-button:focus {
+#elementor-editor-button:hover, #elementor-editor-button:focus {
   background: #007db9;
   border-color: #003f5e;
   color: #fff;
   box-shadow: 0 1px 0 #003f5e;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:focus {
+#elementor-editor-button:focus {
   box-shadow: inset 0 1px 0 #005177, 0 0 2px 1px #33b3db;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:active, #wpwrap .edit-post-visual-editor #elementor-editor-button.active, #wpwrap .edit-post-visual-editor #elementor-editor-button.active:focus, #wpwrap .edit-post-visual-editor #elementor-editor-button.active:hover {
+#elementor-editor-button:active, #elementor-editor-button.active, #elementor-editor-button.active:focus, #elementor-editor-button.active:hover {
   background: #005177;
   border-color: #003f5e;
   box-shadow: inset 0 2px 0 #003f5e;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button[disabled], #wpwrap .edit-post-visual-editor #elementor-editor-button:disabled, #wpwrap .edit-post-visual-editor #elementor-editor-button.button-primary-disabled, #wpwrap .edit-post-visual-editor #elementor-editor-button.disabled {
+#elementor-editor-button[disabled], #elementor-editor-button:disabled, #elementor-editor-button.button-primary-disabled, #elementor-editor-button.disabled {
   color: #c7ced1 !important;
   background: #005781 !important;
   border-color: #003f5e !important;
   text-shadow: none !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button.button-hero {
+#elementor-editor-button.button-hero {
   box-shadow: 0 2px 0 #003f5e !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button.button-hero:active {
+#elementor-editor-button.button-hero:active {
   box-shadow: inset 0 3px 0 #003f5e !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button i {
+#elementor-editor-button i {
   font-style: normal;
   color: white;
 }
 
-#wpwrap .edit-post-visual-editor .editor-media-placeholder button,
-#wpwrap .edit-post-visual-editor .fl-builder-layout-launch-view button {
+.editor-media-placeholder button,
+.fl-builder-layout-launch-view button {
   margin: 2px;
 }
 
-#wpwrap .edit-post-visual-editor .fl-builder-layout-launch-view .is-primary.is-primary {
+.fl-builder-layout-launch-view .is-primary.is-primary {
   color: white;
 }
 

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -475,6 +475,13 @@ html {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
+@media (min-width: 600px) {
+  #wpwrap .edit-post-visual-editor .editor-block-list__block {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
 #wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
@@ -485,9 +492,21 @@ html {
   margin-left: 0;
 }
 
+@media (min-width: 600px) {
+  #wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+    padding-right: 28px;
+    padding-left: 28px;
+  }
+}
+
+#wpwrap .edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
+  right: -50px;
+  top: -5px;
+}
+
 #wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
-  padding-right: 43px;
-  padding-left: 43px;
+  padding-right: 26px;
+  padding-left: 26px;
 }
 
 #wpwrap .edit-post-visual-editor .editor-post-title__block,

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -455,7 +455,7 @@ html {
   font-size: 1.1em;
 }
 
-p,
+.edit-post-visual-editor p,
 .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -455,6 +455,30 @@ html {
   font-size: 1.1em;
 }
 
+.edit-post-visual-editor .wp-block-heading h1 {
+  line-height: 1.2;
+}
+
+.edit-post-visual-editor .wp-block-heading h2 {
+  line-height: 1.3;
+}
+
+.edit-post-visual-editor .wp-block-heading h3 {
+  line-height: 1.4;
+}
+
+.edit-post-visual-editor .wp-block-heading h4 {
+  line-height: 1.5;
+}
+
+.edit-post-visual-editor .wp-block-heading h5 {
+  line-height: 1.6;
+}
+
+.edit-post-visual-editor .wp-block-heading h6 {
+  line-height: 1.7;
+}
+
 .edit-post-visual-editor p,
 .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -475,10 +475,25 @@ html {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
+#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
+  font-size: 1.1rem;
+  line-height: 1.8571428571;
+}
+
+#wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
+  padding-left: 43px;
+  padding-right: 43px;
+}
+
 #wpwrap .edit-post-visual-editor .editor-post-title__block,
 #wpwrap .edit-post-visual-editor .editor-default-block-appender,
 #wpwrap .edit-post-visual-editor .editor-block-list__block {
-  max-width: 1200px;
+  max-width: 1256px;
 }
 
 #wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=full] {
@@ -528,11 +543,6 @@ html {
 
 #wpwrap .edit-post-visual-editor .mce-widget i {
   font-style: normal;
-}
-
-#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
-  font-size: 1.1rem;
-  line-height: 1.8571428571;
 }
 
 #wpwrap .edit-post-visual-editor #elementor-editor-button {

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -475,6 +475,13 @@ html {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
+@media (min-width: 600px) {
+  #wpwrap .edit-post-visual-editor .editor-block-list__block {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 #wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
@@ -485,9 +492,21 @@ html {
   margin-right: 0;
 }
 
+@media (min-width: 600px) {
+  #wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+    padding-left: 28px;
+    padding-right: 28px;
+  }
+}
+
+#wpwrap .edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
+  left: -50px;
+  top: -5px;
+}
+
 #wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
-  padding-left: 43px;
-  padding-right: 43px;
+  padding-left: 26px;
+  padding-right: 26px;
 }
 
 #wpwrap .edit-post-visual-editor .editor-post-title__block,

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -1,87 +1,91 @@
+html {
+  font-size: 93.75%;
+}
+
 /* Variables */
 /*----------  Media Query min-width Structure   ----------*/
 /*----------  Media Query max-width Structure   ----------*/
 /*----------  Break-point min-width Structure   ----------*/
 /*----------  Break-point max-width Structure   ----------*/
-/*
- * Button mixin- creates 3d-ish button effect with correct
- * highlights/shadows, based on a base color.
- */
-html {
-  font-size: 93.75%;
-}
-
 /*----------  Font Size  ----------*/
 /*----------  Line Height  ----------*/
 /*----------  Site Basic Structure  ----------*/
 /*----------  z-index Structure   ----------*/
-html {
+/*
+ * Button mixin- creates 3d-ish button effect with correct
+ * highlights/shadows, based on a base color.
+ */
+.edit-post-visual-editor {
+  /* must have higher specificity than alternative color schemes inline styles */
+}
+
+.edit-post-visual-editor html {
   box-sizing: border-box;
 }
 
-*,
-*:before,
-*:after {
+.edit-post-visual-editor *,
+.edit-post-visual-editor *:before,
+.edit-post-visual-editor *:after {
   /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
   box-sizing: inherit;
 }
 
-body {
+.edit-post-visual-editor body {
   color: #808285;
   background: #ffffff;
   /* Fallback for when there is no custom background color defined. */
   font-style: normal;
 }
 
-ul, ol {
+.edit-post-visual-editor ul, .edit-post-visual-editor ol {
   margin: 0 0 1.5em 3em;
 }
 
-ul {
+.edit-post-visual-editor ul {
   list-style: disc;
 }
 
-ol {
+.edit-post-visual-editor ol {
   list-style: decimal;
 }
 
-li > ul,
-li > ol {
+.edit-post-visual-editor li > ul,
+.edit-post-visual-editor li > ol {
   margin-bottom: 0;
   margin-left: 1.5em;
 }
 
-dt {
+.edit-post-visual-editor dt {
   font-weight: bold;
 }
 
-dd {
+.edit-post-visual-editor dd {
   margin: 0 1.5em 1.5em;
 }
 
-b, strong {
+.edit-post-visual-editor b, .edit-post-visual-editor strong {
   font-weight: bold;
 }
 
-dfn,
-cite,
-em,
-i {
+.edit-post-visual-editor dfn,
+.edit-post-visual-editor cite,
+.edit-post-visual-editor em,
+.edit-post-visual-editor i {
   font-style: italic;
 }
 
-blockquote,
-q {
+.edit-post-visual-editor blockquote,
+.edit-post-visual-editor q {
   quotes: "" "";
 }
 
-blockquote:before, blockquote:after,
-q:before,
-q:after {
+.edit-post-visual-editor blockquote:before, .edit-post-visual-editor blockquote:after,
+.edit-post-visual-editor q:before,
+.edit-post-visual-editor q:after {
   content: "";
 }
 
-blockquote {
+.edit-post-visual-editor blockquote {
   border-left: 5px solid rgba(0, 0, 0, 0.05);
   padding: 20px;
   font-size: 1.2em;
@@ -90,21 +94,21 @@ blockquote {
   position: relative;
 }
 
-blockquote p:last-child {
+.edit-post-visual-editor blockquote p:last-child {
   margin: 0;
 }
 
-address {
+.edit-post-visual-editor address {
   margin: 0 0 1.5em;
 }
 
-abbr,
-acronym {
+.edit-post-visual-editor abbr,
+.edit-post-visual-editor acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
 
-pre {
+.edit-post-visual-editor pre {
   background: #eee;
   font-family: "Courier 10 Pitch", Courier, monospace;
   margin-bottom: 1.6em;
@@ -113,33 +117,33 @@ pre {
   padding: 1.6em;
 }
 
-code,
-kbd,
-tt,
-var {
+.edit-post-visual-editor code,
+.edit-post-visual-editor kbd,
+.edit-post-visual-editor tt,
+.edit-post-visual-editor var {
   font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
-img {
+.edit-post-visual-editor img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;
   /* Adhere to container width. */
 }
 
-hr {
+.edit-post-visual-editor hr {
   background-color: #ccc;
   border: 0;
   height: 1px;
   margin-bottom: 1.5em;
 }
 
-.ast-button,
-.button,
-button,
-input,
-select,
-textarea {
+.edit-post-visual-editor .ast-button,
+.edit-post-visual-editor .button,
+.edit-post-visual-editor button,
+.edit-post-visual-editor input,
+.edit-post-visual-editor select,
+.edit-post-visual-editor textarea {
   color: #808285;
   font-weight: normal;
   font-size: 100%;
@@ -150,53 +154,53 @@ textarea {
   /* Improves appearance and consistency in all browsers */
 }
 
-button,
-input {
+.edit-post-visual-editor button,
+.edit-post-visual-editor input {
   line-height: normal;
   /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
-big {
+.edit-post-visual-editor big {
   font-size: 125%;
 }
 
-mark,
-ins {
+.edit-post-visual-editor mark,
+.edit-post-visual-editor ins {
   background: transparent;
   text-decoration: none;
 }
 
-ul, ol {
+.edit-post-visual-editor ul, .edit-post-visual-editor ol {
   margin: 0 0 1.5em 3em;
 }
 
-ul {
+.edit-post-visual-editor ul {
   list-style: disc;
 }
 
-ol {
+.edit-post-visual-editor ol {
   list-style: decimal;
 }
 
-li > ul,
-li > ol {
+.edit-post-visual-editor li > ul,
+.edit-post-visual-editor li > ol {
   margin-bottom: 0;
   margin-left: 1.5em;
 }
 
-dt {
+.edit-post-visual-editor dt {
   font-weight: bold;
 }
 
-dd {
+.edit-post-visual-editor dd {
   margin: 0 1.5em 1.5em;
 }
 
-table, th, td {
+.edit-post-visual-editor table, .edit-post-visual-editor th, .edit-post-visual-editor td {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-table {
+.edit-post-visual-editor table {
   border-collapse: separate;
   border-spacing: 0;
   border-width: 1px 0 0 1px;
@@ -204,72 +208,72 @@ table {
   width: 100%;
 }
 
-th {
+.edit-post-visual-editor th {
   font-weight: bold;
 }
 
-th, td {
+.edit-post-visual-editor th, .edit-post-visual-editor td {
   padding: 8px;
   text-align: left;
   border-width: 0 1px 1px 0;
 }
 
-::selection {
+.edit-post-visual-editor ::selection {
   color: #fff;
   background: royalblue;
 }
 
-html {
+.edit-post-visual-editor html {
   overflow-y: scroll;
 }
 
-body {
+.edit-post-visual-editor body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-body:not(.logged-in) {
+.edit-post-visual-editor body:not(.logged-in) {
   position: relative;
 }
 
-#page {
+.edit-post-visual-editor #page {
   position: relative;
 }
 
-a,
-a:focus {
+.edit-post-visual-editor a,
+.edit-post-visual-editor a:focus {
   text-decoration: none;
 }
 
-a,
-.site-header a *,
-.site-footer a *,
-.secondary a * {
+.edit-post-visual-editor a,
+.edit-post-visual-editor .site-header a *,
+.edit-post-visual-editor .site-footer a *,
+.edit-post-visual-editor .secondary a * {
   transition: all 0.2s linear;
 }
 
-.capitalize {
+.edit-post-visual-editor .capitalize {
   text-transform: uppercase;
 }
 
-img {
+.edit-post-visual-editor img {
   vertical-align: middle;
 }
 
-.entry-content h1,
-.entry-content h2,
-.entry-content h3,
-.entry-content h4,
-.entry-content h5,
-.entry-content h6 {
+.edit-post-visual-editor .entry-content h1,
+.edit-post-visual-editor .entry-content h2,
+.edit-post-visual-editor .entry-content h3,
+.edit-post-visual-editor .entry-content h4,
+.edit-post-visual-editor .entry-content h5,
+.edit-post-visual-editor .entry-content h6 {
   margin-bottom: 20px;
 }
 
-p {
+.edit-post-visual-editor p {
   margin-bottom: 1.75em;
 }
 
-blockquote {
+.edit-post-visual-editor blockquote {
   margin: 1.5em 1em 1.5em 3em;
   padding: 1.2em;
   font-size: 1.1em;
@@ -277,10 +281,10 @@ blockquote {
   position: relative;
 }
 
-.ast-button,
-.button,
-input[type="button"],
-input[type="submit"] {
+.edit-post-visual-editor .ast-button,
+.edit-post-visual-editor .button,
+.edit-post-visual-editor input[type="button"],
+.edit-post-visual-editor input[type="submit"] {
   border-radius: 0;
   padding: 18px 30px;
   border: 0;
@@ -288,78 +292,78 @@ input[type="submit"] {
   text-shadow: none;
 }
 
-.ast-button:hover,
-.button:hover,
-input[type="button"]:hover,
-input[type="submit"]:hover {
+.edit-post-visual-editor .ast-button:hover,
+.edit-post-visual-editor .button:hover,
+.edit-post-visual-editor input[type="button"]:hover,
+.edit-post-visual-editor input[type="submit"]:hover {
   box-shadow: none;
 }
 
-.ast-button:active, .ast-button:focus,
-.button:active,
-.button:focus,
-input[type="button"]:active,
-input[type="button"]:focus,
-input[type="submit"]:active,
-input[type="submit"]:focus {
+.edit-post-visual-editor .ast-button:active, .edit-post-visual-editor .ast-button:focus,
+.edit-post-visual-editor .button:active,
+.edit-post-visual-editor .button:focus,
+.edit-post-visual-editor input[type="button"]:active,
+.edit-post-visual-editor input[type="button"]:focus,
+.edit-post-visual-editor input[type="submit"]:active,
+.edit-post-visual-editor input[type="submit"]:focus {
   box-shadow: none;
 }
 
-.site-title {
+.edit-post-visual-editor .site-title {
   font-weight: normal;
 }
 
-.site-title,
-.site-description {
+.edit-post-visual-editor .site-title,
+.edit-post-visual-editor .site-description {
   margin-bottom: 0;
 }
 
-.site-title a,
-.site-title:hover a,
-.site-title:focus a,
-.site-description a,
-.site-description:hover a,
-.site-description:focus a {
+.edit-post-visual-editor .site-title a,
+.edit-post-visual-editor .site-title:hover a,
+.edit-post-visual-editor .site-title:focus a,
+.edit-post-visual-editor .site-description a,
+.edit-post-visual-editor .site-description:hover a,
+.edit-post-visual-editor .site-description:focus a {
   transition: all 0.2s linear;
 }
 
-.site-title a,
-.site-title a:focus,
-.site-title a:hover,
-.site-title a:visited {
+.edit-post-visual-editor .site-title a,
+.edit-post-visual-editor .site-title a:focus,
+.edit-post-visual-editor .site-title a:hover,
+.edit-post-visual-editor .site-title a:visited {
   color: #222;
 }
 
-.site-description a,
-.site-description a:focus,
-.site-description a:hover,
-.site-description a:visited {
+.edit-post-visual-editor .site-description a,
+.edit-post-visual-editor .site-description a:focus,
+.edit-post-visual-editor .site-description a:hover,
+.edit-post-visual-editor .site-description a:visited {
   color: #999;
 }
 
-.search-form .search-field {
+.edit-post-visual-editor .search-form .search-field {
   outline: none;
 }
 
-.ast-search-menu-icon {
+.edit-post-visual-editor .ast-search-menu-icon {
   position: relative;
 }
 
-.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
   margin-right: 1em;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
   display: none;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
   width: 100%;
   padding-right: 5.5em;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
   display: block;
   position: absolute;
   height: 100%;
@@ -369,14 +373,13 @@ input[type="submit"]:focus {
   border-radius: 0;
 }
 
-.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
+.edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
   padding: 0;
   display: block;
   overflow: hidden;
 }
 
-/* must have higher specificity than alternative color schemes inline styles */
-.site .skip-link {
+.edit-post-visual-editor .site .skip-link {
   background-color: #f1f1f1;
   box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
   color: #21759b;
@@ -392,7 +395,7 @@ input[type="submit"]:focus {
   top: -9999em;
 }
 
-.site .skip-link:focus {
+.edit-post-visual-editor .site .skip-link:focus {
   clip: auto;
   height: auto;
   left: 6px;
@@ -401,52 +404,52 @@ input[type="submit"]:focus {
   z-index: 100000;
 }
 
-.logged-in .site .skip-link {
+.logged-in .edit-post-visual-editor .site .skip-link {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.2);
   font-family: "Open Sans", sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 {
+.edit-post-visual-editor h1, .edit-post-visual-editor h2, .edit-post-visual-editor h3, .edit-post-visual-editor h4, .edit-post-visual-editor h5, .edit-post-visual-editor h6 {
   clear: both;
 }
 
-h1,
-.entry-content h1 {
+.edit-post-visual-editor h1,
+.edit-post-visual-editor .entry-content h1 {
   color: #808285;
   font-size: 2em;
   line-height: 1.2;
 }
 
-h2,
-.entry-content h2 {
+.edit-post-visual-editor h2,
+.edit-post-visual-editor .entry-content h2 {
   color: #808285;
   font-size: 1.7em;
   line-height: 1.3;
 }
 
-h3,
-.entry-content h3 {
+.edit-post-visual-editor h3,
+.edit-post-visual-editor .entry-content h3 {
   color: #808285;
   font-size: 1.5em;
   line-height: 1.4;
 }
 
-h4,
-.entry-content h4 {
+.edit-post-visual-editor h4,
+.edit-post-visual-editor .entry-content h4 {
   color: #808285;
   line-height: 1.5;
   font-size: 1.3em;
 }
 
-h5,
-.entry-content h5 {
+.edit-post-visual-editor h5,
+.edit-post-visual-editor .entry-content h5 {
   color: #808285;
   line-height: 1.6;
   font-size: 1.2em;
 }
 
-h6,
-.entry-content h6 {
+.edit-post-visual-editor h6,
+.edit-post-visual-editor .entry-content h6 {
   color: #808285;
   line-height: 1.7;
   font-size: 1.1em;

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -11,81 +11,77 @@ html {
   font-size: 93.75%;
 }
 
-#wpwrap .edit-post-visual-editor {
-  /*----------  Font Size  ----------*/
-  /*----------  Line Height  ----------*/
-  /*----------  Site Basic Structure  ----------*/
-  /*----------  z-index Structure   ----------*/
-  /* must have higher specificity than alternative color schemes inline styles */
-}
-
-#wpwrap .edit-post-visual-editor html {
+/*----------  Font Size  ----------*/
+/*----------  Line Height  ----------*/
+/*----------  Site Basic Structure  ----------*/
+/*----------  z-index Structure   ----------*/
+html {
   box-sizing: border-box;
 }
 
-#wpwrap .edit-post-visual-editor *,
-#wpwrap .edit-post-visual-editor *:before,
-#wpwrap .edit-post-visual-editor *:after {
+*,
+*:before,
+*:after {
   /* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
   box-sizing: inherit;
 }
 
-#wpwrap .edit-post-visual-editor body {
+body {
   color: #808285;
   background: #ffffff;
   /* Fallback for when there is no custom background color defined. */
   font-style: normal;
 }
 
-#wpwrap .edit-post-visual-editor ul, #wpwrap .edit-post-visual-editor ol {
+ul, ol {
   margin: 0 0 1.5em 3em;
 }
 
-#wpwrap .edit-post-visual-editor ul {
+ul {
   list-style: disc;
 }
 
-#wpwrap .edit-post-visual-editor ol {
+ol {
   list-style: decimal;
 }
 
-#wpwrap .edit-post-visual-editor li > ul,
-#wpwrap .edit-post-visual-editor li > ol {
+li > ul,
+li > ol {
   margin-bottom: 0;
   margin-left: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor dt {
+dt {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dd {
+dd {
   margin: 0 1.5em 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor b, #wpwrap .edit-post-visual-editor strong {
+b, strong {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dfn,
-#wpwrap .edit-post-visual-editor cite,
-#wpwrap .edit-post-visual-editor em,
-#wpwrap .edit-post-visual-editor i {
+dfn,
+cite,
+em,
+i {
   font-style: italic;
 }
 
-#wpwrap .edit-post-visual-editor blockquote,
-#wpwrap .edit-post-visual-editor q {
+blockquote,
+q {
   quotes: "" "";
 }
 
-#wpwrap .edit-post-visual-editor blockquote:before, #wpwrap .edit-post-visual-editor blockquote:after,
-#wpwrap .edit-post-visual-editor q:before,
-#wpwrap .edit-post-visual-editor q:after {
+blockquote:before, blockquote:after,
+q:before,
+q:after {
   content: "";
 }
 
-#wpwrap .edit-post-visual-editor blockquote {
+blockquote {
   border-left: 5px solid rgba(0, 0, 0, 0.05);
   padding: 20px;
   font-size: 1.2em;
@@ -94,21 +90,21 @@ html {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor blockquote p:last-child {
+blockquote p:last-child {
   margin: 0;
 }
 
-#wpwrap .edit-post-visual-editor address {
+address {
   margin: 0 0 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor abbr,
-#wpwrap .edit-post-visual-editor acronym {
+abbr,
+acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
 
-#wpwrap .edit-post-visual-editor pre {
+pre {
   background: #eee;
   font-family: "Courier 10 Pitch", Courier, monospace;
   margin-bottom: 1.6em;
@@ -117,33 +113,33 @@ html {
   padding: 1.6em;
 }
 
-#wpwrap .edit-post-visual-editor code,
-#wpwrap .edit-post-visual-editor kbd,
-#wpwrap .edit-post-visual-editor tt,
-#wpwrap .edit-post-visual-editor var {
+code,
+kbd,
+tt,
+var {
   font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
-#wpwrap .edit-post-visual-editor img {
+img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;
   /* Adhere to container width. */
 }
 
-#wpwrap .edit-post-visual-editor hr {
+hr {
   background-color: #ccc;
   border: 0;
   height: 1px;
   margin-bottom: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button,
-#wpwrap .edit-post-visual-editor .button,
-#wpwrap .edit-post-visual-editor button,
-#wpwrap .edit-post-visual-editor input,
-#wpwrap .edit-post-visual-editor select,
-#wpwrap .edit-post-visual-editor textarea {
+.ast-button,
+.button,
+button,
+input,
+select,
+textarea {
   color: #808285;
   font-weight: normal;
   font-size: 100%;
@@ -154,53 +150,53 @@ html {
   /* Improves appearance and consistency in all browsers */
 }
 
-#wpwrap .edit-post-visual-editor button,
-#wpwrap .edit-post-visual-editor input {
+button,
+input {
   line-height: normal;
   /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
 }
 
-#wpwrap .edit-post-visual-editor big {
+big {
   font-size: 125%;
 }
 
-#wpwrap .edit-post-visual-editor mark,
-#wpwrap .edit-post-visual-editor ins {
+mark,
+ins {
   background: transparent;
   text-decoration: none;
 }
 
-#wpwrap .edit-post-visual-editor ul, #wpwrap .edit-post-visual-editor ol {
+ul, ol {
   margin: 0 0 1.5em 3em;
 }
 
-#wpwrap .edit-post-visual-editor ul {
+ul {
   list-style: disc;
 }
 
-#wpwrap .edit-post-visual-editor ol {
+ol {
   list-style: decimal;
 }
 
-#wpwrap .edit-post-visual-editor li > ul,
-#wpwrap .edit-post-visual-editor li > ol {
+li > ul,
+li > ol {
   margin-bottom: 0;
   margin-left: 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor dt {
+dt {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor dd {
+dd {
   margin: 0 1.5em 1.5em;
 }
 
-#wpwrap .edit-post-visual-editor table, #wpwrap .edit-post-visual-editor th, #wpwrap .edit-post-visual-editor td {
+table, th, td {
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-#wpwrap .edit-post-visual-editor table {
+table {
   border-collapse: separate;
   border-spacing: 0;
   border-width: 1px 0 0 1px;
@@ -208,72 +204,72 @@ html {
   width: 100%;
 }
 
-#wpwrap .edit-post-visual-editor th {
+th {
   font-weight: bold;
 }
 
-#wpwrap .edit-post-visual-editor th, #wpwrap .edit-post-visual-editor td {
+th, td {
   padding: 8px;
   text-align: left;
   border-width: 0 1px 1px 0;
 }
 
-#wpwrap .edit-post-visual-editor ::selection {
+::selection {
   color: #fff;
   background: royalblue;
 }
 
-#wpwrap .edit-post-visual-editor html {
+html {
   overflow-y: scroll;
 }
 
-#wpwrap .edit-post-visual-editor body {
+body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#wpwrap .edit-post-visual-editor body:not(.logged-in) {
+body:not(.logged-in) {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor #page {
+#page {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor a,
-#wpwrap .edit-post-visual-editor a:focus {
+a,
+a:focus {
   text-decoration: none;
 }
 
-#wpwrap .edit-post-visual-editor a,
-#wpwrap .edit-post-visual-editor .site-header a *,
-#wpwrap .edit-post-visual-editor .site-footer a *,
-#wpwrap .edit-post-visual-editor .secondary a * {
+a,
+.site-header a *,
+.site-footer a *,
+.secondary a * {
   transition: all 0.2s linear;
 }
 
-#wpwrap .edit-post-visual-editor .capitalize {
+.capitalize {
   text-transform: uppercase;
 }
 
-#wpwrap .edit-post-visual-editor img {
+img {
   vertical-align: middle;
 }
 
-#wpwrap .edit-post-visual-editor .entry-content h1,
-#wpwrap .edit-post-visual-editor .entry-content h2,
-#wpwrap .edit-post-visual-editor .entry-content h3,
-#wpwrap .edit-post-visual-editor .entry-content h4,
-#wpwrap .edit-post-visual-editor .entry-content h5,
-#wpwrap .edit-post-visual-editor .entry-content h6 {
+.entry-content h1,
+.entry-content h2,
+.entry-content h3,
+.entry-content h4,
+.entry-content h5,
+.entry-content h6 {
   margin-bottom: 20px;
 }
 
-#wpwrap .edit-post-visual-editor p {
+p {
   margin-bottom: 1.75em;
 }
 
-#wpwrap .edit-post-visual-editor blockquote {
+blockquote {
   margin: 1.5em 1em 1.5em 3em;
   padding: 1.2em;
   font-size: 1.1em;
@@ -281,10 +277,10 @@ html {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button,
-#wpwrap .edit-post-visual-editor .button,
-#wpwrap .edit-post-visual-editor input[type="button"],
-#wpwrap .edit-post-visual-editor input[type="submit"] {
+.ast-button,
+.button,
+input[type="button"],
+input[type="submit"] {
   border-radius: 0;
   padding: 18px 30px;
   border: 0;
@@ -292,78 +288,78 @@ html {
   text-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button:hover,
-#wpwrap .edit-post-visual-editor .button:hover,
-#wpwrap .edit-post-visual-editor input[type="button"]:hover,
-#wpwrap .edit-post-visual-editor input[type="submit"]:hover {
+.ast-button:hover,
+.button:hover,
+input[type="button"]:hover,
+input[type="submit"]:hover {
   box-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-button:active, #wpwrap .edit-post-visual-editor .ast-button:focus,
-#wpwrap .edit-post-visual-editor .button:active,
-#wpwrap .edit-post-visual-editor .button:focus,
-#wpwrap .edit-post-visual-editor input[type="button"]:active,
-#wpwrap .edit-post-visual-editor input[type="button"]:focus,
-#wpwrap .edit-post-visual-editor input[type="submit"]:active,
-#wpwrap .edit-post-visual-editor input[type="submit"]:focus {
+.ast-button:active, .ast-button:focus,
+.button:active,
+.button:focus,
+input[type="button"]:active,
+input[type="button"]:focus,
+input[type="submit"]:active,
+input[type="submit"]:focus {
   box-shadow: none;
 }
 
-#wpwrap .edit-post-visual-editor .site-title {
+.site-title {
   font-weight: normal;
 }
 
-#wpwrap .edit-post-visual-editor .site-title,
-#wpwrap .edit-post-visual-editor .site-description {
+.site-title,
+.site-description {
   margin-bottom: 0;
 }
 
-#wpwrap .edit-post-visual-editor .site-title a,
-#wpwrap .edit-post-visual-editor .site-title:hover a,
-#wpwrap .edit-post-visual-editor .site-title:focus a,
-#wpwrap .edit-post-visual-editor .site-description a,
-#wpwrap .edit-post-visual-editor .site-description:hover a,
-#wpwrap .edit-post-visual-editor .site-description:focus a {
+.site-title a,
+.site-title:hover a,
+.site-title:focus a,
+.site-description a,
+.site-description:hover a,
+.site-description:focus a {
   transition: all 0.2s linear;
 }
 
-#wpwrap .edit-post-visual-editor .site-title a,
-#wpwrap .edit-post-visual-editor .site-title a:focus,
-#wpwrap .edit-post-visual-editor .site-title a:hover,
-#wpwrap .edit-post-visual-editor .site-title a:visited {
+.site-title a,
+.site-title a:focus,
+.site-title a:hover,
+.site-title a:visited {
   color: #222;
 }
 
-#wpwrap .edit-post-visual-editor .site-description a,
-#wpwrap .edit-post-visual-editor .site-description a:focus,
-#wpwrap .edit-post-visual-editor .site-description a:hover,
-#wpwrap .edit-post-visual-editor .site-description a:visited {
+.site-description a,
+.site-description a:focus,
+.site-description a:hover,
+.site-description a:visited {
   color: #999;
 }
 
-#wpwrap .edit-post-visual-editor .search-form .search-field {
+.search-form .search-field {
   outline: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-search-menu-icon {
+.ast-search-menu-icon {
   position: relative;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
+.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {
   margin-right: 1em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {
   display: none;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {
   width: 100%;
   padding-right: 5.5em;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {
   display: block;
   position: absolute;
   height: 100%;
@@ -373,13 +369,14 @@ html {
   border-radius: 0;
 }
 
-#wpwrap .edit-post-visual-editor .ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
+.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {
   padding: 0;
   display: block;
   overflow: hidden;
 }
 
-#wpwrap .edit-post-visual-editor .site .skip-link {
+/* must have higher specificity than alternative color schemes inline styles */
+.site .skip-link {
   background-color: #f1f1f1;
   box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
   color: #21759b;
@@ -395,7 +392,7 @@ html {
   top: -9999em;
 }
 
-#wpwrap .edit-post-visual-editor .site .skip-link:focus {
+.site .skip-link:focus {
   clip: auto;
   height: auto;
   left: 6px;
@@ -404,167 +401,174 @@ html {
   z-index: 100000;
 }
 
-.logged-in #wpwrap .edit-post-visual-editor .site .skip-link {
+.logged-in .site .skip-link {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.2);
   font-family: "Open Sans", sans-serif;
 }
 
-#wpwrap .edit-post-visual-editor h1, #wpwrap .edit-post-visual-editor h2, #wpwrap .edit-post-visual-editor h3, #wpwrap .edit-post-visual-editor h4, #wpwrap .edit-post-visual-editor h5, #wpwrap .edit-post-visual-editor h6 {
+h1, h2, h3, h4, h5, h6 {
   clear: both;
 }
 
-#wpwrap .edit-post-visual-editor h1,
-#wpwrap .edit-post-visual-editor .entry-content h1 {
+h1,
+.entry-content h1 {
   color: #808285;
   font-size: 2em;
   line-height: 1.2;
 }
 
-#wpwrap .edit-post-visual-editor h2,
-#wpwrap .edit-post-visual-editor .entry-content h2 {
+h2,
+.entry-content h2 {
   color: #808285;
   font-size: 1.7em;
   line-height: 1.3;
 }
 
-#wpwrap .edit-post-visual-editor h3,
-#wpwrap .edit-post-visual-editor .entry-content h3 {
+h3,
+.entry-content h3 {
   color: #808285;
   font-size: 1.5em;
   line-height: 1.4;
 }
 
-#wpwrap .edit-post-visual-editor h4,
-#wpwrap .edit-post-visual-editor .entry-content h4 {
+h4,
+.entry-content h4 {
   color: #808285;
   line-height: 1.5;
   font-size: 1.3em;
 }
 
-#wpwrap .edit-post-visual-editor h5,
-#wpwrap .edit-post-visual-editor .entry-content h5 {
+h5,
+.entry-content h5 {
   color: #808285;
   line-height: 1.6;
   font-size: 1.2em;
 }
 
-#wpwrap .edit-post-visual-editor h6,
-#wpwrap .edit-post-visual-editor .entry-content h6 {
+h6,
+.entry-content h6 {
   color: #808285;
   line-height: 1.7;
   font-size: 1.1em;
 }
 
-#wpwrap .edit-post-visual-editor p,
-#wpwrap .edit-post-visual-editor .editor-block-list__block p,
-#wpwrap .edit-post-visual-editor .editor-default-block-appender textarea.editor-default-block-appender__content {
+p,
+.editor-block-list__block p,
+.editor-default-block-appender textarea.editor-default-block-appender__content {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
   font-weight: inherit;
   font-size: 15px;
   font-size: 1rem;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
+.editor-post-title__block .editor-post-title__input {
   font-size: 30px;
   font-size: 2rem;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
   font-weight: normal;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block {
+.editor-block-list__block {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
 @media (min-width: 600px) {
-  #wpwrap .edit-post-visual-editor .editor-block-list__block {
+  .editor-block-list__block {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block blockquote p {
+.editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+.editor-block-list__block .editor-block-list__block-edit {
   margin-left: 0;
   margin-right: 0;
 }
 
 @media (min-width: 600px) {
-  #wpwrap .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
+  .editor-block-list__block .editor-block-list__block-edit {
     padding-left: 28px;
     padding-right: 28px;
   }
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
+.editor-block-list__block > .editor-block-mover {
   left: -50px;
   top: -5px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input {
-  padding-left: 26px;
-  padding-right: 26px;
+.editor-post-title__block .editor-post-title__input {
+  padding-left: 43px;
+  padding-right: 43px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-post-title__block,
-#wpwrap .edit-post-visual-editor .editor-default-block-appender,
-#wpwrap .edit-post-visual-editor .editor-block-list__block {
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
   max-width: 1256px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=full] {
+.editor-block-list__block[data-align=full] {
   max-width: none;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=wide] {
+@media (min-width: 600px) {
+  .editor-block-list__block[data-align=full] .editor-block-list__block-edit {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.editor-block-list__block[data-align=wide] {
   max-width: 1400px;
 }
 
-#wpwrap .edit-post-visual-editor .editor-block-list__layout .editor-block-list__layout {
+.editor-block-list__layout .editor-block-list__layout {
   padding: 0;
 }
 
-#wpwrap .edit-post-visual-editor .editor-default-block-appender__content {
+.editor-default-block-appender__content {
   margin-top: 32px;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts.is-grid {
+.wp-block-latest-posts.is-grid {
   list-style: none;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-gallery {
+.wp-block-gallery {
   margin: 0;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-gallery.is-cropped .blocks-gallery-item img {
+.wp-block-gallery.is-cropped .blocks-gallery-item img {
   height: 100%;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts {
+.wp-block-latest-posts {
   margin-left: 0;
 }
 
-#wpwrap .edit-post-visual-editor .wp-block-latest-posts li {
+.wp-block-latest-posts li {
   list-style: none;
 }
 
-#wpwrap .edit-post-visual-editor h1,
-#wpwrap .edit-post-visual-editor h2,
-#wpwrap .edit-post-visual-editor h3,
-#wpwrap .edit-post-visual-editor h4,
-#wpwrap .edit-post-visual-editor h5,
-#wpwrap .edit-post-visual-editor h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: inherit;
 }
 
-#wpwrap .edit-post-visual-editor .mce-widget i {
+.mce-widget i {
   font-style: normal;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button {
+#elementor-editor-button {
   background: #0073aa;
   border-color: #005177 #003f5e #003f5e;
   color: #fff;
@@ -584,49 +588,49 @@ html {
   box-shadow: 0 2px 0 #006799;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:hover, #wpwrap .edit-post-visual-editor #elementor-editor-button:focus {
+#elementor-editor-button:hover, #elementor-editor-button:focus {
   background: #007db9;
   border-color: #003f5e;
   color: #fff;
   box-shadow: 0 1px 0 #003f5e;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:focus {
+#elementor-editor-button:focus {
   box-shadow: inset 0 1px 0 #005177, 0 0 2px 1px #33b3db;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button:active, #wpwrap .edit-post-visual-editor #elementor-editor-button.active, #wpwrap .edit-post-visual-editor #elementor-editor-button.active:focus, #wpwrap .edit-post-visual-editor #elementor-editor-button.active:hover {
+#elementor-editor-button:active, #elementor-editor-button.active, #elementor-editor-button.active:focus, #elementor-editor-button.active:hover {
   background: #005177;
   border-color: #003f5e;
   box-shadow: inset 0 2px 0 #003f5e;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button[disabled], #wpwrap .edit-post-visual-editor #elementor-editor-button:disabled, #wpwrap .edit-post-visual-editor #elementor-editor-button.button-primary-disabled, #wpwrap .edit-post-visual-editor #elementor-editor-button.disabled {
+#elementor-editor-button[disabled], #elementor-editor-button:disabled, #elementor-editor-button.button-primary-disabled, #elementor-editor-button.disabled {
   color: #c7ced1 !important;
   background: #005781 !important;
   border-color: #003f5e !important;
   text-shadow: none !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button.button-hero {
+#elementor-editor-button.button-hero {
   box-shadow: 0 2px 0 #003f5e !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button.button-hero:active {
+#elementor-editor-button.button-hero:active {
   box-shadow: inset 0 3px 0 #003f5e !important;
 }
 
-#wpwrap .edit-post-visual-editor #elementor-editor-button i {
+#elementor-editor-button i {
   font-style: normal;
   color: white;
 }
 
-#wpwrap .edit-post-visual-editor .editor-media-placeholder button,
-#wpwrap .edit-post-visual-editor .fl-builder-layout-launch-view button {
+.editor-media-placeholder button,
+.fl-builder-layout-launch-view button {
   margin: 2px;
 }
 
-#wpwrap .edit-post-visual-editor .fl-builder-layout-launch-view .is-primary.is-primary {
+.fl-builder-layout-launch-view .is-primary.is-primary {
   color: white;
 }
 

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -468,42 +468,43 @@ p,
   font-weight: normal;
 }
 
-.editor-block-list__block {
+.edit-post-visual-editor .editor-block-list__block {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
 }
 
 @media (min-width: 600px) {
-  .editor-block-list__block {
+  .edit-post-visual-editor .editor-block-list__block {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.editor-block-list__block blockquote p {
+.edit-post-visual-editor .editor-block-list__block blockquote p {
   font-size: 1.1rem;
   line-height: 1.8571428571;
 }
 
-.editor-block-list__block .editor-block-list__block-edit {
+.edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
   margin-left: 0;
   margin-right: 0;
 }
 
 @media (min-width: 600px) {
-  .editor-block-list__block .editor-block-list__block-edit {
+  .edit-post-visual-editor .editor-block-list__block .editor-block-list__block-edit {
     padding-left: 28px;
     padding-right: 28px;
   }
 }
 
-.editor-block-list__block > .editor-block-mover {
+.edit-post-visual-editor .editor-block-list__block > .editor-block-mover {
   left: -50px;
   top: -5px;
 }
 
 .editor-post-title__block .editor-post-title__input {
-  padding-left: 43px;
-  padding-right: 43px;
+  padding-left: 28px;
+  padding-right: 28px;
+  font-weight: normal;
 }
 
 .editor-post-title__block,

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -74,33 +74,33 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'html'                                => array(
 					'font-size' => astra_get_font_css_value( (int) $body_font_size_desktop * 6.25, '%' ),
 				),
-				'#wpwrap .edit-post-visual-editor a'  => array(
+				'a'  => array(
 					'color' => esc_attr( $link_color ),
 				),
 				// Global selection CSS.
-				'#wpwrap .edit-post-visual-editor ::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit:before' => array(
+				'::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit:before' => array(
 					'background-color' => esc_attr( $theme_color ),
 				),
-				'#wpwrap .edit-post-visual-editor ::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit' => array(
+				'::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit' => array(
 					'color' => esc_attr( $highlight_theme_color ),
 				),
 
-				'.ast-separate-container #wpwrap .edit-post-visual-editor, .ast-page-builder-template #wpwrap .edit-post-visual-editor, .ast-plain-container #wpwrap .edit-post-visual-editor' => astra_get_background_obj( $box_bg_obj ),
-				'#wpwrap .edit-post-visual-editor .editor-post-title__block,#wpwrap .edit-post-visual-editor .editor-default-block-appender,#wpwrap .edit-post-visual-editor .editor-block-list__block' => array(
+				'.ast-separate-container .edit-post-visual-editor, .ast-page-builder-template .edit-post-visual-editor, .ast-plain-container .edit-post-visual-editor' => astra_get_background_obj( $box_bg_obj ),
+				'.editor-post-title__block,.editor-default-block-appender,.editor-block-list__block' => array(
 					'max-width' => astra_get_css_value( $site_content_width, 'px' ),
 				),
-				'#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=wide]' => array(
+				'.editor-block-list__block[data-align=wide]' => array(
 					'max-width' => astra_get_css_value( $site_content_width + 200, 'px' ),
 				),
-				'#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input,  #wpwrap .edit-post-visual-editor h1, #wpwrap .edit-post-visual-editor h2, #wpwrap .edit-post-visual-editor h3, #wpwrap .edit-post-visual-editor h4, #wpwrap .edit-post-visual-editor h5, #wpwrap .edit-post-visual-editor h6' => array(
+				'.editor-post-title__block .editor-post-title__input,  h1, h2, h3, h4, h5, h6' => array(
 					'font-family'    => astra_get_css_value( $headings_font_family, 'font' ),
 					'font-weight'    => astra_get_css_value( $headings_font_weight, 'font' ),
 					'text-transform' => esc_attr( $headings_text_transform ),
 				),
-				'#wpwrap .edit-post-visual-editor p,#wpwrap .edit-post-visual-editor .editor-block-list__block p' => array(
+				'p,.editor-block-list__block p' => array(
 					'font-size' => astra_responsive_font( $body_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor p,#wpwrap .edit-post-visual-editor .editor-block-list__block p, #wpwrap .edit-post-visual-editor .wp-block-latest-posts a,#wpwrap .edit-post-visual-editor .editor-default-block-appender textarea.editor-default-block-appender__content, #wpwrap .edit-post-visual-editor .editor-block-list__block' => array(
+				'p,.editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .editor-block-list__block' => array(
 					'font-family'    => astra_get_font_family( $body_font_family ),
 					'font-weight'    => esc_attr( $body_font_weight ),
 					'font-size'      => astra_responsive_font( $body_font_size, 'desktop' ),
@@ -108,37 +108,37 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'text-transform' => esc_attr( $body_text_transform ),
 					'margin-bottom'  => astra_get_css_value( $para_margin_bottom, 'em' ),
 				),
-				'#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input' => array(
+				'.editor-post-title__block .editor-post-title__input' => array(
 					'font-family' => ( 'inherit' === $headings_font_family ) ? astra_get_font_family( $body_font_family ) : astra_get_font_family( $headings_font_family ),
 					'font-size'   => astra_responsive_font( $single_post_title_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor .editor-block-list__block, #wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input, #wpwrap .edit-post-visual-editor h1,#wpwrap .edit-post-visual-editor h2,#wpwrap .edit-post-visual-editor h3,#wpwrap .edit-post-visual-editor h4,#wpwrap .edit-post-visual-editor h5,#wpwrap .edit-post-visual-editor h6' => array(
+				'.editor-block-list__block, .editor-post-title__block .editor-post-title__input, h1,h2,h3,h4,h5,h6' => array(
 					'color' => esc_attr( $text_color ),
 				),
 				// Blockquote Text Color.
-				'#wpwrap .edit-post-visual-editor blockquote, #wpwrap .edit-post-visual-editor blockquote a' => array(
+				'blockquote, blockquote a' => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
 				),
-				'#wpwrap .edit-post-visual-editor blockquote' => array(
+				'blockquote' => array(
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
 				),
 				// Heading H1 - H6 font size.
-				'#wpwrap .edit-post-visual-editor h1' => array(
+				'h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor h2' => array(
+				'h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor h3' => array(
+				'h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor h4' => array(
+				'h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor h5' => array(
+				'h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'desktop' ),
 				),
-				'#wpwrap .edit-post-visual-editor h6' => array(
+				'h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'desktop' ),
 				),
 			);
@@ -146,26 +146,26 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			$css .= astra_parse_css( $desktop_css );
 
 			$tablet_css = array(
-				'#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input' => array(
+				'.editor-post-title__block .editor-post-title__input' => array(
 					'font-size' => astra_responsive_font( $single_post_title_font_size, 'tablet', 30 ),
 				),
 				// Heading H1 - H6 font size.
-				'#wpwrap .edit-post-visual-editor h1' => array(
+				'h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'tablet', 30 ),
 				),
-				'#wpwrap .edit-post-visual-editor h2' => array(
+				'h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'tablet', 25 ),
 				),
-				'#wpwrap .edit-post-visual-editor h3' => array(
+				'h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'tablet', 20 ),
 				),
-				'#wpwrap .edit-post-visual-editor h4' => array(
+				'h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'tablet' ),
 				),
-				'#wpwrap .edit-post-visual-editor h5' => array(
+				'h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'tablet' ),
 				),
-				'#wpwrap .edit-post-visual-editor h6' => array(
+				'h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'tablet' ),
 				),
 			);
@@ -173,29 +173,29 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			$css .= astra_parse_css( $tablet_css, '', '768' );
 
 			$mobile_css = array(
-				'#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input' => array(
+				'.editor-post-title__block .editor-post-title__input' => array(
 					'font-size' => astra_responsive_font( $single_post_title_font_size, 'mobile', 30 ),
 				),
 				// Heading H1 - H6 font size.
-				'#wpwrap .edit-post-visual-editor h1' => array(
+				'h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'mobile', 30 ),
 				),
-				'#wpwrap .edit-post-visual-editor h2' => array(
+				'h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'mobile', 25 ),
 				),
-				'#wpwrap .edit-post-visual-editor h3' => array(
+				'h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'mobile', 20 ),
 				),
-				'#wpwrap .edit-post-visual-editor h4' => array(
+				'h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'mobile' ),
 				),
-				'#wpwrap .edit-post-visual-editor h4' => array(
+				'h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'mobile' ),
 				),
-				'#wpwrap .edit-post-visual-editor h5' => array(
+				'h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'mobile' ),
 				),
-				'#wpwrap .edit-post-visual-editor h6' => array(
+				'h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'mobile' ),
 				),
 			);
@@ -204,36 +204,36 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			if ( in_array( $pagenow, array( 'post-new.php' ) ) || 'content-boxed-container' === $container_layout || 'boxed-container' === $container_layout ) {
 				$boxed_container = array(
-					'#wpwrap .edit-post-visual-editor .editor-writing-flow' => array(
+					'.editor-writing-flow' => array(
 						'max-width'        => 'calc( ' . astra_get_css_value( $site_content_width, 'px' ) . ' - 40px )',
 						'margin'           => '0 auto',
 						'background-color' => '#fff',
 						'overflow'         => 'hidden',
 					),
-					'#wpwrap .gutenberg__editor'         => array(
+					'.gutenberg__editor'         => array(
 						'background-color' => '#f5f5f5',
 					),
-					'#wpwrap .editor-block-list__layout, #wpwrap .editor-post-title' => array(
+					'.editor-block-list__layout, .editor-post-title' => array(
 						'padding-top'    => '5.34em',
 						'padding-bottom' => '5.34em',
 						'padding-left'   => 'calc( 6.67em - 14px )',
 						'padding-right'  => 'calc( 6.67em - 14px )',
 					),
-					'#wpwrap .editor-block-list__layout' => array(
+					'.editor-block-list__layout' => array(
 						'padding-top' => '0',
 					),
-					'#wpwrap .editor-post-title'         => array(
+					'.editor-post-title'         => array(
 						'padding-bottom' => '0',
 					),
-					'#wpwrap .edit-post-visual-editor .editor-block-list__block' => array(
+					'.editor-block-list__block' => array(
 						'max-width' => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em)',
 					),
-					'#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=wide]' => array(
+					'.editor-block-list__block[data-align=wide]' => array(
 						'max-width'    => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em + 40px)',
 						'margin-left'  => '-20px',
 						'margin-right' => '-20px',
 					),
-					'#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=full]' => array(
+					'.editor-block-list__block[data-align=full]' => array(
 						'margin-left'  => '-6.67em',
 						'margin-right' => '-6.67em',
 					),

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -124,22 +124,22 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
 				),
 				// Heading H1 - H6 font size.
-				'.edit-post-visual-editor h1, .wp-block-heading h1' => array(
+				'.edit-post-visual-editor h1, .wp-block-heading h1, .wp-block-freeform.block-library-rich-text__tinymce h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor h2, .wp-block-heading h2' => array(
+				'.edit-post-visual-editor h2, .wp-block-heading h2, .wp-block-freeform.block-library-rich-text__tinymce h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor h3, .wp-block-heading h3' => array(
+				'.edit-post-visual-editor h3, .wp-block-heading h3, .wp-block-freeform.block-library-rich-text__tinymce h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor h4, .wp-block-heading h4' => array(
+				'.edit-post-visual-editor h4, .wp-block-heading h4, .wp-block-freeform.block-library-rich-text__tinymce h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor h5, .wp-block-heading h5' => array(
+				'.edit-post-visual-editor h5, .wp-block-heading h5, .wp-block-freeform.block-library-rich-text__tinymce h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor h6, .wp-block-heading h6' => array(
+				'.edit-post-visual-editor h6, .wp-block-heading h6, .wp-block-freeform.block-library-rich-text__tinymce h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'desktop' ),
 				),
 			);

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-weight'    => astra_get_css_value( $headings_font_weight, 'font' ),
 					'text-transform' => esc_attr( $headings_text_transform ),
 				),
-				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .editor-block-list__layout' => array(
+				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .editor-block-list__layout, .editor-post-title' => array(
 					'font-size' => astra_responsive_font( $body_font_size, 'desktop' ),
 				),
 				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .editor-block-list__block' => array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 		public static function get_css() {
 			global $pagenow;
 
-			$site_content_width          = astra_get_option( 'site-content-width', 1200 );
+			$site_content_width          = astra_get_option( 'site-content-width', 1200 ) + 56;
 			$headings_font_family        = astra_get_option( 'headings-font-family' );
 			$headings_font_weight        = astra_get_option( 'headings-font-weight' );
 			$headings_text_transform     = astra_get_option( 'headings-text-transform' );

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -113,7 +113,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-size'   => astra_responsive_font( $single_post_title_font_size, 'desktop' ),
 					'font-weight' => 'normal',
 				),
-				'.editor-block-list__block, .editor-post-title__block .editor-post-title__input, h1,h2,h3,h4,h5,h6' => array(
+				'.editor-block-list__block, .editor-post-title__block .editor-post-title__input, .edit-post-visual-editor h1, .edit-post-visual-editor h2, .edit-post-visual-editor h3, .edit-post-visual-editor h4, .edit-post-visual-editor h5, .edit-post-visual-editor h6' => array(
 					'color' => esc_attr( $text_color ),
 				),
 				// Blockquote Text Color.

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-weight'    => astra_get_css_value( $headings_font_weight, 'font' ),
 					'text-transform' => esc_attr( $headings_text_transform ),
 				),
-				'.editor-styles-wrapper p,.editor-block-list__block p' => array(
+				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .editor-block-list__layout' => array(
 					'font-size' => astra_responsive_font( $body_font_size, 'desktop' ),
 				),
 				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .editor-block-list__block' => array(
@@ -206,7 +206,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			if ( in_array( $pagenow, array( 'post-new.php' ) ) || 'content-boxed-container' === $container_layout || 'boxed-container' === $container_layout ) {
 				$boxed_container = array(
 					'.editor-writing-flow'       => array(
-						'max-width'        => 'calc( ' . astra_get_css_value( $site_content_width, 'px' ) . ' - 40px )',
+						'max-width'        => astra_get_css_value( $site_content_width - 56, 'px' ),
 						'margin'           => '0 auto',
 						'background-color' => '#fff',
 						'overflow'         => 'hidden',
@@ -215,10 +215,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 						'background-color' => '#f5f5f5',
 					),
 					'.editor-block-list__layout, .editor-post-title' => array(
-						'padding-top'    => '5.34em',
+						'padding-top'    => 'calc( 5.34em - 19px)',
 						'padding-bottom' => '5.34em',
-						'padding-left'   => 'calc( 6.67em - 14px )',
-						'padding-right'  => 'calc( 6.67em - 14px )',
+						'padding-left'   => 'calc( 6.67em - 28px )',
+						'padding-right'  => 'calc( 6.67em - 28px )',
 					),
 					'.editor-block-list__layout' => array(
 						'padding-top' => '0',

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -209,7 +209,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 						'max-width'        => astra_get_css_value( $site_content_width - 56, 'px' ),
 						'margin'           => '0 auto',
 						'background-color' => '#fff',
-						'overflow'         => 'hidden',
 					),
 					'.gutenberg__editor'         => array(
 						'background-color' => '#f5f5f5',
@@ -230,13 +229,16 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 						'max-width' => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em)',
 					),
 					'.editor-block-list__block[data-align=wide]' => array(
-						'max-width'    => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em + 40px)',
 						'margin-left'  => '-20px',
 						'margin-right' => '-20px',
 					),
 					'.editor-block-list__block[data-align=full]' => array(
 						'margin-left'  => '-6.67em',
 						'margin-right' => '-6.67em',
+					),
+					'.editor-block-list__layout .editor-block-list__block[data-align="full"], .editor-block-list__layout .editor-block-list__block[data-align="full"] > .editor-block-list__block-edit' => array(
+						'margin-left'  => '0',
+						'margin-right' => '0',
 					),
 				);
 

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -124,22 +124,22 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
 				),
 				// Heading H1 - H6 font size.
-				'h1, .wp-block-heading h1' => array(
+				'.edit-post-visual-editor h1, .wp-block-heading h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'desktop' ),
 				),
-				'h2, .wp-block-heading h2' => array(
+				'.edit-post-visual-editor h2, .wp-block-heading h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'desktop' ),
 				),
-				'h3, .wp-block-heading h3' => array(
+				'.edit-post-visual-editor h3, .wp-block-heading h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'desktop' ),
 				),
-				'h4, .wp-block-heading h4' => array(
+				'.edit-post-visual-editor h4, .wp-block-heading h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'desktop' ),
 				),
-				'h5, .wp-block-heading h5' => array(
+				'.edit-post-visual-editor h5, .wp-block-heading h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'desktop' ),
 				),
-				'h6, .wp-block-heading h6' => array(
+				'.edit-post-visual-editor h6, .wp-block-heading h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'desktop' ),
 				),
 			);
@@ -151,22 +151,22 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-size' => astra_responsive_font( $single_post_title_font_size, 'tablet', 30 ),
 				),
 				// Heading H1 - H6 font size.
-				'h1' => array(
+				'.edit-post-visual-editor h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'tablet', 30 ),
 				),
-				'h2' => array(
+				'.edit-post-visual-editor h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'tablet', 25 ),
 				),
-				'h3' => array(
+				'.edit-post-visual-editor h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'tablet', 20 ),
 				),
-				'h4' => array(
+				'.edit-post-visual-editor h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'tablet' ),
 				),
-				'h5' => array(
+				'.edit-post-visual-editor h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'tablet' ),
 				),
-				'h6' => array(
+				'.edit-post-visual-editor h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'tablet' ),
 				),
 			);
@@ -178,25 +178,22 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-size' => astra_responsive_font( $single_post_title_font_size, 'mobile', 30 ),
 				),
 				// Heading H1 - H6 font size.
-				'h1' => array(
+				'.edit-post-visual-editor h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'mobile', 30 ),
 				),
-				'h2' => array(
+				'.edit-post-visual-editor h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'mobile', 25 ),
 				),
-				'h3' => array(
+				'.edit-post-visual-editor h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'mobile', 20 ),
 				),
-				'h4' => array(
+				'.edit-post-visual-editor h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'mobile' ),
 				),
-				'h4' => array(
-					'font-size' => astra_responsive_font( $heading_h4_font_size, 'mobile' ),
-				),
-				'h5' => array(
+				'.edit-post-visual-editor h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'mobile' ),
 				),
-				'h6' => array(
+				'.edit-post-visual-editor h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'mobile' ),
 				),
 			);

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -87,10 +87,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 				'.ast-separate-container #wpwrap .edit-post-visual-editor, .ast-page-builder-template #wpwrap .edit-post-visual-editor, .ast-plain-container #wpwrap .edit-post-visual-editor' => astra_get_background_obj( $box_bg_obj ),
 				'#wpwrap .edit-post-visual-editor .editor-post-title__block,#wpwrap .edit-post-visual-editor .editor-default-block-appender,#wpwrap .edit-post-visual-editor .editor-block-list__block' => array(
-					'max-width' => astra_get_css_value( $site_content_width + 40, 'px' ),
+					'max-width' => astra_get_css_value( $site_content_width, 'px' ),
 				),
 				'#wpwrap .edit-post-visual-editor .editor-block-list__block[data-align=wide]' => array(
-					'max-width' => astra_get_css_value( $site_content_width + 40 + 200, 'px' ),
+					'max-width' => astra_get_css_value( $site_content_width + 200, 'px' ),
 				),
 				'#wpwrap .edit-post-visual-editor .editor-post-title__block .editor-post-title__input,  #wpwrap .edit-post-visual-editor h1, #wpwrap .edit-post-visual-editor h2, #wpwrap .edit-post-visual-editor h3, #wpwrap .edit-post-visual-editor h4, #wpwrap .edit-post-visual-editor h5, #wpwrap .edit-post-visual-editor h6' => array(
 					'font-family'    => astra_get_css_value( $headings_font_family, 'font' ),

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -71,10 +71,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			$css = '';
 
 			$desktop_css = array(
-				'html'                                => array(
+				'html'                     => array(
 					'font-size' => astra_get_font_css_value( (int) $body_font_size_desktop * 6.25, '%' ),
 				),
-				'a'  => array(
+				'a'                        => array(
 					'color' => esc_attr( $link_color ),
 				),
 				// Global selection CSS.
@@ -97,10 +97,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'font-weight'    => astra_get_css_value( $headings_font_weight, 'font' ),
 					'text-transform' => esc_attr( $headings_text_transform ),
 				),
-				'p,.editor-block-list__block p' => array(
+				'.editor-styles-wrapper p,.editor-block-list__block p' => array(
 					'font-size' => astra_responsive_font( $body_font_size, 'desktop' ),
 				),
-				'p,.editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .editor-block-list__block' => array(
+				'.edit-post-visual-editor.editor-styles-wrapper p,.editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .editor-block-list__block' => array(
 					'font-family'    => astra_get_font_family( $body_font_family ),
 					'font-weight'    => esc_attr( $body_font_weight ),
 					'font-size'      => astra_responsive_font( $body_font_size, 'desktop' ),
@@ -111,6 +111,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'.editor-post-title__block .editor-post-title__input' => array(
 					'font-family' => ( 'inherit' === $headings_font_family ) ? astra_get_font_family( $body_font_family ) : astra_get_font_family( $headings_font_family ),
 					'font-size'   => astra_responsive_font( $single_post_title_font_size, 'desktop' ),
+					'font-weight' => 'normal',
 				),
 				'.editor-block-list__block, .editor-post-title__block .editor-post-title__input, h1,h2,h3,h4,h5,h6' => array(
 					'color' => esc_attr( $text_color ),
@@ -119,26 +120,26 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'blockquote, blockquote a' => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
 				),
-				'blockquote' => array(
+				'blockquote'               => array(
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
 				),
 				// Heading H1 - H6 font size.
-				'h1' => array(
+				'h1, .wp-block-heading h1' => array(
 					'font-size' => astra_responsive_font( $heading_h1_font_size, 'desktop' ),
 				),
-				'h2' => array(
+				'h2, .wp-block-heading h2' => array(
 					'font-size' => astra_responsive_font( $heading_h2_font_size, 'desktop' ),
 				),
-				'h3' => array(
+				'h3, .wp-block-heading h3' => array(
 					'font-size' => astra_responsive_font( $heading_h3_font_size, 'desktop' ),
 				),
-				'h4' => array(
+				'h4, .wp-block-heading h4' => array(
 					'font-size' => astra_responsive_font( $heading_h4_font_size, 'desktop' ),
 				),
-				'h5' => array(
+				'h5, .wp-block-heading h5' => array(
 					'font-size' => astra_responsive_font( $heading_h5_font_size, 'desktop' ),
 				),
-				'h6' => array(
+				'h6, .wp-block-heading h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'desktop' ),
 				),
 			);
@@ -204,7 +205,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			if ( in_array( $pagenow, array( 'post-new.php' ) ) || 'content-boxed-container' === $container_layout || 'boxed-container' === $container_layout ) {
 				$boxed_container = array(
-					'.editor-writing-flow' => array(
+					'.editor-writing-flow'       => array(
 						'max-width'        => 'calc( ' . astra_get_css_value( $site_content_width, 'px' ) . ' - 40px )',
 						'margin'           => '0 auto',
 						'background-color' => '#fff',
@@ -225,7 +226,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'.editor-post-title'         => array(
 						'padding-bottom' => '0',
 					),
-					'.editor-block-list__block' => array(
+					'.editor-block-list__block'  => array(
 						'max-width' => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em)',
 					),
 					'.editor-block-list__block[data-align=wide]' => array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'.editor-block-list__block[data-align=wide]' => array(
 					'max-width' => astra_get_css_value( $site_content_width + 200, 'px' ),
 				),
-				'.editor-post-title__block .editor-post-title__input,  h1, h2, h3, h4, h5, h6' => array(
+				'.editor-post-title__block .editor-post-title__input,  .edit-post-visual-editor h1, .edit-post-visual-editor h2, .edit-post-visual-editor h3, .edit-post-visual-editor h4, .edit-post-visual-editor h5, .edit-post-visual-editor h6' => array(
 					'font-family'    => astra_get_css_value( $headings_font_family, 'font' ),
 					'font-weight'    => astra_get_css_value( $headings_font_weight, 'font' ),
 					'text-transform' => esc_attr( $headings_text_transform ),

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -78,10 +78,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'color' => esc_attr( $link_color ),
 				),
 				// Global selection CSS.
-				'::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit:before' => array(
+				'.editor-block-list__layout .editor-block-list__block ::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit:before' => array(
 					'background-color' => esc_attr( $theme_color ),
 				),
-				'::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit' => array(
+				'.editor-block-list__layout .editor-block-list__block ::selection,.editor-block-list__layout .editor-block-list__block.is-multi-selected .editor-block-list__block-edit' => array(
 					'color' => esc_attr( $highlight_theme_color ),
 				),
 

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -47,6 +47,11 @@ html {
         .editor-block-list__block {
             font-family: $font-family;
 
+            @media (min-width: 600px) {
+                padding-left: 0;
+                padding-right: 0;
+            }
+
             blockquote {
                 p {
                     font-size: 1.1rem;
@@ -58,13 +63,23 @@ html {
             .editor-block-list__block-edit {
                 margin-left: 0;
                 margin-right: 0;
+
+                @media (min-width: 600px) {
+                    padding-left: 28px;
+                    padding-right: 28px;
+                }
+            }
+
+            >.editor-block-mover {
+                left: -50px;
+                top: -5px;
             }
         }
 
         .editor-post-title__block {
             .editor-post-title__input {
-                padding-left: 43px;
-                padding-right: 43px;
+                padding-left: 26px;
+                padding-right: 26px;
             }
         }
 

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -41,42 +41,45 @@ p,
     }
 }
 
-.editor-block-list__block {
-    font-family: $font-family;
+.edit-post-visual-editor {
+    .editor-block-list__block {
+    	font-family: $font-family;
 
-    @media (min-width: 600px) {
-        padding-left: 0;
-        padding-right: 0;
-    }
+    	@media (min-width: 600px) {
+    		padding-left: 0;
+    		padding-right: 0;
+    	}
 
-    blockquote {
-        p {
-            font-size: 1.1rem;
-            line-height: $line-height;
-        }
-    }
+    	blockquote {
+    		p {
+    			font-size: 1.1rem;
+    			line-height: $line-height;
+    		}
+    	}
 
-    // Remove default Guteberg negative margin.
-    .editor-block-list__block-edit {
-        margin-left: 0;
-        margin-right: 0;
+    	// Remove default Guteberg negative margin.
+    	.editor-block-list__block-edit {
+    		margin-left: 0;
+    		margin-right: 0;
 
-        @media (min-width: 600px) {
-            padding-left: 28px;
-            padding-right: 28px;
-        }
-    }
+    		@media (min-width: 600px) {
+    			padding-left: 28px;
+    			padding-right: 28px;
+    		}
+    	}
 
-    >.editor-block-mover {
-        left: -50px;
-        top: -5px;
+    	>.editor-block-mover {
+    		left: -50px;
+    		top: -5px;
+    	}
     }
 }
 
 .editor-post-title__block {
     .editor-post-title__input {
-        padding-left: 43px;
-        padding-right: 43px;
+        padding-left: 28px;
+        padding-right: 28px;
+        font-weight: normal;
     }
 }
 

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -14,174 +14,174 @@ html {
     font-size: 93.75%;
 }
 
-#wpwrap {
-    .edit-post-visual-editor {
+// Import CSS for the headings in the block editor.
+@import "../variables-site/variables-site";
+@import "../elements/elements";
 
-        // Import CSS for the headings in the block editor.
-        @import "../variables-site/variables-site";
-        @import "../elements/elements";
+@import "../site/mixins/mixins-master";
+@import "../site/site-normalize/site-normalize.scss";
 
-        @import "../site/mixins/mixins-master";
-        @import "../site/site-normalize/site-normalize.scss";
+@import "../typography/headings";
 
-        @import "../typography/headings";
+p,
+.editor-block-list__block p,
+.editor-default-block-appender textarea.editor-default-block-appender__content {
+    font-family: $font-family;
+    font-weight: inherit;
+    font-size: 15px;
+    font-size: 1rem;
+}
 
-        p,
-        .editor-block-list__block p,
-        .editor-default-block-appender textarea.editor-default-block-appender__content {
-            font-family: $font-family;
-            font-weight: inherit;
-            font-size: 15px;
-            font-size: 1rem;
-        }
-
-        .editor-post-title__block {
-            .editor-post-title__input {
-                font-size: 30px;
-                font-size: 2rem;
-                font-family: $font-family;
-                font-weight: normal;
-            }
-        }
-
-        .editor-block-list__block {
-            font-family: $font-family;
-
-            @media (min-width: 600px) {
-                padding-left: 0;
-                padding-right: 0;
-            }
-
-            blockquote {
-                p {
-                    font-size: 1.1rem;
-                    line-height: $line-height;
-                }
-            }
-
-            // Remove default Guteberg negative margin.
-            .editor-block-list__block-edit {
-                margin-left: 0;
-                margin-right: 0;
-
-                @media (min-width: 600px) {
-                    padding-left: 28px;
-                    padding-right: 28px;
-                }
-            }
-
-            >.editor-block-mover {
-                left: -50px;
-                top: -5px;
-            }
-        }
-
-        .editor-post-title__block {
-            .editor-post-title__input {
-                padding-left: 26px;
-                padding-right: 26px;
-            }
-        }
-
-        .editor-post-title__block,
-        .editor-default-block-appender,
-        .editor-block-list__block {
-            max-width: 1256px;
-        }
-
-        .editor-block-list__block[data-align=full] {
-            max-width: none;
-        }
-
-        .editor-block-list__block[data-align=wide] {
-            max-width: 1400px;
-        }
-
-        .editor-block-list__layout {
-            .editor-block-list__layout {
-                padding: 0;
-            }
-        }
-
-        .editor-default-block-appender__content {
-            margin-top: 32px;
-        }
-
-        // Custom block stylings.
-        .wp-block-latest-posts.is-grid {
-            list-style: none;
-        }
-
-        .wp-block-gallery {
-            margin: 0;
-
-            &.is-cropped {
-                .blocks-gallery-item {
-                    img {
-                        height: 100%;
-                    }
-                }
-            }
-        }
-        .wp-block-latest-posts {
-            margin-left: 0;
-            li {
-                list-style: none;
-            }
-        }
-        h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        h6{
-            font-weight: inherit;
-        }
-
-        .mce-widget i {
-            font-style: normal;
-        }
-
-        // Edit with elementor button unstyled.
-        #elementor-editor-button {
-            @include button($button-color);
-
-            font-size: 14px;
-            height: 46px;
-            line-height: 44px;
-            padding: 0 36px;
-            display: inline-block;
-            border-width: 1px;
-            border-style: solid;
-            -webkit-appearance: none;
-            border-radius: 3px;
-            white-space: nowrap;
-            box-sizing: border-box;
-            box-shadow: 0 2px 0 #006799;
-
-        	i {
-        		font-style: normal;
-        		color: white;
-        	}
-        }
-
-        .editor-media-placeholder,
-        .fl-builder-layout-launch-view {
-        	button {
-        		margin: 2px;
-        	}
-        }
-
-        // Edit with BB button styling.
-        .fl-builder-layout-launch-view {
-            .is-primary.is-primary {
-            	color: white;
-            }
-        }
-
+.editor-post-title__block {
+    .editor-post-title__input {
+        font-size: 30px;
+        font-size: 2rem;
+        font-family: $font-family;
+        font-weight: normal;
     }
 }
 
+.editor-block-list__block {
+    font-family: $font-family;
+
+    @media (min-width: 600px) {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    blockquote {
+        p {
+            font-size: 1.1rem;
+            line-height: $line-height;
+        }
+    }
+
+    // Remove default Guteberg negative margin.
+    .editor-block-list__block-edit {
+        margin-left: 0;
+        margin-right: 0;
+
+        @media (min-width: 600px) {
+            padding-left: 28px;
+            padding-right: 28px;
+        }
+    }
+
+    >.editor-block-mover {
+        left: -50px;
+        top: -5px;
+    }
+}
+
+.editor-post-title__block {
+    .editor-post-title__input {
+        padding-left: 43px;
+        padding-right: 43px;
+    }
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+    max-width: 1256px;
+}
+
+.editor-block-list__block[data-align=full] {
+    max-width: none;
+
+    .editor-block-list__block-edit {
+        @media (min-width: 600px) {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
+}
+
+.editor-block-list__block[data-align=wide] {
+    max-width: 1400px;
+}
+
+.editor-block-list__layout {
+    .editor-block-list__layout {
+        padding: 0;
+    }
+}
+
+.editor-default-block-appender__content {
+    margin-top: 32px;
+}
+
+// Custom block stylings.
+.wp-block-latest-posts.is-grid {
+    list-style: none;
+}
+
+.wp-block-gallery {
+    margin: 0;
+
+    &.is-cropped {
+        .blocks-gallery-item {
+            img {
+                height: 100%;
+            }
+        }
+    }
+}
+.wp-block-latest-posts {
+    margin-left: 0;
+    li {
+        list-style: none;
+    }
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6{
+    font-weight: inherit;
+}
+
+.mce-widget i {
+    font-style: normal;
+}
+
+// Edit with elementor button unstyled.
+#elementor-editor-button {
+    @include button($button-color);
+
+    font-size: 14px;
+    height: 46px;
+    line-height: 44px;
+    padding: 0 36px;
+    display: inline-block;
+    border-width: 1px;
+    border-style: solid;
+    -webkit-appearance: none;
+    border-radius: 3px;
+    white-space: nowrap;
+    box-sizing: border-box;
+    box-shadow: 0 2px 0 #006799;
+
+    i {
+        font-style: normal;
+        color: white;
+    }
+}
+
+.editor-media-placeholder,
+.fl-builder-layout-launch-view {
+    button {
+        margin: 2px;
+    }
+}
+
+// Edit with BB button styling.
+.fl-builder-layout-launch-view {
+    .is-primary.is-primary {
+        color: white;
+    }
+}
 
 .ast-separate-container {
 	#wpwrap {

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -1,27 +1,29 @@
-/* Variables */
-
-@import "../site/variables-site/colors";
-@import "../site/variables-site/structure";
-@import "../site/variables-site/typography";
-
-// Import WordPress's Mixins for promary button CSS.
-@import "../../../../../wp-admin/css/colors/variables";
-@import "../../../../../wp-admin/css/colors/mixins";
-
 $font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+$line-height: 1.85714285714286 !default;
 
 html {
     font-size: 93.75%;
 }
 
-// Import CSS for the headings in the block editor.
+/* Variables */
+@import "../site/variables-site/colors";
+@import "../site/variables-site/structure";
+@import "../site/variables-site/typography";
 @import "../variables-site/variables-site";
-@import "../elements/elements";
-
 @import "../site/mixins/mixins-master";
-@import "../site/site-normalize/site-normalize.scss";
 
-@import "../typography/headings";
+// Import WordPress's Mixins for promary button CSS.
+@import "../../../../../wp-admin/css/colors/variables";
+@import "../../../../../wp-admin/css/colors/mixins";
+
+.edit-post-visual-editor {
+    // Import CSS for the headings in the block editor.
+    @import "../elements/elements";
+
+    @import "../site/site-normalize/site-normalize.scss";
+
+    @import "../typography/headings";
+}
 
 p,
 .editor-block-list__block p,

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -46,12 +46,32 @@ html {
 
         .editor-block-list__block {
             font-family: $font-family;
+
+            blockquote {
+                p {
+                    font-size: 1.1rem;
+                    line-height: $line-height;
+                }
+            }
+
+            // Remove default Guteberg negative margin.
+            .editor-block-list__block-edit {
+                margin-left: 0;
+                margin-right: 0;
+            }
+        }
+
+        .editor-post-title__block {
+            .editor-post-title__input {
+                padding-left: 43px;
+                padding-right: 43px;
+            }
         }
 
         .editor-post-title__block,
         .editor-default-block-appender,
         .editor-block-list__block {
-            max-width: 1200px;
+            max-width: 1256px;
         }
 
         .editor-block-list__block[data-align=full] {
@@ -106,14 +126,6 @@ html {
         .mce-widget i {
             font-style: normal;
         }
-        .editor-block-list__block{
-            blockquote{
-                p{
-                    font-size: 1.1rem;
-                    line-height: $line-height;
-                }
-            }
-        }
 
         // Edit with elementor button unstyled.
         #elementor-editor-button {
@@ -151,6 +163,7 @@ html {
             	color: white;
             }
         }
+
     }
 }
 

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -23,6 +23,30 @@ html {
     @import "../site/site-normalize/site-normalize.scss";
 
     @import "../typography/headings";
+
+    .wp-block-heading h1 {
+    	line-height: $line-height-h1;
+    }
+
+    .wp-block-heading h2 {
+    	line-height: $line-height-h2;
+    }
+
+    .wp-block-heading h3 {
+    	line-height: $line-height-h3;
+    }
+
+    .wp-block-heading h4 {
+    	line-height: $line-height-h4;
+    }
+
+    .wp-block-heading h5 {
+    	line-height: $line-height-h5;
+    }
+
+    .wp-block-heading h6 {
+    	line-height: $line-height-h6;
+    }
 }
 
 .edit-post-visual-editor p,

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -25,7 +25,7 @@ html {
     @import "../typography/headings";
 }
 
-p,
+.edit-post-visual-editor p,
 .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
     font-family: $font-family;


### PR DESCRIPTION
The block editor adds a negative margin of -28px on left and right for  This negative margin is removed and added to the content width that is added to the containers in the block editor.