### PR TITLE
[Fix] -> Position of head_bottom hook is changed to at the very botto…

### DIFF
--- a/header.php
+++ b/header.php
@@ -19,8 +19,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="profile" href="https://gmpg.org/xfn/11">
 
-<?php astra_head_bottom(); ?>
 <?php wp_head(); ?>
+<?php astra_head_bottom(); ?>
 </head>
 
 <body <?php astra_schema_body(); ?> <?php body_class(); ?>>


### PR DESCRIPTION
The Position of the head_bottom hook is changed to the very bottom of the tag head after wp_head().


