### PR TITLE
Fix: Regenerate the logo if filter astra_resize_logo is enabled 

### DIFF
--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -670,6 +670,10 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 				Astra_Customizer::generate_logo_by_width( $custom_logo_id );
 				remove_filter( 'intermediate_image_sizes_advanced', 'Astra_Customizer::logo_image_sizes', 10 );
 
+			} else {
+				// Regenerate the logo without custom image sizes.
+				$custom_logo_id = get_theme_mod( 'custom_logo' );
+				Astra_Customizer::generate_logo_by_width( $custom_logo_id );
 			}
 
 			do_action( 'astra_customizer_save' );


### PR DESCRIPTION
This will allow the logo to be correctly replaced with the full dimension of the image file in the frontend