### PR TITLE
Version 1.6.10

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+v1.6.10
+- New: filter to disable automatic logo resizing. (https://wpastra.com/docs/disable-logo-cropping/)
+- New: CSS class `ast-left-align-sub-menu` will change the direction navigation menu opens for all submenus. (https://wpastra.com/docs/change-the-direction-for-submenu-opening/)
+- Improvement: Gutenberg - Body color not applied in the block editor when boxed layout or contained boxed layout.
+- Improvement: Correctly move hook `astra_head_bottom` to the very bottom of the <head> tag.
+
 v1.6.9
 - Fix: Transparent header logonot displayed on tablet screen sizes.
 - Fix: After changing a font in typography param it would stop previewing next fonts due to a JS error.

--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,7 @@
 /**
  * Define Constants
  */
-define( 'ASTRA_THEME_VERSION', '1.6.9' );
+define( 'ASTRA_THEME_VERSION', '1.6.10' );
 define( 'ASTRA_THEME_SETTINGS', 'astra-settings' );
 define( 'ASTRA_THEME_DIR', trailingslashit( get_template_directory() ) );
 define( 'ASTRA_THEME_URI', trailingslashit( esc_url( get_template_directory_uri() ) ) );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -769,7 +769,7 @@ add_action( 'astra_masthead_content', 'astra_primary_navigation_markup', 10 );
  * Add CSS classes from wp_nav_menu the wp_page_menu()'s menu items.
  * This will help avoid targeting wp_page_menu and wp_nav_manu separately in CSS/JS.
  *
- * @since x.x.x
+ * @since 1.6.10
  * @param array   $css_class    An array of CSS classes to be applied
  *                              to each list item.
  * @param WP_Post $page         Page data object.

--- a/languages/astra.pot
+++ b/languages/astra.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.=!>
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra 1.6.9\n"
+"Project-Id-Version: Astra 1.6.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/astra\n"
-"POT-Creation-Date: 2019-02-07 11:05:01+00:00\n"
+"POT-Creation-Date: 2019-02-20 11:05:26+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -308,7 +308,7 @@ msgstr ""
 #: inc/compatibility/edd/class-astra-edd.php:224
 #: inc/compatibility/edd/customizer/class-astra-customizer-register-edd-section.php:36
 #: inc/compatibility/edd/customizer/sections/class-astra-edd-sidebar-configs.php:57
-#: inc/core/class-astra-admin-settings.php:991
+#: inc/core/class-astra-admin-settings.php:935
 msgid "Easy Digital Downloads"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgstr ""
 
 #: inc/compatibility/learndash/customizer/class-astra-customizer-register-learndash-section.php:36
 #: inc/compatibility/learndash/customizer/sections/class-astra-learndash-sidebar-configs.php:57
-#: inc/core/class-astra-admin-settings.php:1004
+#: inc/core/class-astra-admin-settings.php:948
 msgid "LearnDash"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgstr ""
 
 #: inc/compatibility/lifterlms/customizer/class-astra-liferlms-section-configs.php:35
 #: inc/compatibility/lifterlms/customizer/sections/class-astra-lifter-sidebar-configs.php:57
-#: inc/core/class-astra-admin-settings.php:1018
+#: inc/core/class-astra-admin-settings.php:962
 msgid "LifterLMS"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 
 #: inc/compatibility/woocommerce/customizer/class-astra-customizer-register-woo-section.php:37
 #: inc/compatibility/woocommerce/customizer/sections/class-astra-woo-shop-sidebar-configs.php:57
-#: inc/core/class-astra-admin-settings.php:978
+#: inc/core/class-astra-admin-settings.php:922
 msgid "WooCommerce"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Availability:"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:97
+#: inc/core/class-astra-admin-settings.php:89
 msgid "Astra Options"
 msgstr ""
 
@@ -799,41 +799,41 @@ msgstr ""
 msgid "Astra"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:185
+#: inc/core/class-astra-admin-settings.php:175
 msgid ""
 "Hello! Seems like you have used Astra theme to build this website — Thanks "
 "a ton!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:186
+#: inc/core/class-astra-admin-settings.php:176
 msgid ""
 "Could you please do us a BIG favor and give it a 5-star rating on "
 "WordPress? This would boost our motivation and help other users make a "
 "comfortable decision while choosing the Astra theme."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:188
+#: inc/core/class-astra-admin-settings.php:178
 msgid "Ok, you deserve it"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:190
+#: inc/core/class-astra-admin-settings.php:180
 msgid "Nope, maybe later"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:191
+#: inc/core/class-astra-admin-settings.php:181
 msgid "I already did"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:208
-#: inc/core/class-astra-admin-settings.php:211
+#: inc/core/class-astra-admin-settings.php:198
+#: inc/core/class-astra-admin-settings.php:201
 msgid "Get Started"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:237
+#: inc/core/class-astra-admin-settings.php:227
 msgid "Thank you for installing Astra!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:238
+#: inc/core/class-astra-admin-settings.php:228
 msgid ""
 "Did you know Astra comes with dozens of ready-to-use <a "
 "href=\"https://wpastra.com/ready-websites/?utm_source=install-notice\""
@@ -841,277 +841,273 @@ msgid ""
 "started."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:265
+#: inc/core/class-astra-admin-settings.php:255
 msgid "Activate Importer Plugin"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:269
-#: inc/core/class-astra-admin-settings.php:281
-#: inc/core/class-astra-admin-settings.php:289
-#: inc/core/class-astra-admin-settings.php:293
-#: inc/core/class-astra-admin-settings.php:396
+#: inc/core/class-astra-admin-settings.php:259
+#: inc/core/class-astra-admin-settings.php:271
+#: inc/core/class-astra-admin-settings.php:279
+#: inc/core/class-astra-admin-settings.php:283
+#: inc/core/class-astra-admin-settings.php:367
 msgid "See Library »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:270
-#: inc/core/class-astra-admin-settings.php:394
+#: inc/core/class-astra-admin-settings.php:260
+#: inc/core/class-astra-admin-settings.php:365
 msgid "Activating Importer Plugin "
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:277
+#: inc/core/class-astra-admin-settings.php:267
 msgid "Install Importer Plugin"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:284
+#: inc/core/class-astra-admin-settings.php:274
 msgid "Details »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:308
-msgid "Welcome"
-msgstr ""
-
-#: inc/core/class-astra-admin-settings.php:397
+#: inc/core/class-astra-admin-settings.php:368
 msgid "Activating"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:398
+#: inc/core/class-astra-admin-settings.php:369
 msgid "Deactivating"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:399
-#: inc/core/class-astra-admin-settings.php:1250
-#: inc/core/class-astra-admin-settings.php:1267
+#: inc/core/class-astra-admin-settings.php:370
+#: inc/core/class-astra-admin-settings.php:1194
+#: inc/core/class-astra-admin-settings.php:1211
 msgid "Activate"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:400
-#: inc/core/class-astra-admin-settings.php:1284
+#: inc/core/class-astra-admin-settings.php:371
+#: inc/core/class-astra-admin-settings.php:1228
 msgid "Deactivate"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:401
+#: inc/core/class-astra-admin-settings.php:372
 msgid "Settings"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:560
+#: inc/core/class-astra-admin-settings.php:504
 msgid "Import Starter Site"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:567
+#: inc/core/class-astra-admin-settings.php:511
 msgid "Starter Site Templates?"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:570
+#: inc/core/class-astra-admin-settings.php:514
 #. translators: %1$s: Starter site link.
 msgid "Did you know %1$s offers a free library of %2$s "
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:579
+#: inc/core/class-astra-admin-settings.php:523
 msgid "Import your favorite site one click and start your project in style!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:627
+#: inc/core/class-astra-admin-settings.php:571
 msgid "Knowledge Base"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:631
+#: inc/core/class-astra-admin-settings.php:575
 msgid "Not sure how something works? Take a peek at the knowledge base and learn."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:635
+#: inc/core/class-astra-admin-settings.php:579
 msgid "Visit Knowledge Base »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:669
+#: inc/core/class-astra-admin-settings.php:613
 #. translators: %1$s: Astra Theme name.
 msgid "%1$s Community"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:679
+#: inc/core/class-astra-admin-settings.php:623
 #. translators: %1$s: Astra Theme name.
 msgid ""
 "Join the community of super helpful %1$s users. Say hello, ask questions, "
 "give feedback and help each other!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:686
+#: inc/core/class-astra-admin-settings.php:630
 msgid "Join Our Facebook Group »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:716
+#: inc/core/class-astra-admin-settings.php:660
 #. translators: %1$s: Astra Knowledge doc link.
 msgid "Five Star Support"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:723
+#: inc/core/class-astra-admin-settings.php:667
 #. translators: %1$s: Astra Theme name.
 msgid "Got a question? Get in touch with %1$s developers. We're happy to help!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:730
+#: inc/core/class-astra-admin-settings.php:674
 msgid "Submit a Ticket »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:751
+#: inc/core/class-astra-admin-settings.php:695
 #. translators: %1$s: Astra Knowledge doc link.
 msgid "More Options Available with Astra Pro!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:758
+#: inc/core/class-astra-admin-settings.php:702
 msgid "Upload Logo"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:763
+#: inc/core/class-astra-admin-settings.php:707
 msgid "Set Colors"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:768
+#: inc/core/class-astra-admin-settings.php:712
 msgid "Customize Fonts"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:773
+#: inc/core/class-astra-admin-settings.php:717
 msgid "Layout Options"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:778
+#: inc/core/class-astra-admin-settings.php:722
 msgid "Header Options"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:783
+#: inc/core/class-astra-admin-settings.php:727
 msgid "Blog Layouts"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:788
+#: inc/core/class-astra-admin-settings.php:732
 msgid "Footer Settings"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:793
+#: inc/core/class-astra-admin-settings.php:737
 msgid "Sidebar Options"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:804
+#: inc/core/class-astra-admin-settings.php:748
 #: inc/customizer/class-astra-customizer-register-sections-panels.php:256
 msgid "Colors & Background"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:811
-#: inc/core/class-astra-admin-settings.php:824
-#: inc/core/class-astra-admin-settings.php:837
-#: inc/core/class-astra-admin-settings.php:850
-#: inc/core/class-astra-admin-settings.php:863
-#: inc/core/class-astra-admin-settings.php:876
-#: inc/core/class-astra-admin-settings.php:889
-#: inc/core/class-astra-admin-settings.php:902
-#: inc/core/class-astra-admin-settings.php:917
-#: inc/core/class-astra-admin-settings.php:933
-#: inc/core/class-astra-admin-settings.php:946
-#: inc/core/class-astra-admin-settings.php:959
-#: inc/core/class-astra-admin-settings.php:972
-#: inc/core/class-astra-admin-settings.php:985
-#: inc/core/class-astra-admin-settings.php:998
-#: inc/core/class-astra-admin-settings.php:1012
-#: inc/core/class-astra-admin-settings.php:1025
-#: inc/core/class-astra-admin-settings.php:1038
+#: inc/core/class-astra-admin-settings.php:755
+#: inc/core/class-astra-admin-settings.php:768
+#: inc/core/class-astra-admin-settings.php:781
+#: inc/core/class-astra-admin-settings.php:794
+#: inc/core/class-astra-admin-settings.php:807
+#: inc/core/class-astra-admin-settings.php:820
+#: inc/core/class-astra-admin-settings.php:833
+#: inc/core/class-astra-admin-settings.php:846
+#: inc/core/class-astra-admin-settings.php:861
+#: inc/core/class-astra-admin-settings.php:877
+#: inc/core/class-astra-admin-settings.php:890
+#: inc/core/class-astra-admin-settings.php:903
+#: inc/core/class-astra-admin-settings.php:916
+#: inc/core/class-astra-admin-settings.php:929
+#: inc/core/class-astra-admin-settings.php:942
+#: inc/core/class-astra-admin-settings.php:956
+#: inc/core/class-astra-admin-settings.php:969
+#: inc/core/class-astra-admin-settings.php:982
 msgid "Learn More »"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:817
+#: inc/core/class-astra-admin-settings.php:761
 #: inc/customizer/class-astra-customizer-register-sections-panels.php:304
 msgid "Typography"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:830
+#: inc/core/class-astra-admin-settings.php:774
 msgid "Spacing"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:843
+#: inc/core/class-astra-admin-settings.php:787
 msgid "Blog Pro"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:856
+#: inc/core/class-astra-admin-settings.php:800
 #: inc/customizer/configurations/layout/class-astra-header-layout-configs.php:360
 msgid "Mobile Header"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:869
+#: inc/core/class-astra-admin-settings.php:813
 msgid "Header Sections"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:882
+#: inc/core/class-astra-admin-settings.php:826
 msgid "Nav Menu"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:895
+#: inc/core/class-astra-admin-settings.php:839
 msgid "Sticky Header"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:908
+#: inc/core/class-astra-admin-settings.php:852
 msgid "Page Headers"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:909
+#: inc/core/class-astra-admin-settings.php:853
 msgid "Make your header layouts look more appealing and sexy!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:923
+#: inc/core/class-astra-admin-settings.php:867
 msgid "Custom Layouts"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:925
+#: inc/core/class-astra-admin-settings.php:869
 msgid "Add content conditionally in the various hook areas of the theme."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:939
+#: inc/core/class-astra-admin-settings.php:883
 msgid "Site Layouts"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:952
+#: inc/core/class-astra-admin-settings.php:896
 #: inc/customizer/class-astra-customizer-register-sections-panels.php:174
 #: inc/customizer/class-astra-customizer-register-sections-panels.php:293
 msgid "Footer Widgets"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:965
+#: inc/core/class-astra-admin-settings.php:909
 msgid "Scroll To Top"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1005
+#: inc/core/class-astra-admin-settings.php:949
 msgid "Supercharge your LearnDash website with amazing design features."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1031
+#: inc/core/class-astra-admin-settings.php:975
 msgid "White Label"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1047
+#: inc/core/class-astra-admin-settings.php:991
 msgid "Links to Customizer Settings:"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1121
+#: inc/core/class-astra-admin-settings.php:1065
 #. translators: %1s Astra Theme
 msgid "Extend %1s with free plugins!"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1343
-#: inc/core/class-astra-admin-settings.php:1381
+#: inc/core/class-astra-admin-settings.php:1287
+#: inc/core/class-astra-admin-settings.php:1325
 msgid "No plugin specified"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1364
+#: inc/core/class-astra-admin-settings.php:1308
 msgid "Plugin Successfully Activated"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1402
+#: inc/core/class-astra-admin-settings.php:1346
 msgid "Plugin Successfully Deactivated"
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1434
+#: inc/core/class-astra-admin-settings.php:1378
 #. translators: %1$1s: Addon Name, %2$2s: Minimum Required version of the Astra
 #. Addon
 msgid "Update to the latest version of %1$2s to make changes in settings below."
 msgstr ""
 
-#: inc/core/class-astra-admin-settings.php:1454
+#: inc/core/class-astra-admin-settings.php:1398
 msgid "⚡ Lightning Fast & Fully Customizable WordPress theme!"
 msgstr ""
 
@@ -2223,15 +2219,15 @@ msgstr ""
 msgid "Assign Footer Menu"
 msgstr ""
 
-#: inc/extras.php:1200
+#: inc/extras.php:1241
 msgid "Add Widget"
 msgstr ""
 
-#: inc/extras.php:1237
+#: inc/extras.php:1278
 msgid "Click here to assign a widget for this area."
 msgstr ""
 
-#: inc/extras.php:1578
+#: inc/extras.php:1619
 msgid "Astra Pro"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
       "dev": true
     },
     "brace-expansion": {
@@ -860,13 +860,27 @@
       }
     },
     "gettext-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
-      "integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.0.tgz",
+      "integrity": "sha512-eVD8RxFMeHg8pjl5zsk7xlEDaKdcYlotLztiMaYGLvI13LMXwWlybLg7rg6eagct79vyGkPGZrMPBsdjsQOnWg==",
       "dev": true,
       "requires": {
         "encoding": "^0.1.12",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "^3.0.6",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "github-from-package": {
@@ -1370,13 +1384,13 @@
       "dev": true
     },
     "grunt-wp-i18n": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-wp-i18n/-/grunt-wp-i18n-1.0.2.tgz",
-      "integrity": "sha512-s7DdR1wRYWvgeQOELL/s8AmWz0scVUq+h0yYVWvLx23kTXOBslvaD35NTvubyM+MO+k29bgND0gDDvS6sHixfg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-wp-i18n/-/grunt-wp-i18n-1.0.3.tgz",
+      "integrity": "sha512-CJNbEKeBeOSAPeaJ9B8iCgSwtaG63UR9/uT46a4OsIqnFhOJpeAi138JTlvjfIbnDVoBrzvdrKJe1svveLjUtA==",
       "dev": true,
       "requires": {
-        "grunt": "^1.0.2",
-        "node-wp-i18n": "^1.0.5"
+        "grunt": "^1.0.3",
+        "node-wp-i18n": "^1.2.2"
       }
     },
     "gzip-size": {
@@ -1662,9 +1676,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.assign": {
@@ -2039,13 +2053,13 @@
       }
     },
     "node-wp-i18n": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.2.0.tgz",
-      "integrity": "sha512-HsvI4yYt+bZ1G92Sb4YmAz2xoC7t/YWct/OPa33ZczjLrRpp7R9Wj7vp1gq2bcrCI2U7MX8Kuw0Iy7AwEPohdA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.2.3.tgz",
+      "integrity": "sha512-YMzMcsjXbGYDB9vHyb289CYXAGmXhcNLbeTlOnWgPNkZd9xrovcbRd7cQyKd9BQHOjS7Nw8WCbJ7nvtR7rc0rg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.4.1",
-        "gettext-parser": "^1.2.0",
+        "gettext-parser": "^3.1.0",
         "glob": "^7.0.5",
         "lodash": "^4.14.2",
         "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "A very lightweight and beautiful theme made to work with Page Builders.",
   "main": "Gruntfile.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-rtlcss": "^2.0.1",
     "grunt-sass": "^3.0.1",
     "grunt-text-replace": "^0.4.0",
-    "grunt-wp-i18n": "^1.0.2",
+    "grunt-wp-i18n": "^1.0.3",
     "node-sass": "^4.11.0",
     "postcss-flexibility": "^2.0.0"
   }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wpastra.com/
 Author: Brainstorm Force
 Author URI: https://wpastra.com/about/
 Description: Astra is fast, fully customizable & beautiful theme suitable for blog, personal portfolio, business website and WooCommerce storefront. It is very lightweight (less than 50KB on frontend) and offers unparalleled speed. Built with SEO in mind, Astra comes with Schema.org code integrated so search engines will love your site. It offers special features and templates so it works perfectly with all page builders like Elementor, Beaver Builder, Visual Composer, SiteOrigin, Divi, etc. Some of the other features: # WooCommerce Ready # Responsive # RTL & Translation Ready # Extendible with premium addons # Regularly updated # Designed, Developed, Maintained & Supported by Brainstorm Force. Looking for a perfect base theme? Look no further. Astra is fast, fully customizable and WooCommerce ready theme that you can use for building any kind of website!
-Version: 1.6.9
+Version: 1.6.10
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: astra


### PR DESCRIPTION
- New: filter to disable automatic logo resizing. (https://wpastra.com/docs/disable-logo-cropping/)
- New: CSS class `ast-left-align-sub-menu` will change the direction navigation menu opens for all submenus. (https://wpastra.com/docs/change-the-direction-for-submenu-opening/)
- Improvement: Gutenberg - Body color not applied in the block editor when boxed layout or contained boxed layout.
- Improvement: Correctly move hook `astra_head_bottom` to the very bottom of the <head> tag.