### PR TITLE
Upload theme not working fix

### DIFF
--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -239,6 +239,11 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 						'display-with-other-notices' => false,
 					)
 				);
+
+				// Enqueue Plugin Install script only if the notice with plugin installation is not expired.
+				if ( ! Astra_Notices::is_notice_expired( 'astra-sites-on-active' ) ) {
+					wp_enqueue_script( 'plugin-install' );
+				}
 			}
 		}
 
@@ -345,8 +350,6 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 
 			wp_enqueue_script( 'astra-color-alpha', $assets_js_uri . 'wp-color-picker-alpha' . $file_prefix . '.js', $js_handle, ASTRA_THEME_VERSION, true );
 
-			// For popup starter site plugin detail.
-			wp_enqueue_script( 'plugin-install' );
 			wp_enqueue_script( 'thickbox' );
 			wp_enqueue_style( 'thickbox' );
 		}

--- a/inc/lib/notices/class-astra-notices.php
+++ b/inc/lib/notices/class-astra-notices.php
@@ -230,7 +230,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 *
 		 * @since 1.7.0
 		 * @param  array $id Notice id.
-		 * @return void
+		 * @return boolean
 		 */
 		public static function is_notice_expired( $id ) {
 			if ( self::is_expired( $id ) ) {

--- a/inc/lib/notices/class-astra-notices.php
+++ b/inc/lib/notices/class-astra-notices.php
@@ -226,6 +226,20 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		}
 
 		/**
+		 * Is notice expired? public function.
+		 *
+		 * @since 1.7.0
+		 * @param  array $id Notice id.
+		 * @return void
+		 */
+		public static function is_notice_expired( $id ) {
+			if ( self::is_expired( $id ) ) {
+				return true;
+			}
+			return false;
+		}
+
+		/**
 		 * Notice classes.
 		 *
 		 * @since 1.4.0

--- a/inc/lib/notices/class-astra-notices.php
+++ b/inc/lib/notices/class-astra-notices.php
@@ -226,7 +226,9 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		}
 
 		/**
-		 * Is notice expired? public function.
+		 * Function to check if the notice is expired or not.
+		 *
+		 * Pass Notice ID to this function to check if the notice is expired or not.
 		 *
 		 * @since 1.7.0
 		 * @param  array $id Notice id.


### PR DESCRIPTION
[Fix] -> Add New theme upload theme was not working because of the plugin-install JS enqueue.  To fix this issue, added a condition to load plugin-install JS only when notice is active.
