### PR TITLE
AMP Compatibility: Fix usage of amp-state component

### DIFF
--- a/inc/compatibility/class-astra-amp.php
+++ b/inc/compatibility/class-astra-amp.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'Astra_AMP' ) ) :
 			add_filter( 'astra_nav_toggle_data_attrs', array( $this, 'add_nav_toggle_attrs' ) );
 			add_filter( 'astra_search_slide_toggle_data_attrs', array( $this, 'add_search_slide_toggle_attrs' ) );
 			add_filter( 'astra_search_field_toggle_data_attrs', array( $this, 'add_search_field_toggle_attrs' ) );
-			add_action( 'wp_head', array( $this, 'render_amp_states' ) );
+			add_action( 'wp_footer', array( $this, 'render_amp_states' ) );
 			add_filter( 'astra_attr_ast-main-header-bar-alignment', array( $this, 'nav_menu_wrapper' ) );
 			add_filter( 'astra_attr_ast-menu-toggle', array( $this, 'menu_toggle_button' ), 20, 3 );
 			add_filter( 'astra_theme_dynamic_css', array( $this, 'dynamic_css' ) );

--- a/inc/compatibility/class-astra-amp.php
+++ b/inc/compatibility/class-astra-amp.php
@@ -1013,7 +1013,7 @@ if ( ! class_exists( 'Astra_AMP' ) ) :
 		 * @return String HTML MArkup for the menu including the AML State.
 		 */
 		public function toggle_button_markup( $item_output, $item ) {
-			$item_output .= '<amp-state id="neveMenuItemExpanded' . esc_attr( $item->ID ) . '" class="i-amphtml-element i-amphtml-layout-container" hidden="" aria-hidden="true"><script type="application/json">false</script></amp-state>';
+			$item_output .= '<amp-state id="neveMenuItemExpanded' . esc_attr( $item->ID ) . '"><script type="application/json">false</script></amp-state>';
 
 			return $item_output;
 		}


### PR DESCRIPTION
I noticed quite a few AMP validation errors when testing the theme, and they turned out to just be due to `<amp-state>` being incorrectly placed in the `head` when it has to be in the `body`.

Also, these attributes on `<amp-state>` are added automatically by the `amp-state` component and they should be omitted:

* `class="i-amphtml-element i-amphtml-layout-container"`
* `hidden=""` 
* `aria-hidden="true"`