### PR TITLE
Fix: Title margin appearing when only title is globally enabled.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1309,7 +1309,7 @@ if ( ! function_exists( 'astra_entry_header_class' ) ) {
 		$post_meta_markup           = astra_single_get_post_meta( '', '', false );
 		$blog_single_post_structure = astra_get_option( 'blog-single-post-structure' );
 
-		if ( ! $blog_single_post_structure || ( 'single-image' === astra_get_prop( $blog_single_post_structure, 0 ) && empty( $thumb_markup ) ) ) {
+		if ( ! $blog_single_post_structure || ( 'single-image' === astra_get_prop( $blog_single_post_structure, 0 ) && empty( $thumb_markup ) && 'single-title-meta' !== astra_get_prop( $blog_single_post_structure, 1 ) ) ) {
 			$classes[] = 'ast-header-without-markup';
 		} elseif ( empty( $title_markup ) && empty( $thumb_markup ) && ( is_page() || empty( $post_meta_markup ) ) ) {
 			$classes[] = 'ast-header-without-markup';


### PR DESCRIPTION
To fix this issue, added one more condition to check if title meta is active do not add 
`ast-header-without-markup` class.