### PR TITLE
Removed CSS bg option array for above/below header 

### DIFF
--- a/inc/addons/transparent-header/classes/dynamic-css/dynamic.css.php
+++ b/inc/addons/transparent-header/classes/dynamic-css/dynamic.css.php
@@ -120,16 +120,6 @@ function astra_ext_transparent_header_dynamic_css( $dynamic_css, $dynamic_css_fi
 		'.ast-header-break-point.ast-replace-site-logo-transparent.ast-theme-transparent-header .transparent-custom-logo' => array(
 			'display' => 'inline-block',
 		),
-
-		'.ast-theme-transparent-header .ast-above-header' => array(
-			'background-image' => 'none',
-			'background-color' => 'transparent',
-		),
-
-		'.ast-theme-transparent-header .ast-below-header' => array(
-			'background-image' => 'none',
-			'background-color' => 'transparent',
-		),
 	);
 
 	/**

--- a/inc/addons/transparent-header/classes/dynamic-css/dynamic.css.php
+++ b/inc/addons/transparent-header/classes/dynamic-css/dynamic.css.php
@@ -99,7 +99,7 @@ function astra_ext_transparent_header_dynamic_css( $dynamic_css, $dynamic_css_fi
 	$css              .= astra_parse_css( $mobile_css_output, '', '543' );
 
 	$transparent_heder_base = array(
-		'.ast-theme-transparent-header #masthead'         => array(
+		'.ast-theme-transparent-header #masthead' => array(
 			'position' => 'absolute',
 			'left'     => '0',
 			'right'    => '0',


### PR DESCRIPTION
Removed CSS bg option array for above/below header in case of the transparent header.