### PR TITLE
Fixed: color for anchor is not working in blockquote in gutenberg

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -452,7 +452,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				),
 
 				// Blockquote Text Color.
-				'blockquote'                => array(
+				'blockquote'                              => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
 				),
 

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -452,7 +452,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				),
 
 				// Blockquote Text Color.
-				'blockquote, blockquote a'                => array(
+				'blockquote'                => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
 				),
 

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -151,7 +151,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				),
 			);
 
-			// var_dump($desktop_css);
 			$css .= astra_parse_css( $desktop_css );
 
 			$tablet_css = array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -118,8 +118,11 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'color' => esc_attr( $text_color ),
 				),
 				// Blockquote Text Color.
-				'blockquote, blockquote a' => array(
+				'blockquote' => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
+				),
+				'blockquote .editor-rich-text__tinymce a'               => array(
+					'color' => astra_hex_to_rgba( $link_color, 1 ),
 				),
 				'blockquote'               => array(
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
@@ -148,6 +151,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				),
 			);
 
+			// var_dump($desktop_css);
 			$css .= astra_parse_css( $desktop_css );
 
 			$tablet_css = array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -72,10 +72,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			$css = '';
 
 			$desktop_css = array(
-				'html'                     => array(
+				'html'                                    => array(
 					'font-size' => astra_get_font_css_value( (int) $body_font_size_desktop * 6.25, '%' ),
 				),
-				'a'                        => array(
+				'a'                                       => array(
 					'color' => esc_attr( $link_color ),
 				),
 				// Global selection CSS.
@@ -118,13 +118,13 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'color' => esc_attr( $text_color ),
 				),
 				// Blockquote Text Color.
-				'blockquote' => array(
+				'blockquote'                              => array(
 					'color' => astra_adjust_brightness( $text_color, 75, 'darken' ),
 				),
-				'blockquote .editor-rich-text__tinymce a'               => array(
+				'blockquote .editor-rich-text__tinymce a' => array(
 					'color' => astra_hex_to_rgba( $link_color, 1 ),
 				),
-				'blockquote'               => array(
+				'blockquote'                              => array(
 					'border-color' => astra_hex_to_rgba( $link_color, 0.05 ),
 				),
 				'.editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large), .edit-post-visual-editor .wp-block-pullquote blockquote' => array(


### PR DESCRIPTION
Fixed: Color for anchor tag is not working in Gutenberg blockquote in front end and back end. 