### PR TITLE
fix: Omit printing skip-focus-fix script on AMP content

### DIFF
--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -59,8 +59,14 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 		 *
 		 * @link https://git.io/vWdr2
 		 * @link https://github.com/WordPress/twentynineteen/pull/47/files
+		 * @link https://github.com/ampproject/amphtml/issues/18671
 		 */
 		function astra_skip_link_focus_fix() {
+			// Skip printing script on AMP content, since accessibility fix is covered by AMP framework.
+			if ( astra_is_amp_endpoint() ) {
+				return;
+			}
+
 			// The following is minified via `terser --compress --mangle -- js/skip-link-focus-fix.js`.
 			?>
 			<script>


### PR DESCRIPTION
Updated to the latest version of the Astra theme and encountered an AMP validation error (see attachment) 
<img width="1236" alt="Screen Shot 2019-08-19 at 2 37 58 PM" src="https://user-images.githubusercontent.com/506089/63303299-4c25ba00-c294-11e9-8b67-c027ecc28d66.png">

This validation error can be fixed by preventing the printing of the `skip-focus-fix` script, since it is covered by the AMP framework.

See: https://github.com/ampproject/amphtml/issues/18671