### PR TITLE
fix: rename function astra_is_emp_endpoint to astra_is_amp_endpoint

### DIFF
--- a/inc/compatibility/class-astra-amp.php
+++ b/inc/compatibility/class-astra-amp.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'Astra_AMP' ) ) :
 		public function astra_amp_init() {
 
 			// bail if AMP endpoint is not detected.
-			if ( ! astra_is_emp_endpoint() ) {
+			if ( ! astra_is_amp_endpoint() ) {
 				return;
 			}
 

--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -212,7 +212,7 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 				wp_enqueue_style( 'astra-menu-animation' );
 			}
 
-			if ( astra_is_emp_endpoint() ) {
+			if ( astra_is_amp_endpoint() ) {
 				return;
 			}
 

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1136,7 +1136,7 @@ endif;
  *
  * @return bool
  */
-function astra_is_emp_endpoint() {
+function astra_is_amp_endpoint() {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }
 

--- a/inc/core/deprecated/deprecated-functions.php
+++ b/inc/core/deprecated/deprecated-functions.php
@@ -133,7 +133,11 @@ if ( ! function_exists( 'astar' ) ) :
 
 endif;
 
-
+/**
+ * Check if we're being delivered AMP.
+ *
+ * @return bool
+ */
 function astra_is_emp_endpoint() {
 	_deprecated_function( __FUNCTION__, 'x.x.x', 'astra_is_amp_endpoint()' );
 

--- a/inc/core/deprecated/deprecated-functions.php
+++ b/inc/core/deprecated/deprecated-functions.php
@@ -132,3 +132,10 @@ if ( ! function_exists( 'astar' ) ) :
 	}
 
 endif;
+
+
+function astra_is_emp_endpoint() {
+	_deprecated_function( __FUNCTION__, 'x.x.x', 'astra_is_amp_endpoint()' );
+
+	return astra_is_amp_endpoint();
+}

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -77,7 +77,7 @@ if ( ! function_exists( 'astra_body_classes' ) ) {
 			$classes[] = 'ast-desktop';
 		}
 
-		if ( astra_is_emp_endpoint() ) {
+		if ( astra_is_amp_endpoint() ) {
 			$classes[] = 'ast-amp';
 		}
 


### PR DESCRIPTION
- to fix the typo in the function name.
- deprecates `astra_is_emp_endpoint()` function.