### PR TITLE
Fix: don't set Astra_Cache in admin

### DIFF
--- a/inc/cache/class-astra-cache-base.php
+++ b/inc/cache/class-astra-cache-base.php
@@ -76,6 +76,10 @@ class Astra_Cache_Base {
 	 * @param String $cache_dir Base cache directory in the uploads directory.
 	 */
 	public function __construct( $cache_dir ) {
+		if ( true === is_admin() ) {
+			return false;
+		}
+
 		$this->cache_dir = $cache_dir;
 
 		add_action( 'wp', array( $this, 'init_cache' ) );


### PR DESCRIPTION
- Avoid PHP notices in the admin area on custom admin pages.