### PR TITLE
fix: editor layout is broken with long content.

### DIFF
--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -284,6 +284,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 						'max-width'        => astra_get_css_value( $site_content_width - 56, 'px' ),
 						'margin'           => '0 auto',
 						'background-color' => '#fff',
+						'overflow'         => 'scroll',
 					),
 					'.gutenberg__editor'         => array(
 						'background-color' => '#f5f5f5',


### PR DESCRIPTION
Please refer to the following image.

![Screen Shot 2019-10-31 at 4 05 32 PM](https://user-images.githubusercontent.com/1086008/67930617-189fce00-fbfb-11e9-9fe0-9dc3a2dc612b.png)
