### PR TITLE
fix: Added compatibility for Yoast SEO v12.8.1

### DIFF
--- a/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
@@ -67,9 +67,12 @@ function astra_get_breadcrumb( $echo = true ) {
 function astra_get_selected_breadcrumb( $echo = true ) {
 
 	$breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
-	$wpseo_option      = get_option( 'wpseo_internallinks' );
+	$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+	if ( ! is_array( $wpseo_option ) ) {
+		$wpseo_option = array('breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+	}
 
-	if ( function_exists( 'yoast_breadcrumb' ) && $wpseo_option && true === $wpseo_option['breadcrumbs-enable'] && $breadcrumb_source && 'yoast-seo-breadcrumbs' == $breadcrumb_source ) {
+	if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] && $breadcrumb_source && 'yoast-seo-breadcrumbs' == $breadcrumb_source ) {
 		// Check if breadcrumb is turned on from WPSEO option.
 		return yoast_breadcrumb( '<div id="ast-breadcrumbs-yoast" >', '</div>', $echo );
 	} elseif ( function_exists( 'bcn_display' ) && $breadcrumb_source && 'breadcrumb-navxt' == $breadcrumb_source ) {

--- a/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
@@ -67,10 +67,14 @@ function astra_get_breadcrumb( $echo = true ) {
 function astra_get_selected_breadcrumb( $echo = true ) {
 
 	$breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
-	$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+
+	$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
+	$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 	if ( ! is_array( $wpseo_option ) ) {
+		
+		unset($wpseo_option);
 		$wpseo_option = array(
-			'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) 
+			'breadcrumbs-enable' => $breadcrumb_enable 
 		);
 	}
 

--- a/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
@@ -69,10 +69,9 @@ function astra_get_selected_breadcrumb( $echo = true ) {
 	$breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
 
 	$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
-	$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
+	$wpseo_option      = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 	if ( ! is_array( $wpseo_option ) ) {
-		
-		unset($wpseo_option);
+		unset( $wpseo_option );
 		$wpseo_option = array(
 			'breadcrumbs-enable' => $breadcrumb_enable 
 		);

--- a/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumb-trail.php
@@ -69,7 +69,9 @@ function astra_get_selected_breadcrumb( $echo = true ) {
 	$breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
 	$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
 	if ( ! is_array( $wpseo_option ) ) {
-		$wpseo_option = array('breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+		$wpseo_option = array(
+			'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) 
+		);
 	}
 
 	if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] && $breadcrumb_source && 'yoast-seo-breadcrumbs' == $breadcrumb_source ) {

--- a/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
@@ -69,11 +69,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs' ) ) {
 		 */
 		function astra_breadcrumb_source_list_items( $options ) {
 
-			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
+			$wpseo_option      = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 			if ( ! is_array( $wpseo_option ) ) {
 
+				unset( $wpseo_option );
 				$wpseo_option = array(
-					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+					'breadcrumbs-enable' => $breadcrumb_enable,
 				);
 			}
 

--- a/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
@@ -72,7 +72,6 @@ if ( ! class_exists( 'Astra_Breadcrumbs' ) ) {
 			$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
 			$wpseo_option      = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 			if ( ! is_array( $wpseo_option ) ) {
-
 				unset( $wpseo_option );
 				$wpseo_option = array(
 					'breadcrumbs-enable' => $breadcrumb_enable,

--- a/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
@@ -72,7 +72,9 @@ if ( ! class_exists( 'Astra_Breadcrumbs' ) ) {
 			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
 			if ( ! is_array( $wpseo_option ) ) {
 
-				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+				$wpseo_option = array(
+					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+				);
 			}
 
 			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] ) {

--- a/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
+++ b/inc/addons/breadcrumbs/class-astra-breadcrumbs.php
@@ -69,9 +69,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs' ) ) {
 		 */
 		function astra_breadcrumb_source_list_items( $options ) {
 
-			$wpseo_option = get_option( 'wpseo_internallinks' );
+			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			if ( ! is_array( $wpseo_option ) ) {
 
-			if ( function_exists( 'yoast_breadcrumb' ) && $wpseo_option && true === $wpseo_option['breadcrumbs-enable'] ) {
+				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+			}
+
+			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] ) {
 				$options['yoast-seo-breadcrumbs'] = 'Yoast SEO Breadcrumbs';
 			}
 

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
@@ -288,7 +288,9 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
 			if ( ! is_array( $wpseo_option ) ) {
 
-				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+				$wpseo_option = array(
+					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+				);
 			}
 
 			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] ) {
@@ -318,7 +320,9 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 			$wpseo_option               = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
 			if ( ! is_array( $wpseo_option ) ) {
 
-				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+				$wpseo_option = array(
+					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+				);
 			}
 
 			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] && 'yoast-seo-breadcrumbs' === $selected_breadcrumb_source ) {

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
@@ -288,7 +288,6 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 			$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
 			$wpseo_option      = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 			if ( ! is_array( $wpseo_option ) ) {
-
 				unset( $wpseo_option );
 				$wpseo_option = array(
 					'breadcrumbs-enable' => $breadcrumb_enable,

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
@@ -285,9 +285,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 		public function is_third_party_breadcrumb_active() {
 
 			// Check if breadcrumb is turned on from WPSEO option.
-			$wpseo_option = get_option( 'wpseo_internallinks' );
+			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			if ( ! is_array( $wpseo_option ) ) {
 
-			if ( function_exists( 'yoast_breadcrumb' ) && $wpseo_option && true === $wpseo_option['breadcrumbs-enable'] ) {
+				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+			}
+
+			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] ) {
 				// Check if breadcrumb is turned on from SEO Yoast plugin.
 				return true;
 			} elseif ( function_exists( 'bcn_display' ) ) {
@@ -311,9 +315,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 
 			// Check if breadcrumb is turned on from WPSEO option.
 			$selected_breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
-			$wpseo_option               = get_option( 'wpseo_internallinks' );
+			$wpseo_option               = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			if ( ! is_array( $wpseo_option ) ) {
 
-			if ( function_exists( 'yoast_breadcrumb' ) && $wpseo_option && true === $wpseo_option['breadcrumbs-enable'] && 'yoast-seo-breadcrumbs' === $selected_breadcrumb_source ) {
+				$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+			}
+
+			if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] && 'yoast-seo-breadcrumbs' === $selected_breadcrumb_source ) {
 				// Check if breadcrumb is turned on from SEO Yoast plugin.
 				return false;
 			} elseif ( function_exists( 'bcn_display' ) && 'breadcrumb-navxt' === $selected_breadcrumb_source ) {

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-configs.php
@@ -285,11 +285,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 		public function is_third_party_breadcrumb_active() {
 
 			// Check if breadcrumb is turned on from WPSEO option.
-			$wpseo_option = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			$breadcrumb_enable = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
+			$wpseo_option      = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 			if ( ! is_array( $wpseo_option ) ) {
 
+				unset( $wpseo_option );
 				$wpseo_option = array(
-					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+					'breadcrumbs-enable' => $breadcrumb_enable,
 				);
 			}
 
@@ -317,11 +319,13 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Configs' ) ) {
 
 			// Check if breadcrumb is turned on from WPSEO option.
 			$selected_breadcrumb_source = astra_get_option( 'select-breadcrumb-source' );
-			$wpseo_option               = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+			$breadcrumb_enable          = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
+			$wpseo_option               = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 			if ( ! is_array( $wpseo_option ) ) {
 
+				unset( $wpseo_option );
 				$wpseo_option = array(
-					'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+					'breadcrumbs-enable' => $breadcrumb_enable,
 				);
 			}
 

--- a/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
+++ b/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
@@ -99,7 +99,11 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 
 	$css                     = '';
 	$breadcrumbs_default_css = array();
-	$wpseo_option            = get_option( 'wpseo_internallinks' );
+	$wpseo_option            = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+	if ( ! is_array( $wpseo_option ) ) {
+
+		$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+	}
 
 	$css .= astra_parse_css(
 		array(
@@ -114,7 +118,7 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 	/**
 	 * Breadcrumb Colors & Typography
 	 */
-	if ( function_exists( 'yoast_breadcrumb' ) && $wpseo_option && true === $wpseo_option['breadcrumbs-enable'] && $breadcrumb_source && 'yoast-seo-breadcrumbs' == $breadcrumb_source ) {
+	if ( function_exists( 'yoast_breadcrumb' ) && true === $wpseo_option['breadcrumbs-enable'] && $breadcrumb_source && 'yoast-seo-breadcrumbs' == $breadcrumb_source ) {
 
 		/* Yoast SEO Breadcrumb CSS - Desktop */
 		$breadcrumbs_desktop = array(

--- a/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
+++ b/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
@@ -102,7 +102,9 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 	$wpseo_option            = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
 	if ( ! is_array( $wpseo_option ) ) {
 
-		$wpseo_option = array( 'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ) );
+		$wpseo_option = array(
+			'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+		);
 	}
 
 	$css .= astra_parse_css(

--- a/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
+++ b/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
@@ -102,7 +102,6 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 	$breadcrumb_enable       = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
 	$wpseo_option            = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 	if ( ! is_array( $wpseo_option ) ) {
-
 		unset( $wpseo_option );
 		$wpseo_option = array(
 			'breadcrumbs-enable' => $breadcrumb_enable,

--- a/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
+++ b/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
@@ -99,11 +99,13 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 
 	$css                     = '';
 	$breadcrumbs_default_css = array();
-	$wpseo_option            = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : WPSEO_Options::get( 'breadcrumbs-enable' );
+	$breadcrumb_enable       = is_callable( 'WPSEO_Options::get' ) ? WPSEO_Options::get( 'breadcrumbs-enable' ) : false;
+	$wpseo_option            = get_option( 'wpseo_internallinks' ) ? get_option( 'wpseo_internallinks' ) : $breadcrumb_enable;
 	if ( ! is_array( $wpseo_option ) ) {
 
+		unset( $wpseo_option );
 		$wpseo_option = array(
-			'breadcrumbs-enable' => WPSEO_Options::get( 'breadcrumbs-enable' ),
+			'breadcrumbs-enable' => $breadcrumb_enable,
 		);
 	}
 


### PR DESCRIPTION
The Breadcrumb source option went missing after the Yoast SEO v12.8.1. 