### PR TITLE
fix: Define an explicit background color for element within LifterLMS certificate

### DIFF
--- a/assets/css/unminified/compatibility/lifterlms.css
+++ b/assets/css/unminified/compatibility/lifterlms.css
@@ -1156,6 +1156,7 @@ body .llms-loop-item-content .llms-progress-bar .progress-bar-complete {
   padding-left: 10px;
 }
 
-.llms-certificate-container .ast-article-single.llms_certificate {
+.llms-certificate-container .ast-article-single.llms_certificate,
+.llms-certificate-container .ast-article-single.llms_my_certificate {
     background-color: transparent;
 }

--- a/assets/css/unminified/compatibility/lifterlms.css
+++ b/assets/css/unminified/compatibility/lifterlms.css
@@ -1155,3 +1155,7 @@ body .llms-loop-item-content .llms-progress-bar .progress-bar-complete {
 .ast-woocommerce-cart-menu .main-header-bar .main-header-log-out {
   padding-left: 10px;
 }
+
+.llms-certificate-container .ast-article-single.llms_certificate {
+    background-color: transparent;
+}

--- a/assets/css/unminified/compatibility/lifterlms.css
+++ b/assets/css/unminified/compatibility/lifterlms.css
@@ -1,10 +1,10 @@
 /**
  * lifterlms.scss
- * Governs the general look and feel of WooCommerce sections of stores using themes that do not
- * integrate with WooCommerce specifically.
+ * Governs the general look and feel of LifterLMS sections of sites using themes that do not
+ * integrate with LifterLMS specifically.
  */
 /**
- * Astra Theme compatibility with WooCommerce
+ * Astra Theme compatibility with LifterLMS
  */
 /*----------  Media Query min-width Structure   ----------*/
 /*----------  Media Query max-width Structure   ----------*/


### PR DESCRIPTION
Adds css to resolve issue described in #1585 

Additionally replaces text "WooCommerce" with "LifterLMS" in the file's file header comments.