### PR TITLE
fix: RGBA color format not working

### DIFF
--- a/inc/assets/css/astra-admin-menu-settings.css
+++ b/inc/assets/css/astra-admin-menu-settings.css
@@ -27,6 +27,10 @@
  * @package Astra
  * @since 1.2.4
  */
+.ast-addon-list-section .ast-addon-list .active {
+    border-left: 2px solid #008ec2;
+    padding-left: 12px;
+}
 /**
  * Astra Welcome Page
  */

--- a/inc/customizer/custom-controls/color/class-astra-control-color.php
+++ b/inc/customizer/custom-controls/color/class-astra-control-color.php
@@ -93,7 +93,7 @@ class Astra_Control_Color extends WP_Customize_Control {
 			</label>
 		<# } #>
 		<div class="customize-control-content">
-			<input class="ast-color-picker-alpha color-picker-hex" data-name="{{data.name}}"  type="text" maxlength="7" data-alpha="true" placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{data.value}}" />
+			<input class="ast-color-picker-alpha color-picker-hex" data-name="{{data.name}}"  type="text" data-alpha="true" placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{data.value}}" />
 		</div>
 
 		<?php

--- a/inc/customizer/custom-controls/responsive-color/class-astra-control-responsive-color.php
+++ b/inc/customizer/custom-controls/responsive-color/class-astra-control-responsive-color.php
@@ -168,11 +168,11 @@ if ( ! class_exists( 'Astra_Control_Responsive_Color' ) && class_exists( 'WP_Cus
 
 					<# if ( data.responsive ) { #>
 
-						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color desktop active" type="text" maxlength="7" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='desktop' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_desktop }}" />
+						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color desktop active" type="text" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='desktop' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_desktop }}" />
 
-						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color tablet" type="text" maxlength="7" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='tablet' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_tablet }}" />
+						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color tablet" type="text" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='tablet' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_tablet }}" />
 
-						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color mobile" type="text" maxlength="7" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='mobile' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_mobile }}" />
+						<input class="ast-color-picker-alpha color-picker-hex ast-responsive-color mobile" type="text" data-name="{{data.name}}" data-alpha="{{ data.rgba }}" data-id='mobile' placeholder="{{ defaultValue }}" {{ defaultValueAttr }} value="{{ value_mobile }}" />
 
 					<# } else { #>
 


### PR DESCRIPTION
- RGB color format not working in ast-color, ast-responsive-color params
- Added CSS for this - https://share.getcloudapp.com/yAuvxQ1e
- Thems does not have CSS for Extended Plugins activate status