### PR TITLE
chore: cghooks file will no longer avail in final zip version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -355,7 +355,7 @@ module.exports = function (grunt) {
                     '!.git/**',
                     '!bin/**',
                     '!.gitlab-ci.yml',
-                    '!bin/**',
+                    '!cghooks.lock',
                     '!tests/**',
                     '!phpunit.xml.dist',
                     '!*.sh',


### PR DESCRIPTION
- Excluded cghooks.lock file from compression