### PR TITLE
fix: AMP CSS toggle before entity breaks in 2.4.2

### DIFF
--- a/inc/compatibility/class-astra-amp.php
+++ b/inc/compatibility/class-astra-amp.php
@@ -450,7 +450,7 @@ if ( ! class_exists( 'Astra_AMP' ) ) :
 				),
 				'.ast-amp .main-header-bar .main-header-bar-navigation .page_item_has_children > .ast-menu-toggle::before, .ast-amp .main-header-bar .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle::before' => array(
 					'font-weight'     => 'bold',
-					'content'         => '"\01f78e"',
+					'content'         => '"\e900"',
 					'font-family'     => '"Astra"',
 					'text-decoration' => 'inherit',
 					'display'         => 'inline-block',

--- a/inc/compatibility/class-astra-amp.php
+++ b/inc/compatibility/class-astra-amp.php
@@ -280,7 +280,7 @@ if ( ! class_exists( 'Astra_AMP' ) ) :
 					'padding-left' => '30px',
 				),
 				'.ast-amp .main-navigation ul.children li a:before, .ast-amp .main-navigation ul.sub-menu li a:before' => array(
-					'content'         => '"\01f78e"',
+					'content'         => '"\e900"',
 					'font-family'     => '"Astra"',
 					'font-size'       => '0.65em',
 					'text-decoration' => 'inherit',


### PR DESCRIPTION
### Description
- From theme version 2.4.2 AMP toggle before icon breaks

### Screenshots
- https://share.getcloudapp.com/geuWd46E
- https://share.getcloudapp.com/L1u7Wd5p

### Types of changes
- Updated CSS entity for this AMP toggle before the button

### How has this been tested?
- Test from master to this branch

### Checklist:
- My code is tested
- My code passes the PHPCS tests
- My code follows accessibility standards 
- I've included any necessary tests
- I've added proper labels to this pull request 
