### PR TITLE
fix: PHP 7.4 notices.

### DIFF
--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -39,7 +39,7 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 			$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
 		}
 
-		// Test Commit.
+		// Return if non hex.
 		if ( ! ctype_xdigit( $hex ) ) {
 			return $hex;
 		}

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -39,6 +39,7 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 			$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
 		}
 
+		// Test Commit.
 		if ( ! ctype_xdigit( $hex ) ) {
 			return $hex;
 		}

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -993,6 +993,7 @@ if ( ! function_exists( 'astra_adjust_brightness' ) ) {
 		// Get rgb vars.
 		$hex = str_replace( '#', '', $hex );
 
+		// Return if non hex.
 		if ( ! ctype_xdigit( $hex ) ) {
 			return $hex;
 		}

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -39,6 +39,10 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 			$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
 		}
 
+		if ( ! ctype_xdigit( $hex ) ) {
+			return $hex;
+		}
+
 		// Get r, g & b codes from hex code.
 		$r   = hexdec( substr( $hex, 0, 2 ) );
 		$g   = hexdec( substr( $hex, 2, 2 ) );
@@ -987,6 +991,10 @@ if ( ! function_exists( 'astra_adjust_brightness' ) ) {
 
 		// Get rgb vars.
 		$hex = str_replace( '#', '', $hex );
+
+		if ( ! ctype_xdigit( $hex ) ) {
+			return $hex;
+		}
 
 		$shortcode_atts = array(
 			'r' => hexdec( substr( $hex, 0, 2 ) ),


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
PHP 7.4 noitce for function `hexdec`

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/o0ugO97A

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Added condition to check if the provided string is hex or not. If not return the string without passing it through `hexdec`

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Switched the branch and all the PHP notices were gone.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've added proper labels to this pull request <!-- if applicable -->
