### PR TITLE
fix: removed the unnecessary CSS in the code.

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -2100,7 +2100,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 		 * @return boolean false if it is an existing user , true if not.
 		 */
 		public static function gtn_image_group_css_comp() {
-			$astra_settings                            = get_option( ASTRA_THEME_SETTINGS );
+			$astra_settings                                = get_option( ASTRA_THEME_SETTINGS );
 			$astra_settings['gtn-full-wide-image-grp-css'] = isset( $astra_settings['gtn-full-wide-image-grp-css'] ) ? false : true;
 			return apply_filters( 'gtn_image_group_css_comp', $astra_settings['gtn-full-wide-image-grp-css'] );
 		}

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -591,6 +591,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'padding-right'  => 'calc( 6.67em - 28px )',
 				),
 				'.ast-separate-container .block-editor-block-list__layout' => array(
+					'padding-top'    => '0',
 					'padding-bottom' => '5.34em',
 					'padding-left'   => 'calc( 6.67em - 28px )',
 					'padding-right'  => 'calc( 6.67em - 28px )',
@@ -647,7 +648,18 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			$css .= astra_parse_css( $ast_gtn_mobile_css, '', astra_get_mobile_breakpoint() );
 
+			$gtn_full_wide_image_css = array(
+				'.ast-separate-container .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] figure.wp-block-image' => array(
+					'margin-left'  => '-4.8em',
+					'margin-right' => '-4.81em',
+					'max-width'    => 'unset',
+					'width'        => 'unset',
+				),
+			);
+			$css                    .= astra_parse_css( $gtn_full_wide_image_css );
+
 			if ( ( in_array( $pagenow, array( 'post-new.php' ) ) && ! isset( $post ) ) ) {
+
 				$boxed_container = array(
 					'.block-editor-writing-flow'       => array(
 						'max-width'        => astra_get_css_value( $site_content_width - 56, 'px' ),

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -480,33 +480,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
 
-			if ( 'page-builder' === $container_layout ) {
-				$page_builder_css = array(
-					'.editor-post-title__block, .editor-default-block-appender, .block-editor-block-list__block' => array(
-						'width'     => '100%',
-						'max-width' => '100%',
-					),
-					'.block-editor-block-list__layout' => array(
-						'padding-left'  => 0,
-						'padding-right' => 0,
-					),
-					'.editor-block-list__block-edit .editor-block-list__block-edit' => array(
-						'padding-left'  => '0',
-						'padding-right' => '0',
-					),
-					'.edit-post-visual-editor .block-editor-block-list__block' => array(
-						'padding-left'  => '20px',
-						'padding-right' => '20px',
-					),
-					'.edit-post-visual-editor .wp-block .block-editor-block-list__block' => array(
-						'padding-left'  => '0',
-						'padding-right' => '0',
-					),
-				);
-			}
-
-			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
-
 			$page_builder_css = array(
 				'.ast-page-builder-template .editor-post-title__block, .ast-page-builder-template .editor-default-block-appender, .ast-page-builder-template .block-editor-block-list__block' => array(
 					'width'     => '100%',

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -628,6 +628,12 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'max-width'    => 'unset',
 					'width'        => 'unset',
 				),
+				'.ast-separate-container .block-editor-block-list__block[data-align="full"] .wp-block-cover' => array(
+					'margin-left'  => '-4.8em',
+					'margin-right' => '-4.81em',
+					'max-width'    => 'unset',
+					'width'        => 'unset',
+				),
 			);
 			$css                    .= astra_parse_css( $gtn_full_wide_image_css );
 


### PR DESCRIPTION
### Description
Gutenberg image wide width issue fixed and removed the unused CSS.


### Screenshots
Box content -- full width image
https://share.getcloudapp.com/mXuBWb7k
Box-content -- wide width image
https://share.getcloudapp.com/mXuBWbqB


### Types of changes
 Bug-fix.
( Image wide width changes should reflect in the editor ) 

### How has this been tested?

Checked the fill width and wide width image width options with content boxed layout. 

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards 


