### PR TITLE
fix: astra_get_foreground_color returned same rgba color code instead of hex code

### DIFF
--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -40,7 +40,7 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 
 		if ( strpos( $hex, 'rgba' ) !== false ) {
 			$hex = preg_replace( '/[^0-9,]/', '', $hex );
-			$hex = explode( ",", $hex );
+			$hex = explode( ',', $hex );
 			$hex = ( ( $hex[0] * 299 ) + ( $hex[1] * 587 ) + ( $hex[2] * 114 ) ) / 1000;
 
 			return 128 <= $hex ? '#000000' : '#ffffff';

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -43,13 +43,7 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 			$rgba = preg_replace( '/[^0-9,]/', '', $hex );
 			$rgba = explode( ',', $rgba );
 
-			$r_val = (int) $rgba[0];
-			$g_val = (int) $rgba[1];
-			$b_val = (int) $rgba[2];
-
-			$rgba = ( ( $r_val * 0.299 ) + ( $g_val * 0.587 ) + ( $b_val * 0.114 ) );
-
-			return 186 < $rgba ? '#000000' : '#ffffff';
+			$hex = sprintf( '#%02x%02x%02x', $rgba[0], $rgba[1], $rgba[2] );
 		}
 
 		// Return if non hex.

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -40,7 +40,7 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 		}
 
 		// Return if non hex.
-		if ( ! ctype_xdigit( $hex ) ) {
+		if ( ! ctype_xdigit( $hex ) && version_compare( PHP_VERSION, '7.4', '>=' ) ) {
 			return $hex;
 		}
 
@@ -994,7 +994,7 @@ if ( ! function_exists( 'astra_adjust_brightness' ) ) {
 		$hex = str_replace( '#', '', $hex );
 
 		// Return if non hex.
-		if ( ! ctype_xdigit( $hex ) ) {
+		if ( ! ctype_xdigit( $hex ) && version_compare( PHP_VERSION, '7.4', '>=' ) ) {
 			return $hex;
 		}
 

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -29,7 +29,6 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 		// bail early if color's not set.
 		if ( 'transparent' == $hex || 'false' == $hex || '#' == $hex || empty( $hex ) ) {
 			return 'transparent';
-
 		}
 
 		// Get clean hex code.
@@ -39,8 +38,16 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 			$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
 		}
 
+		if ( strpos( $hex, 'rgba' ) !== false ) {
+			$hex = preg_replace( '/[^0-9,]/', '', $hex );
+			$hex = explode( ",", $hex );
+			$hex = ( ( $hex[0] * 299 ) + ( $hex[1] * 587 ) + ( $hex[2] * 114 ) ) / 1000;
+
+			return 128 <= $hex ? '#000000' : '#ffffff';
+		}
+
 		// Return if non hex.
-		if ( ! ctype_xdigit( $hex ) && version_compare( PHP_VERSION, '7.4', '>=' ) ) {
+		if ( ! ctype_xdigit( $hex ) ) {
 			return $hex;
 		}
 
@@ -994,7 +1001,7 @@ if ( ! function_exists( 'astra_adjust_brightness' ) ) {
 		$hex = str_replace( '#', '', $hex );
 
 		// Return if non hex.
-		if ( ! ctype_xdigit( $hex ) && version_compare( PHP_VERSION, '7.4', '>=' ) ) {
+		if ( ! ctype_xdigit( $hex ) ) {
 			return $hex;
 		}
 

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -39,11 +39,17 @@ if ( ! function_exists( 'astra_get_foreground_color' ) ) {
 		}
 
 		if ( strpos( $hex, 'rgba' ) !== false ) {
-			$hex = preg_replace( '/[^0-9,]/', '', $hex );
-			$hex = explode( ',', $hex );
-			$hex = ( ( $hex[0] * 299 ) + ( $hex[1] * 587 ) + ( $hex[2] * 114 ) ) / 1000;
 
-			return 128 <= $hex ? '#000000' : '#ffffff';
+			$rgba = preg_replace( '/[^0-9,]/', '', $hex );
+			$rgba = explode( ',', $rgba );
+
+			$r_val = (int) $rgba[0];
+			$g_val = (int) $rgba[1];
+			$b_val = (int) $rgba[2];
+
+			$rgba = ( ( $r_val * 0.299 ) + ( $g_val * 0.587 ) + ( $b_val * 0.114 ) );
+
+			return 186 < $rgba ? '#000000' : '#ffffff';
 		}
 
 		// Return if non hex.


### PR DESCRIPTION
### Description
- Toggle Button Color breaks when RGBA color applied
- Same color code applies to color & BG-color

### Screenshots
- https://share.getcloudapp.com/GGuk1YBe
- https://share.getcloudapp.com/xQuWXrkP

### Types of changes
- Previously we added ctype_xdigit check to resolve issues in PHP 7.4
- Checked the color code type & if its rgba code then respective hex code returned

### How has this been tested?
- Tested by setting the color to Toggle Button Color

### Checklist:
- My code is tested
- My code passes the PHPCS tests
- My code follows accessibility standards
- I've included any necessary tests
- I've added proper labels to this pull request