### PR TITLE
fix: Elementor headings directly applied bottom margin 20px from v2.9.9

### DIFF
--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -48,6 +48,35 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 			add_action( 'wp', array( $this, 'elementor_default_setting' ), 20 );
 			add_action( 'elementor/preview/init', array( $this, 'elementor_default_setting' ) );
 			add_action( 'elementor/preview/enqueue_styles', array( $this, 'elementor_overlay_zindex' ) );
+
+			/**
+			 * Compatibility for Elementor Headings after Elementor-v2.9.9.
+			 *
+			 * @since  x.x.x
+			 */
+			add_action( 'elementor/preview/enqueue_styles', array( $this, 'enqueue_elementor_compatibility_styles' ) );
+			add_action( 'elementor/frontend/after_enqueue_styles', array( $this, 'enqueue_elementor_compatibility_styles' ) );
+		}
+
+		/**
+		 * Compatibility CSS for Elementor Headings after Elementor-v2.9.9
+		 *
+		 * In v2.9.9 Elementor has removed [ .elementor-widget-heading .elementor-heading-title { margin: 0 } ] this CSS.
+		 * Again in v2.9.10 Elementor added this as .elementor-heading-title { margin: 0 } but still our [ .entry-content heading { margin-bottom: 20px } ] CSS overrding their fix.
+		 *
+		 * That's why adding this CSS fix to headings by setting bottom-margin to 0.
+		 *
+		 * @return void
+		 * @since  x.x.x
+		 */
+		public function enqueue_elementor_compatibility_styles() {
+			?>
+				<style type="text/css" id="ast-elementor-compatibility-css">
+					.elementor-widget-heading .elementor-heading-title {
+						margin: 0
+					}
+				</style>
+			<?php
 		}
 
 		/**


### PR DESCRIPTION
### Description
- In v2.9.9 Elementor has removed [ .elementor-widget-heading .elementor-heading-title { margin: 0 } ] CSS.
- Again in v2.9.10 Elementor added this as .elementor-heading-title { margin: 0 } but still our [ .entry-content heading { margin-bottom: 20px } ] CSS overrding their fix.
- That's why we are adding this CSS fix to headings by setting bottom-margin to 0.

### Screenshots
- https://share.getcloudapp.com/RBuq5PqW
- https://share.getcloudapp.com/6qu2K05A

### Types of changes
- Added short CSS to set bottom-margin as 0

### How has this been tested?
- With ELementor v2.9.8
- With Elementor v2.9.10

### Checklist:
- My code is tested
- My code passes the PHPCS tests
- My code follows accessibility standards
- My code has proper inline documentation 
- I've included any necessary tests
- I've added proper labels to this pull request
