### PR TITLE
chore: Elementor headings compatibility CSS loads twice

### DIFF
--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -52,10 +52,9 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 			/**
 			 * Compatibility for Elementor Headings after Elementor-v2.9.9.
 			 *
-			 * @since  2.4.5
+			 * @since  x.x.x.
 			 */
-			add_action( 'elementor/preview/enqueue_styles', array( $this, 'enqueue_elementor_compatibility_styles' ) );
-			add_action( 'elementor/frontend/after_enqueue_styles', array( $this, 'enqueue_elementor_compatibility_styles' ) );
+			add_filter( 'astra_dynamic_theme_css', array( $this, 'enqueue_elementor_compatibility_styles' ), 10, 2 );
 		}
 
 		/**
@@ -66,17 +65,34 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 		 *
 		 * That's why adding this CSS fix to headings by setting bottom-margin to 0.
 		 *
-		 * @return void
-		 * @since  2.4.5
+		 * @param  string $dynamic_css Astra Dynamic CSS.
+
+		 * @param  string $dynamic_css_filtered Astra Dynamic CSS Filters.
+
+		 * @return string $dynamic_css Generated CSS.
+		 * 
+		 * @since  x.x.x.
 		 */
-		public function enqueue_elementor_compatibility_styles() {
-			?>
-				<style type="text/css" id="ast-elementor-compatibility-css">
-					.elementor-widget-heading .elementor-heading-title {
-						margin: 0;
-					}
-				</style>
-			<?php
+		public function enqueue_elementor_compatibility_styles( $dynamic_css, $dynamic_css_filtered = '' ) {
+
+			global $post;
+			$id = astra_get_post_id();
+
+			if ( $this->is_elementor_activated( $id ) ) {
+
+				$elementor_heading_margin_comp = array(
+					'.elementor-widget-heading .elementor-heading-title' => array(
+						'margin' => '0',
+					),
+				);
+
+				/* Parse CSS from array() */
+				$parse_css = astra_parse_css( $elementor_heading_margin_comp );
+
+				$dynamic_css .= $parse_css;
+
+				return $dynamic_css;
+			}
 		}
 
 		/**

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 			/**
 			 * Compatibility for Elementor Headings after Elementor-v2.9.9.
 			 *
-			 * @since  x.x.x.
+			 * @since  2.4.5
 			 */
 			add_filter( 'astra_dynamic_theme_css', array( $this, 'enqueue_elementor_compatibility_styles' ), 10, 2 );
 		}
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 		 * @param  string $dynamic_css_filtered Astra Dynamic CSS Filters.
 		 * @return string $dynamic_css Generated CSS.
 		 *
-		 * @since  x.x.x.
+		 * @since  2.4.5
 		 */
 		public function enqueue_elementor_compatibility_styles( $dynamic_css, $dynamic_css_filtered = '' ) {
 

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -66,11 +66,9 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 		 * That's why adding this CSS fix to headings by setting bottom-margin to 0.
 		 *
 		 * @param  string $dynamic_css Astra Dynamic CSS.
-
 		 * @param  string $dynamic_css_filtered Astra Dynamic CSS Filters.
-
 		 * @return string $dynamic_css Generated CSS.
-		 * 
+		 *
 		 * @since  x.x.x.
 		 */
 		public function enqueue_elementor_compatibility_styles( $dynamic_css, $dynamic_css_filtered = '' ) {


### PR DESCRIPTION
### Description
- Moved Elementor headings compatibility margin CSS into dynamic styles.
- So it only loads once (previously it load twice because of two different actions)

### Screenshots
- https://share.getcloudapp.com/ApuA9G0v

### Types of changes
- Removed `elementor/preview/enqueue_styles` & `elementor/frontend/after_enqueue_styles` actions 
- Loaded CSS on `astra_dynamic_theme_css` filter

### How has this been tested?
- With new version of Elementor
- Page source to verify it should not load twice.
- Dynamic styles for headings should apply from Elementor builder
- This our CSS should not restrict dynamic CSS coming from the builder

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've added proper labels to this pull request 
