### PR TITLE
fix: Updations in Astra headers PR as per Support & QA points

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -1784,7 +1784,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				'.ast-desktop .main-header-menu.submenu-with-border .sub-menu .sub-menu' => array(
 					'top' => ( isset( $submenu_border['top'] ) && '' != $submenu_border['top'] ) ? astra_get_css_value( '-' . $submenu_border['top'], 'px' ) : '',
 				),
-				'.ast-desktop .main-header-menu.submenu-with-border .sub-menu a, .ast-desktop .main-header-menu.submenu-with-border .children a' => array(
+				'.ast-desktop .main-header-menu.submenu-with-border .sub-menu .menu-link, .ast-desktop .main-header-menu.submenu-with-border .children .menu-link' => array(
 					'border-bottom-width' => ( $primary_submenu_item_border ) ? '1px' : '0px',
 					'border-style'        => 'solid',
 					'border-color'        => esc_attr( $primary_submenu_item_b_color ),

--- a/inc/customizer/configurations/colors-background/class-astra-footer-colors-configs.php
+++ b/inc/customizer/configurations/colors-background/class-astra-footer-colors-configs.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Astra_Footer_Colors_Configs' ) ) {
 					'parent'    => ASTRA_THEME_SETTINGS . '[footer-bar-background-group]',
 					'section'   => 'section-footer-small',
 					'transport' => 'postMessage',
-					'control'   => 'ast-responsive-background',
+					'control'   => 'ast-background',
 					'default'   => astra_get_option( 'footer-bg-obj' ),
 					'label'     => __( 'Background', 'astra' ),
 				),

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -813,7 +813,6 @@ if ( ! function_exists( 'astra_primary_navigation_markup' ) ) {
 				'menu_id'        => 'primary-menu',
 				'menu_class'     => 'main-navigation',
 				'container'      => 'div',
-
 				'before'         => '<ul class="' . esc_attr( implode( ' ', $primary_menu_classes ) ) . '">',
 				'after'          => '</ul>',
 				'walker'         => new Astra_Walker_Page(),
@@ -873,6 +872,39 @@ if ( ! function_exists( 'astra_primary_navigation_markup' ) ) {
 }
 
 add_action( 'astra_masthead_content', 'astra_primary_navigation_markup', 10 );
+
+/**
+ * Add CSS classes for all menu links inside WP Nav menu items.
+ *
+ * Right now, if Addon is active we add 'menu-link' class through walker_nav_menu_start_el, but if only theme is being used no clas is assigned to anchors.
+ *
+ * As we are replacing tag based selector assets to class selector, adding 'menu-link' selector to all anchors inside menu items.
+ * Ex. .main-header-menu a => .main-header-menu .menu-link
+ *
+ * @since x.x.x
+ * @param array $atts   An array of all parameters assigned to menu anchors.
+ */
+function astra_menu_anchor_class_for_nav_menus( $atts ) {
+	$atts['class'] = 'menu-link';
+	return $atts;
+}
+
+add_filter( 'nav_menu_link_attributes', 'astra_menu_anchor_class_for_nav_menus' );
+
+/**
+ * Add CSS classes for all menu links inside WP Page Menu items.
+ *
+ * As we are replacing tag based selector to class selector, adding 'menu-link' selector to all anchors inside menu items.
+ *
+ * @since x.x.x
+ * @param array $atts   An array of all parameters assigned to menu anchors.
+ */
+function astra_menu_anchor_class_for_page_menus( $atts ) {
+	$atts['class'] = 'menu-link';
+	return $atts;
+}
+
+add_filter( 'page_menu_link_attributes', 'astra_menu_anchor_class_for_page_menus' );
 
 /**
  * Add CSS classes from wp_nav_menu the wp_page_menu()'s menu items.


### PR DESCRIPTION
### Description
- Added filter to add menu-link class to menu anchors
- Replaced missed anchor tag with menu-link selector

### Screenshots
- https://i.imgur.com/2m8x4HD.png

### Types of changes
- Used the filters to load the styles based on this selector

### How has this been tested?
- By deactivating Addon
- With normal WP Nav & Page menu

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [x] I've included any necessary tests
- [x] I've included developer documentation
- [x] I've added proper labels to this pull request