### PR TITLE
chore: WPForms upgrade affiliate link

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -329,6 +329,7 @@ add_filter( 'ninja_forms_affiliate_id', 'astra_filter_ninja_forms_comp_id' );
 /**
  * Change upgrade link for wpforms.
  *
+ * @param string $url upgrade launch page URL.
  * @return String updated upgrade link.
  */
 function astra_wpforms_upgrade_link( $url ) {

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -331,8 +331,8 @@ add_filter( 'ninja_forms_affiliate_id', 'astra_filter_ninja_forms_comp_id' );
  *
  * @return String updated upgrade link.
  */
-function astra_wpforms_upgrade_link() {
-	return 'https://shareasale.com/r.cfm?b=834775&u=1115254&m=64312&urllink=&afftrack=';
+function astra_wpforms_upgrade_link( $url ) {
+	return 'https://shareasale.com/r.cfm?b=834775&u=1115254&m=64312&urllink=&afftrack=' . rawurlencode( $url );
 }
 
 add_filter( 'wpforms_upgrade_link', 'astra_wpforms_upgrade_link' );


### PR DESCRIPTION
### Description
- Upgrade affiliate link has been updated for WPForms

### Screenshots
- https://share.getcloudapp.com/GGuoYBby

### Types of changes
- Used their URL param for landing users to the actual sales page

### How has this been tested?
- With the link

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [x] I've included any necessary tests
- [x] I've included developer documentation
- [x] I've added proper labels to this pull request
