### PR TITLE
 fix: added is_callable check for astra_woocommerce class.

### DIFF
--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -482,22 +482,23 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			);
 
 			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
+			if ( class_exists( 'Astra_Woocommerce' ) && is_callable( 'Astra_Woocommerce::astra_global_btn_woo_comp' ) ) {
+				if ( Astra_Woocommerce::astra_global_btn_woo_comp() ) {
 
-			if ( Astra_Woocommerce::astra_global_btn_woo_comp() ) {
-
-				$woo_global_button_css = array(
-					'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link, .wc-block-grid__product-onsale' => array(
-						'border-top-width'    => ( isset( $global_custom_button_border_size['top'] ) && '' !== $global_custom_button_border_size['top'] ) ? astra_get_css_value( $global_custom_button_border_size['top'], 'px' ) : '0',
-						'border-right-width'  => ( isset( $global_custom_button_border_size['right'] ) && '' !== $global_custom_button_border_size['right'] ) ? astra_get_css_value( $global_custom_button_border_size['right'], 'px' ) : '0',
-						'border-left-width'   => ( isset( $global_custom_button_border_size['left'] ) && '' !== $global_custom_button_border_size['left'] ) ? astra_get_css_value( $global_custom_button_border_size['left'], 'px' ) : '0',
-						'border-bottom-width' => ( isset( $global_custom_button_border_size['bottom'] ) && '' !== $global_custom_button_border_size['bottom'] ) ? astra_get_css_value( $global_custom_button_border_size['bottom'], 'px' ) : '0',
-						'border-color'        => $btn_border_color ? $btn_border_color : $btn_bg_color,
-					),
-					'.wc-block-grid__products .wc-block-grid__product .wp-block-button__link:hover' => array(
-						'border-color' => $btn_bg_h_color,
-					),
-				);
-				$css                  .= astra_parse_css( $woo_global_button_css );
+					$woo_global_button_css = array(
+						'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link' => array(
+							'border-top-width'    => ( isset( $global_custom_button_border_size['top'] ) && '' !== $global_custom_button_border_size['top'] ) ? astra_get_css_value( $global_custom_button_border_size['top'], 'px' ) : '0',
+							'border-right-width'  => ( isset( $global_custom_button_border_size['right'] ) && '' !== $global_custom_button_border_size['right'] ) ? astra_get_css_value( $global_custom_button_border_size['right'], 'px' ) : '0',
+							'border-left-width'   => ( isset( $global_custom_button_border_size['left'] ) && '' !== $global_custom_button_border_size['left'] ) ? astra_get_css_value( $global_custom_button_border_size['left'], 'px' ) : '0',
+							'border-bottom-width' => ( isset( $global_custom_button_border_size['bottom'] ) && '' !== $global_custom_button_border_size['bottom'] ) ? astra_get_css_value( $global_custom_button_border_size['bottom'], 'px' ) : '0',
+							'border-color'        => $btn_border_color ? $btn_border_color : $btn_bg_color,
+						),
+						'.wc-block-grid__products .wc-block-grid__product .wp-block-button__link:hover' => array(
+							'border-color' => $btn_bg_h_color,
+						),
+					);
+					$css                  .= astra_parse_css( $woo_global_button_css );
+				}
 			}
 
 			$page_builder_css = array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -482,23 +482,22 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			);
 
 			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
-			if ( class_exists( 'Astra_Woocommerce' ) && is_callable( 'Astra_Woocommerce::astra_global_btn_woo_comp' ) ) {
-				if ( Astra_Woocommerce::astra_global_btn_woo_comp() ) {
 
-					$woo_global_button_css = array(
-						'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link' => array(
-							'border-top-width'    => ( isset( $global_custom_button_border_size['top'] ) && '' !== $global_custom_button_border_size['top'] ) ? astra_get_css_value( $global_custom_button_border_size['top'], 'px' ) : '0',
-							'border-right-width'  => ( isset( $global_custom_button_border_size['right'] ) && '' !== $global_custom_button_border_size['right'] ) ? astra_get_css_value( $global_custom_button_border_size['right'], 'px' ) : '0',
-							'border-left-width'   => ( isset( $global_custom_button_border_size['left'] ) && '' !== $global_custom_button_border_size['left'] ) ? astra_get_css_value( $global_custom_button_border_size['left'], 'px' ) : '0',
-							'border-bottom-width' => ( isset( $global_custom_button_border_size['bottom'] ) && '' !== $global_custom_button_border_size['bottom'] ) ? astra_get_css_value( $global_custom_button_border_size['bottom'], 'px' ) : '0',
-							'border-color'        => $btn_border_color ? $btn_border_color : $btn_bg_color,
-						),
-						'.wc-block-grid__products .wc-block-grid__product .wp-block-button__link:hover' => array(
-							'border-color' => $btn_bg_h_color,
-						),
-					);
-					$css                  .= astra_parse_css( $woo_global_button_css );
-				}
+			if ( is_callable( 'Astra_Woocommerce::astra_global_btn_woo_comp' ) && Astra_Woocommerce::astra_global_btn_woo_comp() ) {
+
+				$woo_global_button_css = array(
+					'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link' => array(
+						'border-top-width'    => ( isset( $global_custom_button_border_size['top'] ) && '' !== $global_custom_button_border_size['top'] ) ? astra_get_css_value( $global_custom_button_border_size['top'], 'px' ) : '0',
+						'border-right-width'  => ( isset( $global_custom_button_border_size['right'] ) && '' !== $global_custom_button_border_size['right'] ) ? astra_get_css_value( $global_custom_button_border_size['right'], 'px' ) : '0',
+						'border-left-width'   => ( isset( $global_custom_button_border_size['left'] ) && '' !== $global_custom_button_border_size['left'] ) ? astra_get_css_value( $global_custom_button_border_size['left'], 'px' ) : '0',
+						'border-bottom-width' => ( isset( $global_custom_button_border_size['bottom'] ) && '' !== $global_custom_button_border_size['bottom'] ) ? astra_get_css_value( $global_custom_button_border_size['bottom'], 'px' ) : '0',
+						'border-color'        => $btn_border_color ? $btn_border_color : $btn_bg_color,
+					),
+					'.wc-block-grid__products .wc-block-grid__product .wp-block-button__link:hover' => array(
+						'border-color' => $btn_bg_h_color,
+					),
+				);
+				$css                  .= astra_parse_css( $woo_global_button_css );
 			}
 
 			$page_builder_css = array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -483,7 +483,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
 
-			if ( is_callable( 'Astra_Woocommerce::astra_global_btn_woo_comp' ) && Astra_Woocommerce::astra_global_btn_woo_comp() ) {
+			if ( class_exists( 'Astra_Woocommerce' ) && Astra_Woocommerce::astra_global_btn_woo_comp() ) {
 
 				$woo_global_button_css = array(
 					'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link' => array(

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -483,7 +483,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			$css .= astra_parse_css( $mobile_css, '', astra_get_mobile_breakpoint() );
 
-			if ( class_exists( 'Astra_Woocommerce' ) && Astra_Woocommerce::astra_global_btn_woo_comp() ) {
+			if ( is_callable( 'Astra_Woocommerce::astra_global_btn_woo_comp' ) && Astra_Woocommerce::astra_global_btn_woo_comp() ) {
 
 				$woo_global_button_css = array(
 					'.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wp-block-button__link' => array(


### PR DESCRIPTION
### Description
Fixed a warning displayed in the editor view in case if the woocommerce plugin is disabled.

### Screenshots
<!-- if applicable -->

### Types of changes
Non-breaking change which fixes an issue

### How has this been tested?
Checked by activating woocommerce and then visiting the editor view and similarly deactivating and checking the editor's view.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
