### PR TITLE
fix: added different files for appearance submenu css and astra settings meta box css.

### DIFF
--- a/inc/assets/css/astra-admin-submenu-rtl.css
+++ b/inc/assets/css/astra-admin-submenu-rtl.css
@@ -1,0 +1,17 @@
+/**
+ * CSS code for showing the icons for the submenu items in the appearance tab.
+ *
+ * @package Astra
+ * @since 2.6.0
+ */
+
+#menu-appearance a[href^="edit.php?post_type=astra-"]:before,
+#menu-appearance a[href^="themes.php?page=astra-"]:before,
+#menu-appearance a[href^="edit.php?post_type=astra_"]:before,
+#menu-appearance a[href^="edit-tags.php?taxonomy=bsf_custom_fonts"]:before,
+#menu-appearance a[href^="themes.php?page=custom-typekit-fonts"]:before,
+#menu-appearance a[href^="edit.php?post_type=bsf-sidebar"]:before {
+        content: "\21B3";
+        margin-left: 0.5em;
+        opacity: 0.5;
+    }

--- a/inc/assets/css/astra-admin-submenu.css
+++ b/inc/assets/css/astra-admin-submenu.css
@@ -1,0 +1,17 @@
+/**
+ * CSS code for showing the icons for the submenu items in the appearance tab.
+ *
+ * @package Astra
+ * @since 2.6.0
+ */
+
+#menu-appearance a[href^="edit.php?post_type=astra-"]:before,
+#menu-appearance a[href^="themes.php?page=astra-"]:before,
+#menu-appearance a[href^="edit.php?post_type=astra_"]:before,
+#menu-appearance a[href^="edit-tags.php?taxonomy=bsf_custom_fonts"]:before,
+#menu-appearance a[href^="themes.php?page=custom-typekit-fonts"]:before,
+#menu-appearance a[href^="edit.php?post_type=bsf-sidebar"]:before {
+        content: "\21B3";
+        margin-right: 0.5em;
+        opacity: 0.5;
+    }

--- a/inc/assets/css/astra-metabox-rtl.css
+++ b/inc/assets/css/astra-metabox-rtl.css
@@ -1,5 +1,5 @@
 /**
- * CSS code for showing the astra settings metabox in the editor view.
+ * CSS code for the astra settings metabox in the editor view.
  *
  * @package Astra
  * @since 2.6.0
@@ -8,7 +8,7 @@
 .block-editor-page #side-sortables #astra_settings_meta_box select { 
      min-width: 84%; padding: 3px 8px 3px 24px; height: 20px; 
     }      
-    
+
 .block-editor-page #normal-sortables #astra_settings_meta_box select {
          min-width: 200px; 
     }

--- a/inc/assets/css/astra-metabox-rtl.css
+++ b/inc/assets/css/astra-metabox-rtl.css
@@ -1,0 +1,38 @@
+/**
+ * CSS code for showing the astra settings metabox in the editor view.
+ *
+ * @package Astra
+ * @since 2.6.0
+ */
+
+.block-editor-page #side-sortables #astra_settings_meta_box select { 
+     min-width: 84%; padding: 3px 8px 3px 24px; height: 20px; 
+    }      
+    
+.block-editor-page #normal-sortables #astra_settings_meta_box select {
+         min-width: 200px; 
+    }
+
+.block-editor-page .edit-post-meta-boxes-area #poststuff #astra_settings_meta_box h2.hndle {
+        border-bottom: 0; 
+    }
+
+.block-editor-page #astra_settings_meta_box .components-base-control__field, .block-editor-page #astra_settings_meta_box .block-editor-page .transparent-header-wrapper, .block-editor-page #astra_settings_meta_box .adv-header-wrapper, .block-editor-page #astra_settings_meta_box .stick-header-wrapper, .block-editor-page #astra_settings_meta_box .disable-section-meta div {
+        margin-bottom: 8px; 
+    }
+
+.block-editor-page #astra_settings_meta_box .disable-section-meta div label {
+        vertical-align: inherit; 
+    }
+
+.block-editor-page #astra_settings_meta_box .post-attributes-label-wrapper {
+        margin-bottom: 4px; 
+    }
+
+#side-sortables #astra_settings_meta_box select {
+        min-width: 100%; 
+    }
+
+#normal-sortables #astra_settings_meta_box select {
+        min-width: 200px; 
+    }

--- a/inc/assets/css/astra-metabox.css
+++ b/inc/assets/css/astra-metabox.css
@@ -1,5 +1,5 @@
 /**
- * CSS code for showing the astra settings metabox in the editor view.
+ * CSS code for the astra settings metabox in the editor view.
  *
  * @package Astra
  * @since 2.6.0
@@ -8,7 +8,7 @@
 .block-editor-page #side-sortables #astra_settings_meta_box select { 
      min-width: 84%; padding: 3px 24px 3px 8px; height: 20px; 
     }      
-    
+
 .block-editor-page #normal-sortables #astra_settings_meta_box select {
          min-width: 200px; 
     }

--- a/inc/assets/css/astra-metabox.css
+++ b/inc/assets/css/astra-metabox.css
@@ -1,0 +1,38 @@
+/**
+ * CSS code for showing the astra settings metabox in the editor view.
+ *
+ * @package Astra
+ * @since 2.6.0
+ */
+
+.block-editor-page #side-sortables #astra_settings_meta_box select { 
+     min-width: 84%; padding: 3px 24px 3px 8px; height: 20px; 
+    }      
+    
+.block-editor-page #normal-sortables #astra_settings_meta_box select {
+         min-width: 200px; 
+    }
+
+.block-editor-page .edit-post-meta-boxes-area #poststuff #astra_settings_meta_box h2.hndle {
+        border-bottom: 0; 
+    }
+
+.block-editor-page #astra_settings_meta_box .components-base-control__field, .block-editor-page #astra_settings_meta_box .block-editor-page .transparent-header-wrapper, .block-editor-page #astra_settings_meta_box .adv-header-wrapper, .block-editor-page #astra_settings_meta_box .stick-header-wrapper, .block-editor-page #astra_settings_meta_box .disable-section-meta div {
+        margin-bottom: 8px; 
+    }
+
+.block-editor-page #astra_settings_meta_box .disable-section-meta div label {
+        vertical-align: inherit; 
+    }
+
+.block-editor-page #astra_settings_meta_box .post-attributes-label-wrapper {
+        margin-bottom: 4px; 
+    }
+
+#side-sortables #astra_settings_meta_box select {
+        min-width: 100%; 
+    }
+
+#normal-sortables #astra_settings_meta_box select {
+        min-width: 200px; 
+    }

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -719,13 +719,6 @@ h6 {
   box-shadow: inset 0 2px 5px -3px black;
 }
 
-#elementor-editor-button[disabled], #elementor-editor-button:disabled, #elementor-editor-button.button-primary-disabled, #elementor-editor-button.disabled {
-  color: #c7ced1 !important;
-  background: #005781 !important;
-  border-color: #005781 !important;
-  text-shadow: none !important;
-}
-
 #elementor-editor-button i {
   font-style: normal;
   color: white;

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -719,13 +719,6 @@ h6 {
   box-shadow: inset 0 2px 5px -3px black;
 }
 
-#elementor-editor-button[disabled], #elementor-editor-button:disabled, #elementor-editor-button.button-primary-disabled, #elementor-editor-button.disabled {
-  color: #c7ced1 !important;
-  background: #005781 !important;
-  border-color: #005781 !important;
-  text-shadow: none !important;
-}
-
 #elementor-editor-button i {
   font-style: normal;
   color: white;

--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -479,33 +479,13 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 				$post_type  = $screen->id;
 
 				if ( in_array( $post_type, (array) $post_types ) ) {
-					echo '<style class="astra-meta-box-style">
-						.block-editor-page #side-sortables #astra_settings_meta_box select { min-width: 84%; padding: 3px 24px 3px 8px; height: 20px; }
-						.block-editor-page #normal-sortables #astra_settings_meta_box select { min-width: 200px; }
-						.block-editor-page .edit-post-meta-boxes-area #poststuff #astra_settings_meta_box h2.hndle { border-bottom: 0; }
-						.block-editor-page #astra_settings_meta_box .components-base-control__field, .block-editor-page #astra_settings_meta_box .block-editor-page .transparent-header-wrapper, .block-editor-page #astra_settings_meta_box .adv-header-wrapper, .block-editor-page #astra_settings_meta_box .stick-header-wrapper, .block-editor-page #astra_settings_meta_box .disable-section-meta div { margin-bottom: 8px; }
-						.block-editor-page #astra_settings_meta_box .disable-section-meta div label { vertical-align: inherit; }
-						.block-editor-page #astra_settings_meta_box .post-attributes-label-wrapper { margin-bottom: 4px; }
-						#side-sortables #astra_settings_meta_box select { min-width: 100%; }
-						#normal-sortables #astra_settings_meta_box select { min-width: 200px; }
-					</style>';
+					wp_enqueue_style( 'astra-settings-metabox', ASTRA_THEME_URI . 'inc/assets/css/astra-metabox.css', array(), ASTRA_THEME_VERSION );
 				}
 			}
 			/* Add CSS for the Submenu for BSF plugins added in Appearance Menu */
 
 			if ( ! is_customize_preview() ) {
-				echo '<style class="astra-menu-appearance-style">
-					#menu-appearance a[href^="edit.php?post_type=astra-"]:before,
-					#menu-appearance a[href^="themes.php?page=astra-"]:before,
-					#menu-appearance a[href^="edit.php?post_type=astra_"]:before,
-					#menu-appearance a[href^="edit-tags.php?taxonomy=bsf_custom_fonts"]:before,
-					#menu-appearance a[href^="themes.php?page=custom-typekit-fonts"]:before,
-					#menu-appearance a[href^="edit.php?post_type=bsf-sidebar"]:before {
-					    content: "\21B3";
-					    margin-right: 0.5em;
-					    opacity: 0.5;
-					}
-				</style>';
+				wp_enqueue_style( 'astra-admin-submenu', ASTRA_THEME_URI . 'inc/assets/css/astra-admin-submenu.css', array(), ASTRA_THEME_VERSION );
 
 				if ( ! current_user_can( 'manage_options' ) ) {
 					return;


### PR DESCRIPTION
### Description
Instead of printing CSS directly on the admin-enqueue scripts, I have added this as an external CSS. This is done according to reference to a git hub issue https://github.com/GoogleChromeLabs/pwa-wp/issues/315

### Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

### How has this been tested?
I have checked the places where this CSS applies.
I have checked the CSS in the source how it's been enqueued.
I have checked if this is loading on the front end.
I have checked this with RTL languages.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
