### PR TITLE
fix: footer wigets background color option not working after update.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define Constants
  */
-define( 'ASTRA_THEME_VERSION', '2.5.1' );
+define( 'ASTRA_THEME_VERSION', '2.5.2' );
 define( 'ASTRA_THEME_SETTINGS', 'astra-settings' );
 define( 'ASTRA_THEME_DIR', trailingslashit( get_template_directory() ) );
 define( 'ASTRA_THEME_URI', trailingslashit( esc_url( get_template_directory_uri() ) ) );

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					'footer-link-h-color'                  => '',
 
 					// Footer Widgets Background.
-					'footer-adv-bg-obj-responsive'         => array(
+					'footer-adv-bg-obj'                    => array(
 						'background-color'      => '',
 						'background-image'      => '',
 						'background-repeat'     => 'repeat',

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -253,3 +253,27 @@ function astra_global_button_woo_css() {
 		update_option( 'astra-settings', $theme_options );
 	}
 }
+
+/**
+ * Migrate Footer Widget param to array.
+ *
+ * @since x.x.x
+ *
+ * @return void
+ */
+function astra_footer_widget_bg() {
+	$theme_options = get_option( 'astra-settings', array() );
+
+	// Set flag to not load button specific CSS.
+	if ( isset( $theme_options['footer-adv-bg-obj'] ) && ! is_array( $theme_options['footer-adv-bg-obj'] )  ) {
+		$theme_options['footer-adv-bg-obj'] = array(
+			'background-color'      => '',
+			'background-image'      => '',
+			'background-repeat'     => 'repeat',
+			'background-position'   => 'center center',
+			'background-size'       => 'auto',
+			'background-attachment' => 'scroll',
+		);
+		update_option( 'astra-settings', $theme_options );
+	}
+}

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -266,6 +266,7 @@ function astra_footer_widget_bg() {
 
 	// Check if Footer Backgound array is already set or not. If not then set it as array.
 	if ( isset( $theme_options['footer-adv-bg-obj'] ) && ! is_array( $theme_options['footer-adv-bg-obj'] ) ) {
+		error_log( 'Astra: Migrating Footer BG option to array.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		$theme_options['footer-adv-bg-obj'] = array(
 			'background-color'      => '',
 			'background-image'      => '',

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -264,8 +264,8 @@ function astra_global_button_woo_css() {
 function astra_footer_widget_bg() {
 	$theme_options = get_option( 'astra-settings', array() );
 
-	// Set flag to not load button specific CSS.
-	if ( isset( $theme_options['footer-adv-bg-obj'] ) && ! is_array( $theme_options['footer-adv-bg-obj'] )  ) {
+	// Check if Footer Backgound array is already set or not. If not then set it as array.
+	if ( isset( $theme_options['footer-adv-bg-obj'] ) && ! is_array( $theme_options['footer-adv-bg-obj'] ) ) {
 		$theme_options['footer-adv-bg-obj'] = array(
 			'background-color'      => '',
 			'background-image'      => '',

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -56,6 +56,9 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 				'astra_global_button_woo_css',
 				'astra_gtn_full_wide_group_cover_css',
 			),
+			'2.5.2' => array(
+				'astra_footer_widget_bg',
+			),
 		);
 
 		/**


### PR DESCRIPTION
### Description
Changed the option name of the footer widget background widget from 'footer-adv-bg-obj-responsive' to 'footer-adv-bg-obj'.

### Types of changes

<!-- Bug fix (non-breaking change which fixes an issue) -->


### How has this been tested?
Checked the working of the footer widget background-color as well as background image.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
