### PR TITLE
fix: WP 5.5 wpColorPickerL10n issue, RGB not working for wp-color-picker-alpha lib.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 v2.5.3
-- Minor code changes.
+- Fix: Minor code changes.
+- Fix: Removing third-party plugins from options page.
+- Fix: RGB color not working in Customizer for WordPress 5.5.
 
 v2.5.2
 - Fix: Footer Widgets background color option not working for new users.

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -709,6 +709,8 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 		 */
 		public function controls_scripts() {
 
+			global $wp_version;
+
 			$js_prefix  = '.min.js';
 			$css_prefix = '.min.css';
 			$dir        = 'minified';
@@ -727,6 +729,31 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 
 			wp_enqueue_style( 'wp-color-picker' );
 			wp_enqueue_script( 'astra-color-alpha' );
+
+			/**
+			 * Localize wp-color-picker & wpColorPickerL10n.
+			 *
+			 * This is only needed in WordPress version >= 5.5 because wpColorPickerL10n has been removed.
+			 * @see https://github.com/WordPress/WordPress/commit/7e7b70cd1ae5772229abb769d0823411112c748b
+			 *
+			 * This is should be removed once the issue is fixed from wp-color-picker-alpha repo.
+			 * @see https://github.com/kallookoo/wp-color-picker-alpha/issues/35
+			 *
+			 * @since x.x.x
+			 */
+			if ( version_compare( $wp_version, '5.4.99', '>=' ) ) {
+				wp_localize_script(
+					'wp-color-picker',
+					'wpColorPickerL10n',
+					array(
+						'clear'            => __( 'Clear' ),
+						'clearAriaLabel'   => __( 'Clear color' ),
+						'defaultString'    => __( 'Default' ),
+						'defaultAriaLabel' => __( 'Select default color' ),
+						'pick'             => __( 'Select Color' ),
+						'defaultLabel'     => __( 'Color value' ),
+				) );
+			}
 
 			wp_enqueue_script( 'thickbox' );
 			wp_enqueue_style( 'thickbox' );

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -734,6 +734,7 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			 * Localize wp-color-picker & wpColorPickerL10n.
 			 *
 			 * This is only needed in WordPress version >= 5.5 because wpColorPickerL10n has been removed.
+			 *
 			 * @see https://github.com/WordPress/WordPress/commit/7e7b70cd1ae5772229abb769d0823411112c748b
 			 *
 			 * This is should be removed once the issue is fixed from wp-color-picker-alpha repo.
@@ -752,7 +753,8 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 						'defaultAriaLabel' => __( 'Select default color' ),
 						'pick'             => __( 'Select Color' ),
 						'defaultLabel'     => __( 'Color value' ),
-				) );
+					)
+				);
 			}
 
 			wp_enqueue_script( 'thickbox' );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
This fixes - Uncaught ReferenceError: wpColorPickerL10n is not defined JS error in customizer for wp-color-picker-alpha lib - https://github.com/kallookoo/wp-color-picker-alpha/issues/35

### Screenshots
<!-- if applicable -->
https://a.cl.ly/E0unPADp

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested with WP 5.5 to see if RGB starts working for colors or not.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
