### PR TITLE
fix: function prefix and making attr translatable for Slide Search.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -331,7 +331,7 @@ function astra_filesystem() {
  * @param WP_Customize_Manager $wp_customize instance of WP_Customize_Manager.
  * @return $wp_customize
  */
-function remove_controls( $wp_customize ) {
+function astra_remove_controls( $wp_customize ) {
 
 	if ( defined( 'ASTRA_EXT_VER' ) && version_compare( ASTRA_EXT_VER, '2.4.0', '<=' ) ) {
 		$layout = array(
@@ -351,7 +351,7 @@ function remove_controls( $wp_customize ) {
 	return $wp_customize;
 }
 
-add_filter( 'astra_customizer_configurations', 'remove_controls', 99 );
+add_filter( 'astra_customizer_configurations', 'astra_remove_controls', 99 );
 
 /**
  * Pass theme specific stats to BSF analytics.

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -397,7 +397,7 @@ if ( ! function_exists( 'astra_get_search' ) ) {
 		?>
 		<div class="ast-search-menu-icon slide-search" <?php echo apply_filters( 'astra_search_slide_toggle_data_attrs', '' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>id="ast-search-form" role="search" tabindex="-1">
 			<div class="ast-search-icon">
-				<a class="slide-search astra-search-icon" aria-label="Search icon link" href="#">
+				<a class="slide-search astra-search-icon" aria-label="<?php esc_attr_e( 'Search icon link', 'astra' ); ?>" href="#">
 					<span class="screen-reader-text"><?php esc_html_e( 'Search', 'astra' ); ?></span>
 				</a>
 			</div>
@@ -634,7 +634,7 @@ if ( ! function_exists( 'astra_header_markup' ) ) {
 		do_action( 'astra_header_markup_before' );
 		?>
 
-		<header 
+		<header
 			<?php
 				echo astra_attr(
 					'header',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
1. Added prefix astra_remove_controls to function remove_controls.
2. escaped attribute for arai-label for slide search form.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Non-breaking changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on code level that the existing and new code is working properly.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
