### PR TITLE
improvement: Replace 'version_compare' with new 'astra_wp_version_compare' function.

### DIFF
--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -709,8 +709,6 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 		 */
 		public function controls_scripts() {
 
-			global $wp_version;
-
 			$js_prefix  = '.min.js';
 			$css_prefix = '.min.css';
 			$dir        = 'minified';
@@ -742,7 +740,7 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			 *
 			 * @since 2.5.3
 			 */
-			if ( version_compare( $wp_version, '5.4.99', '>=' ) ) {
+			if ( astra_wp_version_compare( '5.4.99', '>=' ) ) {
 				wp_localize_script(
 					'wp-color-picker',
 					'wpColorPickerL10n',

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -741,6 +741,7 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			 * @since 2.5.3
 			 */
 			if ( astra_wp_version_compare( '5.4.99', '>=' ) ) {
+				// Localizing variables.
 				wp_localize_script(
 					'wp-color-picker',
 					'wpColorPickerL10n',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Replacing newly introduced function `astra_wp_version_compare` to compare WP version.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Non-breaking changes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Test if the existing fix for JS is still working or not. Working properly.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
