### PR TITLE
fix: Array to string conversion - PHP Notice issue fixed.

### DIFF
--- a/inc/customizer/custom-controls/background/class-astra-control-background.php
+++ b/inc/customizer/custom-controls/background/class-astra-control-background.php
@@ -55,5 +55,12 @@ if ( ! class_exists( 'Astra_Control_Background' ) && class_exists( 'WP_Customize
 				$this->json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 			}
 		}
+
+		/**
+		 * Render the control's content.
+		 *
+		 * @see WP_Customize_Control::render_content()
+		 */
+		protected function render_content() {}
 	}
 endif;

--- a/inc/customizer/custom-controls/border/class-astra-control-border.php
+++ b/inc/customizer/custom-controls/border/class-astra-control-border.php
@@ -77,6 +77,13 @@ if ( ! class_exists( 'Astra_Control_Border' ) && class_exists( 'WP_Customize_Con
 			}
 			$this->json['inputAttrs'] = maybe_serialize( $this->input_attrs() );
 		}
+
+		/**
+		 * Render the control's content.
+		 *
+		 * @see WP_Customize_Control::render_content()
+		 */
+		protected function render_content() {}
 	}
 
 endif;

--- a/inc/customizer/custom-controls/color/class-astra-control-color.php
+++ b/inc/customizer/custom-controls/color/class-astra-control-color.php
@@ -54,4 +54,11 @@ class Astra_Control_Color extends WP_Customize_Control {
 		$this->json['default']     = $this->default;
 		$this->json['input_attrs'] = $this->input_attrs;
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/customizer-link/class-astra-control-customizer-link.php
+++ b/inc/customizer/custom-controls/customizer-link/class-astra-control-customizer-link.php
@@ -59,4 +59,11 @@ class Astra_Control_Customizer_Link extends WP_Customize_Control {
 		$this->json['linked']    = $this->linked;
 		$this->json['link_type'] = $this->link_type;
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/description/class-astra-control-description.php
+++ b/inc/customizer/custom-controls/description/class-astra-control-description.php
@@ -47,4 +47,11 @@ class Astra_Control_Description extends WP_Customize_Control {
 		$this->json['description'] = $this->description;
 		$this->json['help']        = $this->help;
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/divider/class-astra-control-divider.php
+++ b/inc/customizer/custom-controls/divider/class-astra-control-divider.php
@@ -56,4 +56,11 @@ class Astra_Control_Divider extends WP_Customize_Control {
 		$this->json['separator']   = $this->separator;
 	}
 
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
+
 }

--- a/inc/customizer/custom-controls/heading/class-astra-control-heading.php
+++ b/inc/customizer/custom-controls/heading/class-astra-control-heading.php
@@ -46,5 +46,12 @@ class Astra_Control_Heading extends WP_Customize_Control {
 		$this->json['caption']     = $this->caption;
 		$this->json['description'] = $this->description;
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }
 

--- a/inc/customizer/custom-controls/link/class-astra-control-link.php
+++ b/inc/customizer/custom-controls/link/class-astra-control-link.php
@@ -52,4 +52,11 @@ class Astra_Control_Link extends WP_Customize_Control {
 		$this->json['value'] = $this->value();
 		$this->json['label'] = esc_html( $this->label );
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/radio-image/class-astra-control-radio-image.php
+++ b/inc/customizer/custom-controls/radio-image/class-astra-control-radio-image.php
@@ -57,7 +57,7 @@ class Astra_Control_Radio_Image extends WP_Customize_Control {
 	 */
 	public static function astra_add_radio_img_svg_css() {
 		?>
-		<style type="text/css">.ast-radio-img-svg svg * { fill: <?php echo self::$higlight_color; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> !important; stroke: <?php echo self::$higlight_color; ?> !important }</style> 
+		<style type="text/css">.ast-radio-img-svg svg * { fill: <?php echo self::$higlight_color; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> !important; stroke: <?php echo self::$higlight_color; ?> !important }</style>
 		<?php
 	}
 
@@ -112,4 +112,11 @@ class Astra_Control_Radio_Image extends WP_Customize_Control {
 		}
 
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/responsive-background/class-astra-control-responsive-background.php
+++ b/inc/customizer/custom-controls/responsive-background/class-astra-control-responsive-background.php
@@ -74,6 +74,13 @@ if ( ! class_exists( 'Astra_Control_Responsive_Background' ) && class_exists( 'W
 				$this->json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 			}
 		}
+
+		/**
+		 * Render the control's content.
+		 *
+		 * @see WP_Customize_Control::render_content()
+		 */
+		protected function render_content() {}
 	}
 
 endif;

--- a/inc/customizer/custom-controls/responsive-color/class-astra-control-responsive-color.php
+++ b/inc/customizer/custom-controls/responsive-color/class-astra-control-responsive-color.php
@@ -95,6 +95,13 @@ if ( ! class_exists( 'Astra_Control_Responsive_Color' ) && class_exists( 'WP_Cus
 				$this->json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 			}
 		}
+
+		/**
+		 * Render the control's content.
+		 *
+		 * @see WP_Customize_Control::render_content()
+		 */
+		protected function render_content() {}
 	}
 
 endif;

--- a/inc/customizer/custom-controls/responsive-slider/class-astra-control-responsive-slider.php
+++ b/inc/customizer/custom-controls/responsive-slider/class-astra-control-responsive-slider.php
@@ -72,4 +72,11 @@ class Astra_Control_Responsive_Slider extends WP_Customize_Control {
 			$this->json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 		}
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/responsive-spacing/class-astra-control-responsive-spacing.php
+++ b/inc/customizer/custom-controls/responsive-spacing/class-astra-control-responsive-spacing.php
@@ -112,4 +112,11 @@ class Astra_Control_Responsive_Spacing extends WP_Customize_Control {
 		$this->json['inputAttrs'] = maybe_serialize( $this->input_attrs() );
 
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/responsive/class-astra-control-responsive.php
+++ b/inc/customizer/custom-controls/responsive/class-astra-control-responsive.php
@@ -84,4 +84,11 @@ class Astra_Control_Responsive extends WP_Customize_Control {
 		}
 
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/select/class-astra-control-select.php
+++ b/inc/customizer/custom-controls/select/class-astra-control-select.php
@@ -52,4 +52,11 @@ class Astra_Control_Select extends WP_Customize_Control {
 		$this->json['value'] = $this->value();
 		$this->json['label'] = esc_html( $this->label );
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/settings-group/class-astra-control-settings-group.php
+++ b/inc/customizer/custom-controls/settings-group/class-astra-control-settings-group.php
@@ -100,6 +100,13 @@ if ( ! class_exists( 'Astra_Control_Settings_Group' ) && class_exists( 'WP_Custo
 
 			$this->json['ast_fields'] = $config;
 		}
+
+		/**
+		 * Render the control's content.
+		 *
+		 * @see WP_Customize_Control::render_content()
+		 */
+		protected function render_content() {}
 	}
 
 endif;

--- a/inc/customizer/custom-controls/slider/class-astra-control-slider.php
+++ b/inc/customizer/custom-controls/slider/class-astra-control-slider.php
@@ -60,4 +60,11 @@ class Astra_Control_Slider extends WP_Customize_Control {
 			$this->json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 		}
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/sortable/class-astra-control-sortable.php
+++ b/inc/customizer/custom-controls/sortable/class-astra-control-sortable.php
@@ -53,4 +53,11 @@ class Astra_Control_Sortable extends WP_Customize_Control {
 		$this->json['inputAttrs'] = maybe_serialize( $this->input_attrs() );
 
 	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * @see WP_Customize_Control::render_content()
+	 */
+	protected function render_content() {}
 }

--- a/inc/customizer/custom-controls/typography/class-astra-control-typography.php
+++ b/inc/customizer/custom-controls/typography/class-astra-control-typography.php
@@ -333,13 +333,13 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 
 		</label>
 		<select data-inherit="<?php echo esc_attr( $this->ast_inherit ); ?>" <?php $this->link(); ?> class={{ data.font_type }} data-name={{ data.name }}
-		data-value="{{data.value}}" 
+		data-value="{{data.value}}"
 
 		<# if ( data.connect ) { #>
 			data-connected-control={{ data.connect }}
 		<# } #>
 		<# if ( data.variant ) { #>
-			data-connected-variant="{{data.variant}}"; 
+			data-connected-variant="{{data.variant}}";
 		<# } #>
 
 		>


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fixes: PHP Notice:  Array to string conversion in C:\xampp\htdocs\hf-builder\wp-includes\formatting.php on line 1098

### Screenshots
<!-- if applicable -->
https://a.cl.ly/WnuJrq2Y

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Checked the debug log and now this error no longer exists.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
