### PR TITLE
fix: Astra Heading Control - Issue with & getting escaped.

### DIFF
--- a/inc/customizer/custom-controls/heading/class-astra-control-heading.php
+++ b/inc/customizer/custom-controls/heading/class-astra-control-heading.php
@@ -42,7 +42,7 @@ class Astra_Control_Heading extends WP_Customize_Control {
 	 */
 	public function to_json() {
 		parent::to_json();
-		$this->json['label']       = esc_html( $this->label );
+		$this->json['label']       = $this->label;
 		$this->json['caption']     = $this->caption;
 		$this->json['description'] = $this->description;
 	}


### PR DESCRIPTION
### Description
The `ast-heading` control escaped the label HTML.

### Screenshots
https://a.cl.ly/WnuJ5062

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
https://a.cl.ly/WnuJ5062

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
