### PR TITLE
fix: Astra Typography not working in the Setting group.

### DIFF
--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -612,6 +612,14 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			);
 
 			Astra_Customizer_Control_Base::add_control(
+				'ast-font-variant',
+				array(
+					'callback'          => 'Astra_Control_Font_Variant',
+					'sanitize_callback' => 'sanitize_text_field',
+				)
+			);
+
+			Astra_Customizer_Control_Base::add_control(
 				'number',
 				array(
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number' ),

--- a/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
+++ b/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
@@ -68,28 +68,12 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	public $variant = false;
 
 	/**
-	 * Used to set the mode for code controls.
-	 *
-	 * @since x.x.x
-	 * @var bool $mode
-	 */
-	public $mode = 'html';
-
-	/**
 	 * Used to set the default font options.
 	 *
 	 * @since 1.0.8
 	 * @var string $ast_inherit
 	 */
 	public $ast_inherit = '';
-
-	/**
-	 * If true, the preview button for a control will be rendered.
-	 *
-	 * @since x.x.x
-	 * @var bool $preview_button
-	 */
-	public $preview_button = false;
 
 	/**
 	 * Set the default font options.

--- a/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
+++ b/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
@@ -120,7 +120,6 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 		$this->json['connect']             = $this->connect;
 		$this->json['variant']             = $this->variant;
 		$this->json['link']                = $this->get_link();
-		$this->json['ast_all_font_weight'] = $this->ast_all_font_weight;
 	}
 
 	/**

--- a/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
+++ b/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Customizer Control: typography.
+ * Customizer Control: Variant.
  *
  * @package     Astra
  * @author      Astra
  * @copyright   Copyright (c) 2020, Astra
  * @link        https://wpastra.com/
- * @since       1.0.0
+ * @since       x.x.x
  */
 
 // Exit if accessed directly.
@@ -15,14 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Typography control.
+ * Variant control.
  */
 final class Astra_Control_Font_Variant extends WP_Customize_Control {
 
 	/**
 	 * Used to connect controls to each other.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var bool $connect
 	 */
 	public $connect = false;
@@ -30,7 +30,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Option name.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var string $name
 	 */
 	public $name = '';
@@ -38,7 +38,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Option label.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var string $label
 	 */
 	public $label = '';
@@ -46,7 +46,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Option description.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var string $description
 	 */
 	public $description = '';
@@ -54,7 +54,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Control type.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var string $type
 	 */
 	public $type = 'ast-font-variant';
@@ -70,7 +70,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Used to set the mode for code controls.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var bool $mode
 	 */
 	public $mode = 'html';
@@ -86,7 +86,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * If true, the preview button for a control will be rendered.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 * @var bool $preview_button
 	 */
 	public $preview_button = false;
@@ -94,7 +94,7 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	/**
 	 * Set the default font options.
 	 *
-	 * @since 1.0.8
+	 * @since x.x.x
 	 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
 	 * @param string               $id      Control ID.
 	 * @param array                $args    Default parent's arguments.
@@ -106,7 +106,8 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 
 	/**
 	 * Refresh the parameters passed to the JavaScript via JSON.
-	 *
+	 * 
+	 * @since x.x.x
 	 * @see WP_Customize_Control::to_json()
 	 */
 	public function to_json() {
@@ -123,13 +124,10 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 	}
 
 	/**
-	 * An Underscore (JS) template for this control's content (but not its container).
-	 *
-	 * Class variables for this control class are available in the `data` JS object;
-	 * export custom variables by overriding {@see WP_Customize_Control::to_json()}.
+	 * COntent Template for the Control rendering.
 	 *
 	 * @see WP_Customize_Control::print_template()
-	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function content_template() {

--- a/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
+++ b/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
@@ -113,13 +113,13 @@ final class Astra_Control_Font_Variant extends WP_Customize_Control {
 		
 		parent::to_json();
 
-		$this->json['label']               = esc_html( $this->label );
-		$this->json['description']         = $this->description;
-		$this->json['name']                = $this->name;
-		$this->json['value']               = $this->value();
-		$this->json['connect']             = $this->connect;
-		$this->json['variant']             = $this->variant;
-		$this->json['link']                = $this->get_link();
+		$this->json['label']       = esc_html( $this->label );
+		$this->json['description'] = $this->description;
+		$this->json['name']        = $this->name;
+		$this->json['value']       = $this->value();
+		$this->json['connect']     = $this->connect;
+		$this->json['variant']     = $this->variant;
+		$this->json['link']        = $this->get_link();
 	}
 
 	/**

--- a/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
+++ b/inc/customizer/custom-controls/font-variant/class-astra-control-font-variant.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Customizer Control: typography.
+ *
+ * @package     Astra
+ * @author      Astra
+ * @copyright   Copyright (c) 2020, Astra
+ * @link        https://wpastra.com/
+ * @since       1.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Typography control.
+ */
+final class Astra_Control_Font_Variant extends WP_Customize_Control {
+
+	/**
+	 * Used to connect controls to each other.
+	 *
+	 * @since 1.0.0
+	 * @var bool $connect
+	 */
+	public $connect = false;
+
+	/**
+	 * Option name.
+	 *
+	 * @since 1.0.0
+	 * @var string $name
+	 */
+	public $name = '';
+
+	/**
+	 * Option label.
+	 *
+	 * @since 1.0.0
+	 * @var string $label
+	 */
+	public $label = '';
+
+	/**
+	 * Option description.
+	 *
+	 * @since 1.0.0
+	 * @var string $description
+	 */
+	public $description = '';
+
+	/**
+	 * Control type.
+	 *
+	 * @since 1.0.0
+	 * @var string $type
+	 */
+	public $type = 'ast-font-variant';
+
+	/**
+	 * Used to connect variant controls to each other.
+	 *
+	 * @since 1.5.2
+	 * @var bool $variant
+	 */
+	public $variant = false;
+
+	/**
+	 * Used to set the mode for code controls.
+	 *
+	 * @since 1.0.0
+	 * @var bool $mode
+	 */
+	public $mode = 'html';
+
+	/**
+	 * Used to set the default font options.
+	 *
+	 * @since 1.0.8
+	 * @var string $ast_inherit
+	 */
+	public $ast_inherit = '';
+
+	/**
+	 * If true, the preview button for a control will be rendered.
+	 *
+	 * @since 1.0.0
+	 * @var bool $preview_button
+	 */
+	public $preview_button = false;
+
+	/**
+	 * Set the default font options.
+	 *
+	 * @since 1.0.8
+	 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
+	 * @param string               $id      Control ID.
+	 * @param array                $args    Default parent's arguments.
+	 */
+	public function __construct( $manager, $id, $args = array() ) {
+		$this->ast_inherit = __( 'Inherit', 'astra' );
+		parent::__construct( $manager, $id, $args );
+	}
+
+	/**
+	 * Refresh the parameters passed to the JavaScript via JSON.
+	 *
+	 * @see WP_Customize_Control::to_json()
+	 */
+	public function to_json() {
+		
+		parent::to_json();
+
+		$this->json['label']               = esc_html( $this->label );
+		$this->json['description']         = $this->description;
+		$this->json['name']                = $this->name;
+		$this->json['value']               = $this->value();
+		$this->json['connect']             = $this->connect;
+		$this->json['variant']             = $this->variant;
+		$this->json['link']                = $this->get_link();
+		$this->json['ast_all_font_weight'] = $this->ast_all_font_weight;
+	}
+
+	/**
+	 * An Underscore (JS) template for this control's content (but not its container).
+	 *
+	 * Class variables for this control class are available in the `data` JS object;
+	 * export custom variables by overriding {@see WP_Customize_Control::to_json()}.
+	 *
+	 * @see WP_Customize_Control::print_template()
+	 *
+	 * @access protected
+	 */
+	protected function content_template() {
+
+		?>
+
+		<label>
+		<# if ( data.label ) { #>
+			<span class="customize-control-title">{{{data.label}}}</span>
+		<# } #>
+		<# if ( data.description ) { #>
+			<span class="description customize-control-description">{{{data.description}}}</span>
+		<# } #>
+
+		</label>
+		<select data-inherit="<?php echo esc_attr( $this->ast_inherit ); ?>" <?php $this->link(); ?>  multiple data-name={{ data.name }}
+		data-value="{{data.value}}" 
+
+		<# if ( data.connect ) { #>
+			data-connected-control={{ data.connect }}
+		<# } #>
+		<# if ( data.variant ) { #>
+			data-connected-variant="{{data.variant}}"; 
+		<# } #>
+
+		>
+		<?php 
+			$values = explode( ',', $this->value() );
+		foreach ( $values as $key => $value ) {
+			echo '<option value="' . esc_attr( $value ) . '" selected="selected" >' . esc_html( $value ) . '</option>';
+		}
+		?>
+		<input class="ast-font-variant-hidden-value" type="hidden" value="{{data.value}}">
+		</select>
+		<span class="ast-control-tooltip dashicons dashicons-editor-help ast-variant-description" title="<?php esc_html_e( 'Only selected Font Variants will be loaded from Google Fonts.', 'astra' ); ?>"></span>
+		<?php 
+		
+	}
+}

--- a/inc/customizer/custom-controls/typography/class-astra-control-typography.php
+++ b/inc/customizer/custom-controls/typography/class-astra-control-typography.php
@@ -239,13 +239,13 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 		
 		parent::to_json();
 
-		$this->json['label']       = esc_html( $this->label );
-		$this->json['description'] = $this->description;
-		$this->json['name']        = $this->name;
-		$this->json['value']       = $this->value();
-		$this->json['connect']     = $this->connect;
-		$this->json['variant']     = $this->variant;
-		$this->json['link']		   = $this->get_link();
+		$this->json['label']               = esc_html( $this->label );
+		$this->json['description']         = $this->description;
+		$this->json['name']                = $this->name;
+		$this->json['value']               = $this->value();
+		$this->json['connect']             = $this->connect;
+		$this->json['variant']             = $this->variant;
+		$this->json['link']                = $this->get_link();
 		$this->json['ast_all_font_weight'] = $this->ast_all_font_weight;
 	}
 

--- a/inc/customizer/custom-controls/typography/class-astra-control-typography.php
+++ b/inc/customizer/custom-controls/typography/class-astra-control-typography.php
@@ -84,14 +84,6 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 	public $ast_inherit = '';
 
 	/**
-	 * All font weights
-	 *
-	 * @since 1.0.8
-	 * @var string $ast_inherit
-	 */
-	public $ast_all_font_weight = array();
-
-	/**
 	 * If true, the preview button for a control will be rendered.
 	 *
 	 * @since 1.0.0
@@ -108,126 +100,8 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 	 * @param array                $args    Default parent's arguments.
 	 */
 	public function __construct( $manager, $id, $args = array() ) {
-		$this->ast_inherit         = __( 'Inherit', 'astra' );
-		$this->ast_all_font_weight = array(
-			'100'       => __( 'Thin 100', 'astra' ),
-			'100italic' => __( '100 Italic', 'astra' ),
-			'200'       => __( 'Extra-Light 200', 'astra' ),
-			'200italic' => __( '200 Italic', 'astra' ),
-			'300'       => __( 'Light 300', 'astra' ),
-			'300italic' => __( '300 Italic', 'astra' ),
-			'400'       => __( 'Normal 400', 'astra' ),
-			'italic'    => __( '400 Italic', 'astra' ),
-			'500'       => __( 'Medium 500', 'astra' ),
-			'500italic' => __( '500 Italic', 'astra' ),
-			'600'       => __( 'Semi-Bold 600', 'astra' ),
-			'600italic' => __( '600 Italic', 'astra' ),
-			'700'       => __( 'Bold 700', 'astra' ),
-			'700italic' => __( '700 Italic', 'astra' ),
-			'800'       => __( 'Extra-Bold 800', 'astra' ),
-			'800italic' => __( '800 Italic', 'astra' ),
-			'900'       => __( 'Ultra-Bold 900', 'astra' ),
-			'900italic' => __( '900 Italic', 'astra' ),
-		);
+		$this->ast_inherit = __( 'Inherit', 'astra' );
 		parent::__construct( $manager, $id, $args );
-	}
-
-	/**
-	 * Renders the content for a control based on the type
-	 * of control specified when this class is initialized.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 * @return void
-	 */
-	protected function render_content() {
-
-		switch ( $this->type ) {
-
-			case 'ast-font-variant':
-				$this->render_font_variant( $this->ast_inherit );
-				break;
-		}
-	}
-
-	/**
-	 * Enqueue control related scripts/styles.
-	 *
-	 * @access public
-	 */
-	public function enqueue() {
-
-		$js_uri  = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
-		$css_uri = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
-		$js_uri  = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
-		wp_enqueue_style( 'astra-select-woo-style', $css_uri . 'selectWoo.css', null, ASTRA_THEME_VERSION );
-		wp_enqueue_script( 'astra-select-woo-script', $js_uri . 'selectWoo.js', array( 'jquery' ), ASTRA_THEME_VERSION, true );
-
-		wp_enqueue_script( 'astra-typography', $js_uri . 'typography.js', array( 'jquery', 'customize-base' ), ASTRA_THEME_VERSION, true );
-		$astra_typo_localize = $this->ast_all_font_weight;
-
-		wp_localize_script( 'astra-typography', 'astraTypo', $astra_typo_localize );
-	}
-	/**
-	 * Renders the title and description for a control.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 * @return void
-	 */
-	protected function render_content_title() {
-		if ( ! empty( $this->label ) ) {
-			echo '<span class="customize-control-title">' . esc_html( $this->label ) . '</span>';
-		}
-		if ( ! empty( $this->description ) ) {
-			echo '<span class="description customize-control-description">' . esc_html( $this->description ) . '</span>';
-		}
-	}
-
-	/**
-	 * Renders the connect attribute for a connected control.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 * @return void
-	 */
-	protected function render_connect_attribute() {
-		if ( $this->connect ) {
-			echo ' data-connected-control="' . esc_attr( $this->connect ) . '"';
-			echo ' data-inherit="' . esc_attr( $this->ast_inherit ) . '"';
-		}
-		if ( $this->variant ) {
-			echo ' data-connected-variant="' . esc_attr( $this->variant ) . '"';
-			echo ' data-inherit="' . esc_attr( $this->ast_inherit ) . '"';
-		}
-
-		echo ' data-value="' . esc_attr( $this->value() ) . '"';
-		echo ' data-name="' . esc_attr( $this->name ) . '"';
-	}
-	
-	/**
-	 * Renders a font variant control.
-	 *
-	 * @since 1.5.2
-	 * @param  string $default Inherit/Default.
-	 * @access protected
-	 * @return void
-	 */
-	protected function render_font_variant( $default ) {
-		echo '<label>';
-		$this->render_content_title();
-		echo '</label>';
-		echo '<select ';
-		$this->link();
-		$this->render_connect_attribute();
-		echo ' multiple >';
-		$values = explode( ',', $this->value() );
-		foreach ( $values as $key => $value ) {
-			echo '<option value="' . esc_attr( $value ) . '" selected="selected" >' . esc_html( $value ) . '</option>';
-		}
-		echo '<input class="ast-font-variant-hidden-value" type="hidden" value="' . esc_attr( $this->value() ) . '">';
-		echo '</select>';
-		echo '<span class="ast-control-tooltip dashicons dashicons-editor-help ast-variant-description" title="Only selected Font Variants will be loaded from Google Fonts."></span>';
 	}
 
 	/**
@@ -239,14 +113,13 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 		
 		parent::to_json();
 
-		$this->json['label']               = esc_html( $this->label );
-		$this->json['description']         = $this->description;
-		$this->json['name']                = $this->name;
-		$this->json['value']               = $this->value();
-		$this->json['connect']             = $this->connect;
-		$this->json['variant']             = $this->variant;
-		$this->json['link']                = $this->get_link();
-		$this->json['ast_all_font_weight'] = $this->ast_all_font_weight;
+		$this->json['label']       = esc_html( $this->label );
+		$this->json['description'] = $this->description;
+		$this->json['name']        = $this->name;
+		$this->json['value']       = $this->value();
+		$this->json['connect']     = $this->connect;
+		$this->json['variant']     = $this->variant;
+		$this->json['link']        = $this->get_link();
 	}
 
 	/**

--- a/inc/customizer/custom-controls/typography/class-astra-control-typography.php
+++ b/inc/customizer/custom-controls/typography/class-astra-control-typography.php
@@ -57,7 +57,7 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 	 * @since 1.0.0
 	 * @var string $type
 	 */
-	public $type = 'ast-font-variant';
+	public $type = 'ast-font';
 
 	/**
 	 * Used to connect variant controls to each other.
@@ -84,6 +84,14 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 	public $ast_inherit = '';
 
 	/**
+	 * All font weights
+	 *
+	 * @since 1.0.8
+	 * @var string $ast_inherit
+	 */
+	public $ast_all_font_weight = array();
+
+	/**
 	 * If true, the preview button for a control will be rendered.
 	 *
 	 * @since 1.0.0
@@ -100,8 +108,126 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 	 * @param array                $args    Default parent's arguments.
 	 */
 	public function __construct( $manager, $id, $args = array() ) {
-		$this->ast_inherit = __( 'Inherit', 'astra' );
+		$this->ast_inherit         = __( 'Inherit', 'astra' );
+		$this->ast_all_font_weight = array(
+			'100'       => __( 'Thin 100', 'astra' ),
+			'100italic' => __( '100 Italic', 'astra' ),
+			'200'       => __( 'Extra-Light 200', 'astra' ),
+			'200italic' => __( '200 Italic', 'astra' ),
+			'300'       => __( 'Light 300', 'astra' ),
+			'300italic' => __( '300 Italic', 'astra' ),
+			'400'       => __( 'Normal 400', 'astra' ),
+			'italic'    => __( '400 Italic', 'astra' ),
+			'500'       => __( 'Medium 500', 'astra' ),
+			'500italic' => __( '500 Italic', 'astra' ),
+			'600'       => __( 'Semi-Bold 600', 'astra' ),
+			'600italic' => __( '600 Italic', 'astra' ),
+			'700'       => __( 'Bold 700', 'astra' ),
+			'700italic' => __( '700 Italic', 'astra' ),
+			'800'       => __( 'Extra-Bold 800', 'astra' ),
+			'800italic' => __( '800 Italic', 'astra' ),
+			'900'       => __( 'Ultra-Bold 900', 'astra' ),
+			'900italic' => __( '900 Italic', 'astra' ),
+		);
 		parent::__construct( $manager, $id, $args );
+	}
+
+	/**
+	 * Renders the content for a control based on the type
+	 * of control specified when this class is initialized.
+	 *
+	 * @since 1.0.0
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_content() {
+
+		switch ( $this->type ) {
+
+			case 'ast-font-variant':
+				$this->render_font_variant( $this->ast_inherit );
+				break;
+		}
+	}
+
+	/**
+	 * Enqueue control related scripts/styles.
+	 *
+	 * @access public
+	 */
+	public function enqueue() {
+
+		$js_uri  = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
+		$css_uri = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
+		$js_uri  = ASTRA_THEME_URI . 'inc/customizer/custom-controls/typography/';
+		wp_enqueue_style( 'astra-select-woo-style', $css_uri . 'selectWoo.css', null, ASTRA_THEME_VERSION );
+		wp_enqueue_script( 'astra-select-woo-script', $js_uri . 'selectWoo.js', array( 'jquery' ), ASTRA_THEME_VERSION, true );
+
+		wp_enqueue_script( 'astra-typography', $js_uri . 'typography.js', array( 'jquery', 'customize-base' ), ASTRA_THEME_VERSION, true );
+		$astra_typo_localize = $this->ast_all_font_weight;
+
+		wp_localize_script( 'astra-typography', 'astraTypo', $astra_typo_localize );
+	}
+	/**
+	 * Renders the title and description for a control.
+	 *
+	 * @since 1.0.0
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_content_title() {
+		if ( ! empty( $this->label ) ) {
+			echo '<span class="customize-control-title">' . esc_html( $this->label ) . '</span>';
+		}
+		if ( ! empty( $this->description ) ) {
+			echo '<span class="description customize-control-description">' . esc_html( $this->description ) . '</span>';
+		}
+	}
+
+	/**
+	 * Renders the connect attribute for a connected control.
+	 *
+	 * @since 1.0.0
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_connect_attribute() {
+		if ( $this->connect ) {
+			echo ' data-connected-control="' . esc_attr( $this->connect ) . '"';
+			echo ' data-inherit="' . esc_attr( $this->ast_inherit ) . '"';
+		}
+		if ( $this->variant ) {
+			echo ' data-connected-variant="' . esc_attr( $this->variant ) . '"';
+			echo ' data-inherit="' . esc_attr( $this->ast_inherit ) . '"';
+		}
+
+		echo ' data-value="' . esc_attr( $this->value() ) . '"';
+		echo ' data-name="' . esc_attr( $this->name ) . '"';
+	}
+	
+	/**
+	 * Renders a font variant control.
+	 *
+	 * @since 1.5.2
+	 * @param  string $default Inherit/Default.
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_font_variant( $default ) {
+		echo '<label>';
+		$this->render_content_title();
+		echo '</label>';
+		echo '<select ';
+		$this->link();
+		$this->render_connect_attribute();
+		echo ' multiple >';
+		$values = explode( ',', $this->value() );
+		foreach ( $values as $key => $value ) {
+			echo '<option value="' . esc_attr( $value ) . '" selected="selected" >' . esc_html( $value ) . '</option>';
+		}
+		echo '<input class="ast-font-variant-hidden-value" type="hidden" value="' . esc_attr( $this->value() ) . '">';
+		echo '</select>';
+		echo '<span class="ast-control-tooltip dashicons dashicons-editor-help ast-variant-description" title="Only selected Font Variants will be loaded from Google Fonts."></span>';
 	}
 
 	/**
@@ -113,13 +239,13 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 		
 		parent::to_json();
 
-		$this->json['label']               = esc_html( $this->label );
-		$this->json['description']         = $this->description;
-		$this->json['name']                = $this->name;
-		$this->json['value']               = $this->value();
-		$this->json['connect']             = $this->connect;
-		$this->json['variant']             = $this->variant;
-		$this->json['link']                = $this->get_link();
+		$this->json['label']       = esc_html( $this->label );
+		$this->json['description'] = $this->description;
+		$this->json['name']        = $this->name;
+		$this->json['value']       = $this->value();
+		$this->json['connect']     = $this->connect;
+		$this->json['variant']     = $this->variant;
+		$this->json['link']		   = $this->get_link();
 		$this->json['ast_all_font_weight'] = $this->ast_all_font_weight;
 	}
 
@@ -141,12 +267,9 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 		<# if ( data.label ) { #>
 			<span class="customize-control-title">{{{data.label}}}</span>
 		<# } #>
-		<# if ( data.description ) { #>
-			<span class="description customize-control-description">{{{data.description}}}</span>
-		<# } #>
 
 		</label>
-		<select data-inherit="<?php echo esc_attr( $this->ast_inherit ); ?>" <?php $this->link(); ?>  multiple data-name={{ data.name }}
+		<select data-inherit="<?php echo esc_attr( $this->ast_inherit ); ?>" <?php $this->link(); ?> class={{ data.font_type }} data-name={{ data.name }}
 		data-value="{{data.value}}" 
 
 		<# if ( data.connect ) { #>
@@ -157,16 +280,8 @@ final class Astra_Control_Typography extends WP_Customize_Control {
 		<# } #>
 
 		>
-		<?php 
-			$values = explode( ',', $this->value() );
-		foreach ( $values as $key => $value ) {
-			echo '<option value="' . esc_attr( $value ) . '" selected="selected" >' . esc_html( $value ) . '</option>';
-		}
-		?>
-		<input class="ast-font-variant-hidden-value" type="hidden" value="{{data.value}}">
 		</select>
-		<span class="ast-control-tooltip dashicons dashicons-editor-help ast-variant-description" title="<?php esc_html_e( 'Only selected Font Variants will be loaded from Google Fonts.', 'astra' ); ?>"></span>
-		<?php 
-		
+
+		<?php
 	}
 }

--- a/inc/customizer/customizer-controls.php
+++ b/inc/customizer/customizer-controls.php
@@ -23,6 +23,7 @@ require $control_dir . '/slider/class-astra-control-slider.php';
 require $control_dir . '/responsive-slider/class-astra-control-responsive-slider.php';
 require $control_dir . '/responsive/class-astra-control-responsive.php';
 require $control_dir . '/typography/class-astra-control-typography.php';
+require $control_dir . '/font-variant/class-astra-control-font-variant.php';
 require $control_dir . '/responsive-spacing/class-astra-control-responsive-spacing.php';
 require $control_dir . '/divider/class-astra-control-divider.php';
 require $control_dir . '/heading/class-astra-control-heading.php';


### PR DESCRIPTION
### Description
 - When we open the Settings Group popup containing Typography settings it does not open.

### Types of changes
 Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
 - Check Typography settings in Popup are working or not.
 - Check Typography settings out of Popup are working or not.
 - Check Font Variant control working or not.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
