### PR TITLE
fix: First drag-dropped component not previewing correctly

### DIFF
--- a/inc/builder/type/footer/social-icon/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/social-icon/dynamic-css/dynamic.css.php
@@ -26,7 +26,7 @@ add_filter( 'astra_dynamic_theme_css', 'astra_fb_social_icon_dynamic_css' );
  */
 function astra_fb_social_icon_dynamic_css( $dynamic_css, $dynamic_css_filtered = '' ) {
 
-	if ( ! Astra_Builder_Helper::is_component_loaded( 'header', 'social' ) ) {
+	if ( ! Astra_Builder_Helper::is_component_loaded( 'footer', 'social' ) ) {
 		return $dynamic_css;
 	}
 

--- a/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
@@ -28,6 +28,10 @@ function astra_fb_widget_dynamic_css( $dynamic_css, $dynamic_css_filtered = '' )
 
 	for ( $index = 1; $index <= Astra_Constants::$num_of_footer_widgets; $index++ ) {
 
+		if ( ! Astra_Builder_Helper::is_component_loaded( 'footer', 'widget-' . $index ) ) {
+			continue;
+		}
+
 		$_section = 'sidebar-widgets-footer-widget-' . $index;
 		$selector = '.footer-widget-area[data-section="sidebar-widgets-footer-widget-' . $index . '"]';
 

--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -365,7 +365,7 @@ if ( ! class_exists( 'Astra_Builder_Helper' ) ) {
 
 			$loaded_components = self::$loaded_grid;
 
-			return in_array( $component_id, $loaded_components, true );
+			return in_array( $component_id, $loaded_components, true ) || is_customize_preview();
 		}
 	}
 

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-copyright-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-copyright-configs.php
@@ -98,8 +98,8 @@ class Astra_Customizer_Copyright_Configs extends Astra_Customizer_Config_Base {
 				'title'     => __( 'Alignment', 'astra' ),
 				'choices'   => array(
 					'left'   => __( 'Left', 'astra' ),
-					'right'  => __( 'Right', 'astra' ),
 					'center' => __( 'Center', 'astra' ),
+					'right'  => __( 'Right', 'astra' ),
 				),
 				'context'   => Astra_Constants::$general_tab,
 				'transport' => 'postMessage',

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-social-icons-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-social-icons-configs.php
@@ -52,8 +52,8 @@ class Astra_Customizer_Footer_Social_Icons_Configs extends Astra_Customizer_Conf
 				'title'     => __( 'Alignment', 'astra' ),
 				'choices'   => array(
 					'left'   => __( 'Left', 'astra' ),
-					'right'  => __( 'Right', 'astra' ),
 					'center' => __( 'Center', 'astra' ),
+					'right'  => __( 'Right', 'astra' ),
 				),
 				'context'   => Astra_Constants::$general_tab,
 				'transport' => 'postMessage',

--- a/inc/customizer/configurations/builder/footer/class-astra-footer-widget-component-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-footer-widget-component-configs.php
@@ -78,8 +78,8 @@ class Astra_Footer_Widget_Component_Configs extends Astra_Customizer_Config_Base
 					'title'     => __( 'Alignment', 'astra' ),
 					'choices'   => array(
 						'left'   => __( 'Left', 'astra' ),
-						'right'  => __( 'Right', 'astra' ),
 						'center' => __( 'Center', 'astra' ),
+						'right'  => __( 'Right', 'astra' ),
 					),
 					'transport' => 'postMessage',
 					'context'   => Astra_Constants::$general_tab,


### PR DESCRIPTION
### Description
- First, drag-dropped not shows preview correctly unless & until we Publish the customizer & reload it
- Corrected Builder type for Footer Social component
- Maintained Left | Center | Right alignment sequence as it should look like normally

### Screenshots
- Example with Footer HTML - 2
- PS: When firstly it dragged & dropped alignment is Center but till customizer refresh (partial refresh) it does not reflect as expected
- https://a.cl.ly/mXuyezdk

### Types of changes
- Adde a small `is_customize_preview` check in `is_component_loaded` function.

### How has this been tested?
- With any Header / Footer component
- Verification in customizer preview 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
