### PR TITLE
refactor: Removed advanced search configs from theme & added in addon.

### DIFF
--- a/inc/customizer/configurations/builder/header/class-astra-header-search-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-header-search-component-configs.php
@@ -137,40 +137,7 @@ class Astra_Header_Search_Component_Configs extends Astra_Customizer_Config_Base
 				'context'        => Astra_Constants::$design_tab,
 			),
 		);
-
-		if ( $is_astra_addon_active ) {
-			/**
-			 * Option: Pro Search Bar Configs.
-			 */
-			$_addon_dependent_configs = array(
-				// Option: Header Search Style.
-				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[header-search-box-type]',
-					'default'   => $defaults['header-search-box-type'],
-					'section'   => $_section,
-					'priority'  => 10,
-					'title'     => __( 'Search Style', 'astra' ),
-					'type'      => 'control',
-					'control'   => 'select',
-					'choices'   => array(
-						'slide-search' => __( 'Slide Search', 'astra' ),
-						'full-screen'  => __( 'Full Screen Search', 'astra' ),
-						'header-cover' => __( 'Header Cover Search', 'astra' ),
-						'search-box'   => __( 'Search Box', 'astra' ),
-					),
-					'context'   => Astra_Constants::$general_tab,
-					'transport' => 'postMessage',
-					'partial'   => array(
-						'selector'            => '.ast-header-search',
-						'container_inclusive' => false,
-						'render_callback'     => array( 'Astra_Builder_Header', 'header_search' ),
-					),
-				),
-			);
-
-			$_configs = array_merge( $_configs, $_addon_dependent_configs );
-		}
-
+		
 		return array_merge( $configurations, $_configs );
 	}
 }


### PR DESCRIPTION
### Description
Removed advanced search configs from theme & added in the addon.

### Types of changes
 - New feature (non-breaking change which adds functionality

### How has this been tested?
 - The Search style options appear only when the addon is active.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
