### PR TITLE
fix: Inherit button styling from theme instead of defaults.

### DIFF
--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -1123,12 +1123,5 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 		);
 	}
 
-
-	// Button defaults.
-	for ( $index = 1; $index <= Astra_Constants::$num_of_header_button; $index++ ) {
-
-		$defaults[ 'header-button' . $index . '-border-radius' ] = 0;
-	}
-
 	return $defaults;
 }


### PR DESCRIPTION
### Description
This removes the default values set for Button.
Ideally, the button should inherit all the default styling from global options.


### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
