### PR TITLE
fix: conflict with Gutenberg plugin.

### DIFF
--- a/inc/customizer/custom-controls/class-astra-customizer-control-base.php
+++ b/inc/customizer/custom-controls/class-astra-customizer-control-base.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'Astra_Customizer_Control_Base' ) ) {
 		 */
 		public function __construct() {
 
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		}
 
 		/**


### PR DESCRIPTION
### Description
The issue is because of this filter -

remove_filter( 'customize_loaded_components', 'gutenberg_remove_widgets_panel' );

Conflict with -
add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );

 I have used the 'customize_controls_enqueue_scripts' action to enqueue the scripts in the customizer.
ref: https://codex.wordpress.org/Plugin_API/Action_Reference/customize_controls_enqueue_scripts

### Types of changes

<!-- Bug fix (non-breaking change which fixes an issue) -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

Checked with the latest version of Gutenberg plugin.
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
