### PR TITLE
fix: Desktop to mobile layout change does not change the markup & partial refresh issue.

### DIFF
--- a/inc/assets/js/navigation.js
+++ b/inc/assets/js/navigation.js
@@ -299,16 +299,21 @@ var astraTriggerEvent = function astraTriggerEvent( el, typeArg ) {
 		init();
 	} );
 
-	if ( 'dropdown' === mobileHeaderType ) {
+	window.addEventListener('resize', function () {
 		
-		window.addEventListener('resize', function () {
-			// Skip resize event when keyboard display event triggers on devices.
-			if( 'INPUT' !== document.activeElement.tagName ) {
-				updateHeaderBreakPoint();
+		document.getElementById('menu-toggle-close').click();
+		// Skip resize event when keyboard display event triggers on devices.
+		if( 'INPUT' !== document.activeElement.tagName ) {
+			
+			updateHeaderBreakPoint();
+			if ( 'dropdown' === mobileHeaderType ) {
 				AstraToggleSetup();
 			}
-		});
+		}
+	});
 
+	if ( 'dropdown' === mobileHeaderType ) {
+		
 		document.addEventListener('DOMContentLoaded', function () {
 			AstraToggleSetup();
 			/**

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-header-builder-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-header-builder-configs.php
@@ -208,7 +208,7 @@ class Astra_Customizer_Header_Builder_Configs extends Astra_Customizer_Config_Ba
 				'choices'         => self::$header_desktop_items,
 				'transport'       => 'postMessage',
 				'partial'         => array(
-					'selector'            => '#masthead',
+					'selector'            => '#ast-desktop-header',
 					'container_inclusive' => false,
 					'render_callback'     => array( Astra_Builder_Header::get_instance(), 'header_builder_markup' ),
 				),
@@ -292,8 +292,8 @@ class Astra_Customizer_Header_Builder_Configs extends Astra_Customizer_Config_Ba
 				'choices'         => self::$header_mobile_items,
 				'transport'       => 'postMessage',
 				'partial'         => array(
-					'selector'            => '#masthead',
-					'container_inclusive' => false,
+					'selector'            => '#ast-mobile-header',
+					'container_inclusive' => true,
 					'render_callback'     => array( 'Astra_Builder_Header', 'mobile_header' ),
 				),
 				'input_attrs'     => array(

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-header-builder-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-header-builder-configs.php
@@ -293,7 +293,7 @@ class Astra_Customizer_Header_Builder_Configs extends Astra_Customizer_Config_Ba
 				'transport'       => 'postMessage',
 				'partial'         => array(
 					'selector'            => '#ast-mobile-header',
-					'container_inclusive' => true,
+					'container_inclusive' => false,
 					'render_callback'     => array( 'Astra_Builder_Header', 'mobile_header' ),
 				),
 				'input_attrs'     => array(


### PR DESCRIPTION
### Description
 - Desktop to mobile layout change does not change the markup & partial refresh issue.

### Screenshots
 - https://a.cl.ly/YEuyNX0r

### Types of changes
Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
 - Check Off-Canvas & Dropdown working or not.
 - Check by changing devices in customizer if the proper markup loads or not.
 - Check by triggering the partial refresh.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
