### PR TITLE
fix: Line height issue for Above/below/Primary header.

### DIFF
--- a/inc/builder/type/header/above-header/assets/js/customizer-preview.js
+++ b/inc/builder/type/header/above-header/assets/js/customizer-preview.js
@@ -18,14 +18,6 @@
 		'px'
 	);
 
-	// Header Line Height.
-	astra_css(
-		'astra-settings[hba-header-height]',
-		'line-height',
-		'.ast-above-header-bar',
-		'px'
-	);
-
 	// Border Bottom width.
 	astra_css(
 		'astra-settings[hba-header-separator]',

--- a/inc/builder/type/header/above-header/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/above-header/dynamic-css/dynamic.css.php
@@ -48,7 +48,6 @@ function astra_above_header_row_setting( $dynamic_css, $dynamic_css_filtered = '
 	$common_css_output = array(
 		'.ast-above-header-bar' => array(
 			'min-height'          => astra_get_css_value( $hba_header_height, 'px' ),
-			'line-height'         => astra_get_css_value( $hba_header_height, 'px' ),
 			'border-bottom-width' => astra_get_css_value( $hba_header_divider, 'px' ),
 			'border-bottom-color' => esc_attr( $hba_border_color ),
 			'border-bottom-style' => 'solid',

--- a/inc/builder/type/header/below-header/assets/js/customizer-preview.js
+++ b/inc/builder/type/header/below-header/assets/js/customizer-preview.js
@@ -18,14 +18,6 @@
 		'px'
 	);
 
-	// Header Line Height.
-	astra_css(
-		'astra-settings[hbb-header-height]',
-		'line-height',
-		'.ast-below-header-bar',
-		'px'
-	);
-
 	// Border Bottom width.
 	astra_css(
 		'astra-settings[hbb-header-separator]',

--- a/inc/builder/type/header/below-header/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/below-header/dynamic-css/dynamic.css.php
@@ -49,7 +49,6 @@ function astra_below_header_row_setting( $dynamic_css, $dynamic_css_filtered = '
 	$common_css_output = array(
 		'.ast-below-header-bar' => array(
 			'min-height'          => $hbb_header_height,
-			'line-height'         => $hbb_header_height,
 			'border-bottom-width' => astra_get_css_value( $hbb_header_divider, 'px' ),
 			'border-bottom-color' => esc_attr( $hbb_border_color ),
 			'border-bottom-style' => 'solid',

--- a/inc/builder/type/header/primary-header/assets/js/customizer-preview.js
+++ b/inc/builder/type/header/primary-header/assets/js/customizer-preview.js
@@ -18,14 +18,6 @@
 		'px'
 	);
 
-	// Header Line Height.
-	astra_css(
-		'astra-settings[hb-header-height]',
-		'line-height',
-		'.ast-primary-header-bar, .ast-mobile-header-wrap .ast-builder-grid-row-container-inner',
-		'px'
-	);
-
 	// Primary Header - Layout > Content Width.
 	wp.customize( 'astra-settings[hb-header-main-layout-width]', function( setting ) {
 		setting.bind( function( layout ) {

--- a/inc/builder/type/header/primary-header/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/primary-header/dynamic-css/dynamic.css.php
@@ -33,8 +33,7 @@ function astra_primary_header_breakpoint_style( $dynamic_css, $dynamic_css_filte
 
 	$common_css_output = array(
 		'.ast-primary-header-bar, .ast-mobile-header-wrap .ast-builder-grid-row-container-inner' => array(
-			'min-height'  => astra_get_css_value( $hb_header_height, 'px' ),
-			'line-height' => astra_get_css_value( $hb_header_height, 'px' ),
+			'min-height' => astra_get_css_value( $hb_header_height, 'px' ),
 		),
 	);
 


### PR DESCRIPTION
### Description
Line height issue for Above/below/Primary header.

### Screenshots
https://share.getcloudapp.com/L1uQ5B4j

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
