### PR TITLE
fix: BG color not working after migration

### DIFF
--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -357,6 +357,8 @@ if ( ! function_exists( 'astra_get_background_obj' ) ) {
 				default:
 					break;
 			}
+		} elseif ( '' !== $bg_color ) {
+			$gen_bg_css['background-color'] = $bg_color . ';';
 		}
 
 		if ( '' !== $bg_img ) {
@@ -1414,7 +1416,6 @@ function astra_get_db_option( $option, $default = '', $deprecated = '' ) {
  */
 function astra_get_responsive_background_obj( $bg_obj_res, $device ) {
 
-
 	$gen_bg_css = array();
 
 	if ( ! is_array( $bg_obj_res ) ) {
@@ -1476,6 +1477,7 @@ function astra_get_responsive_background_obj( $bg_obj_res, $device ) {
 	} elseif ( '' !== $bg_color ) {
 		$gen_bg_css['background-color'] = $bg_color . ';';
 	}
+
 	if ( '' !== $bg_img ) {
 		if ( isset( $bg_obj['background-repeat'] ) ) {
 			$gen_bg_css['background-repeat'] = esc_attr( $bg_obj['background-repeat'] );

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1414,6 +1414,7 @@ function astra_get_db_option( $option, $default = '', $deprecated = '' ) {
  */
 function astra_get_responsive_background_obj( $bg_obj_res, $device ) {
 
+
 	$gen_bg_css = array();
 
 	if ( ! is_array( $bg_obj_res ) ) {
@@ -1472,6 +1473,8 @@ function astra_get_responsive_background_obj( $bg_obj_res, $device ) {
 			default:
 				break;
 		}
+	} elseif ( '' !== $bg_color ) {
+		$gen_bg_css['background-color'] = $bg_color . ';';
 	}
 	if ( '' !== $bg_img ) {
 		if ( isset( $bg_obj['background-repeat'] ) ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
fix: BG color not working after migration
Task - https://trello.com/c/sB8IdROf/213-bg-not-working-when-set-as-color-and-migrated-to-react-based-customizer

### Screenshots
<!-- if applicable -->
Before: https://d.pr/i/CbR2Gq
After: https://d.pr/i/CIhrtJ

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Logic for BG color CSS generation improved.