### PR TITLE
refactor: Allows 10 elements to be added via filter to avoid load on customizer.

### DIFF
--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -519,6 +519,25 @@ final class Astra_Builder_Helper {
 			)
 		);
 
+		// Buttons.
+		$component_keys_count['header-button'] = ( 10 >= $component_keys_count['header-button'] ) ? $component_keys_count['header-button'] : 10;
+		$component_keys_count['footer-button'] = ( 10 >= $component_keys_count['footer-button'] ) ? $component_keys_count['footer-button'] : 10;
+
+		// HTML.
+		$component_keys_count['header-html'] = ( 10 >= $component_keys_count['header-html'] ) ? $component_keys_count['header-html'] : 10;
+		$component_keys_count['footer-html'] = ( 10 >= $component_keys_count['footer-html'] ) ? $component_keys_count['footer-html'] : 10;
+
+		// Header Menu.
+		$component_keys_count['header-menu'] = ( 5 >= $component_keys_count['header-menu'] ) ? $component_keys_count['header-menu'] : 5;
+
+		// Widgets.
+		$component_keys_count['header-widget'] = ( 10 >= $component_keys_count['header-widget'] ) ? $component_keys_count['header-widget'] : 10;
+		$component_keys_count['footer-widget'] = ( 10 >= $component_keys_count['footer-widget'] ) ? $component_keys_count['footer-widget'] : 10;
+
+		// Social Icons.
+		$component_keys_count['header-social-icons'] = ( 5 >= $component_keys_count['header-social-icons'] ) ? $component_keys_count['header-social-icons'] : 5;
+		$component_keys_count['footer-social-icons'] = ( 5 >= $component_keys_count['footer-social-icons'] ) ? $component_keys_count['footer-social-icons'] : 5;
+
 		return $component_keys_count;
 	}
 


### PR DESCRIPTION
### Description
The current elements filter allows user to add any number of elements in the header footer builder.
This creates a lag in the experience of handling customizer when the count is too high (say > 10).
This PR restricts this count:

- Header Button - 10
- Footer Button - 10
- Header HTML - 10
- Footer HTML - 10
- Header Widgets - 10
- Footer Widgets - 10
- Header Menu - 5
- Header Socials - 5
- Footer Socials - 5


### How has this been tested?
Add this filter from child theme - 
```php
function astra_builder_elements_count( $elements ) {
    $elements['header-button']	     = 20;
    $elements['footer-button']	     = 20;
    $elements['header-html']	     = 20;
    $elements['footer-html']	     = 20;
    $elements['header-divider']	     = 20;
    $elements['footer-divider']	     = 20;
    $elements['header-menu']	     = 20;
    $elements['header-widget']	     = 20;
    $elements['footer-widget']	     = 20;
    $elements['header-social-icons'] = 20;
    $elements['footer-social-icons'] = 20;
    return $elements;
}
add_filter( 'astra_builder_elements_count', 'astra_builder_elements_count', 10 );
```
Yet the number of elements should be as given above and not as per this filter.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests