### PR TITLE
fix: Multiple menu animation CSS case.

### DIFF
--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -262,8 +262,7 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 
 					if ( Astra_Builder_Helper::is_component_loaded( 'header', 'menu-' . $index ) && ! empty( $menu_animation_enable ) ) {
 						$menu_animation = 'is_animated';
-					} else {
-						continue;
+						break;
 					}
 				}           
 			} else {

--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -253,13 +253,13 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 			add_filter( 'astra_dynamic_theme_css', array( 'Astra_Dynamic_CSS', 'return_output' ) );
 			add_filter( 'astra_dynamic_theme_css', array( 'Astra_Dynamic_CSS', 'return_meta_output' ) );
 
-			// Submenu Container Animation.
+			// Submenu Container Animation for header builder.
 			if ( Astra_Builder_Helper::$is_header_footer_builder_active ) {
 				
 				for ( $index = 1; $index <= Astra_Builder_Helper::$num_of_header_menu; $index++ ) {
 
 					$menu_animation_enable = astra_get_option( 'header-menu' . $index . '-submenu-container-animation' );
-					
+
 					if ( Astra_Builder_Helper::is_component_loaded( 'header', 'menu-' . $index ) && ! empty( $menu_animation_enable ) ) {
 						$menu_animation = 'is_animated';
 					} else {

--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -254,7 +254,22 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 			add_filter( 'astra_dynamic_theme_css', array( 'Astra_Dynamic_CSS', 'return_meta_output' ) );
 
 			// Submenu Container Animation.
-			$menu_animation = astra_get_option( 'header-main-submenu-container-animation' );
+			if ( Astra_Builder_Helper::$is_header_footer_builder_active ) {
+				
+				for ( $index = 1; $index <= Astra_Builder_Helper::$num_of_header_menu; $index++ ) {
+
+					$menu_animation_enable = astra_get_option( 'header-menu' . $index . '-submenu-container-animation' );
+					
+					if ( Astra_Builder_Helper::is_component_loaded( 'header', 'menu-' . $index ) && ! empty( $menu_animation_enable ) ) {
+						$menu_animation = 'is_animated';
+					} else {
+						continue;
+					}
+				}           
+			} else {
+				$menu_animation = astra_get_option( 'header-main-submenu-container-animation' );
+			} 
+
 
 			$rtl = ( is_rtl() ) ? '-rtl' : '';
 


### PR DESCRIPTION
### Description
Changed the CSS animation loading logic in case of header builder and multiple menus, this also fixes a bug related to when users shift from old header builder to the new header builder.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Checked by taking different menus and their animation enabled then checking the page source to verify if the CSS loads.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
