### PR TITLE
fix: Handle the condition if any elements count missing in the filter

### DIFF
--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -521,22 +521,24 @@ final class Astra_Builder_Helper {
 	 */
 	public static function get_component_count_by_key() {
 
-		$component_keys_count = apply_filters(
-			'astra_builder_elements_count',
-			array(
-				'header-button'       => 2,
-				'footer-button'       => 2,
-				'header-html'         => 2,
-				'footer-html'         => 2,
-				'header-menu'         => 2,
-				'header-widget'       => 4,
-				'footer-widget'       => 4,
-				'header-social-icons' => 1,
-				'footer-social-icons' => 1,
-				'header-divider'      => 0,
-				'footer-divider'      => 0,
-			)
+		$component_keys_count = array(
+			'header-button'       => 2,
+			'footer-button'       => 2,
+			'header-html'         => 2,
+			'footer-html'         => 2,
+			'header-menu'         => 2,
+			'header-widget'       => 4,
+			'footer-widget'       => 4,
+			'header-social-icons' => 1,
+			'footer-social-icons' => 1,
+			'header-divider'      => 0,
+			'footer-divider'      => 0,
 		);
+
+		$component_keys_count = array_merge( $component_keys_count, apply_filters(
+			'astra_builder_elements_count',
+			$component_keys_count
+		) );
 
 		// Buttons.
 		$component_keys_count['header-button'] = ( 10 >= $component_keys_count['header-button'] ) ? $component_keys_count['header-button'] : 10;

--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -535,10 +535,13 @@ final class Astra_Builder_Helper {
 			'footer-divider'      => 0,
 		);
 
-		$component_keys_count = array_merge( $component_keys_count, apply_filters(
-			'astra_builder_elements_count',
-			$component_keys_count
-		) );
+		$component_keys_count = array_merge(
+			$component_keys_count,
+			apply_filters(
+				'astra_builder_elements_count',
+				$component_keys_count
+			) 
+		);
 
 		// Buttons.
 		$component_keys_count['header-button'] = ( 10 >= $component_keys_count['header-button'] ) ? $component_keys_count['header-button'] : 10;


### PR DESCRIPTION
### Description
Handle the condition if a user does not pass any elements count to the filter. This will show a notice as an undefined variable.

### Screenshots
https://a.cl.ly/ApuGrjOE

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Checkout to the main branch of Theme and Addon.
- Encountered this issue when putting the below code in your child themes Functions.php - 

```
function astra_builder_elements_count( $elements ) {
    return array(
        'header-button'       => 2,
        'footer-button'       => 2,
        'header-html'         => 2,
        'footer-html'         => 2,
        'header-menu'         => 2,
        'header-widget'       => 2,
        'footer-widget'       => 2,
        'header-social-icons' => 2,
        'footer-social-icons' => 2,
    );
}
add_filter( 'astra_builder_elements_count', 'astra_builder_elements_count', 10 );

```

- In the above code, `header-divider` and `footer-divider` are missing so, it displays a notice. Please refer above screenshots. 
- If any element is missing from the filter it will raise a notice!

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
