### PR TITLE
Update class-astra-meta-boxes.php

### DIFF
--- a/inc/metabox/class-astra-meta-boxes.php
+++ b/inc/metabox/class-astra-meta-boxes.php
@@ -197,8 +197,8 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 			if ( is_array( $stored ) ) {
 
 				// Set stored and override defaults.
-				foreach ( $stored as $key => $value ) {
-					self::$meta_option[ $key ]['default'] = ( isset( $stored[ $key ][0] ) ) ? $stored[ $key ][0] : '';
+				foreach ( self::$meta_option as $key => &$value ) {
+					$value['default'] = ( isset( $stored[ $key ][0] ) ) ? $stored[ $key ][0] : '';
 				}
 			}
 


### PR DESCRIPTION
optimize $meta_options for loop for only its parameters not the whole $stored parameters

### Description
I changed the loop iteration from $stored to $meta_options as a reference using ampersand character.

### Screenshots
I tested it and it works fine, you may test it as well.

### Types of changes
only an optimization