### PR TITLE
fix: Duplicate Visibility settings for all elements in both General & Design Tabs.

### DIFF
--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -103,7 +103,7 @@ final class Astra_Builder_Helper {
 	 *
 	 * @var string[][]
 	 */
-	public static $mobile_general_tab = array(
+	public static $responsive_general_tab = array(
 		array(
 			'setting' => 'ast_selected_tab',
 			'value'   => 'general',
@@ -112,6 +112,40 @@ final class Astra_Builder_Helper {
 			'setting'  => 'ast_selected_device',
 			'operator' => 'in',
 			'value'    => array( 'tablet', 'mobile' ),
+		),
+	);
+
+	/**
+	 * Config Tablet device context.
+	 *
+	 * @var string[][]
+	 */
+	public static $tablet_general_tab = array(
+		array(
+			'setting' => 'ast_selected_tab',
+			'value'   => 'general',
+		),
+		array(
+			'setting'  => 'ast_selected_device',
+			'operator' => '==',
+			'value'    => 'tablet',
+		),
+	);
+
+	/**
+	 * Config Mobile device context.
+	 *
+	 * @var string[][]
+	 */
+	public static $mobile_general_tab = array(
+		array(
+			'setting' => 'ast_selected_tab',
+			'value'   => 'general',
+		),
+		array(
+			'setting'  => 'ast_selected_device',
+			'operator' => '==',
+			'value'    => 'mobile',
 		),
 	);
 

--- a/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
+++ b/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
@@ -186,7 +186,7 @@ final class Astra_Builder_Base_Configuration {
 				'title'    => __( 'Visibility', 'astra' ),
 				'priority' => 300,
 				'settings' => array(),
-				'context'  => Astra_Builder_Helper::$responsive_devices,
+				'context'  => Astra_Builder_Helper::$responsive_general_tab,
 			),
 
 			/**
@@ -201,7 +201,7 @@ final class Astra_Builder_Base_Configuration {
 				'priority'  => 320,
 				'title'     => __( 'Hide on Tablet', 'astra' ),
 				'transport' => 'postMessage',
-				'context'   => Astra_Builder_Helper::$tablet_device,
+				'context'   => Astra_Builder_Helper::$tablet_general_tab,
 			),
 
 			/**
@@ -216,7 +216,7 @@ final class Astra_Builder_Base_Configuration {
 				'priority'  => 330,
 				'title'     => __( 'Hide on Mobile', 'astra' ),
 				'transport' => 'postMessage',
-				'context'   => Astra_Builder_Helper::$mobile_device,
+				'context'   => Astra_Builder_Helper::$mobile_general_tab,
 			),
 		);
 	}

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-off-canvas-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-off-canvas-configs.php
@@ -113,7 +113,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 					'type'     => 'control',
 					'control'  => 'select',
 					'section'  => $_section,
-					'context'  => Astra_Builder_Helper::$mobile_general_tab,
+					'context'  => Astra_Builder_Helper::$responsive_general_tab,
 					'priority' => 40,
 					'title'    => __( 'Dropdown Target', 'astra' ),
 					'suffix'   => '',


### PR DESCRIPTION
### Description
 - The Visibility settings are visible in both General & Design Tabs.

### Types of changes
Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
 - No Duplicate settings.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
