### PR TITLE
fix: Stack on mobile option for Menu not working in customizer preview.

### DIFF
--- a/inc/builder/type/header/menu/assets/js/customizer-preview.js
+++ b/inc/builder/type/header/menu/assets/js/customizer-preview.js
@@ -282,7 +282,7 @@
 				wp.customize( 'astra-settings[header-menu'+ index +'-menu-stack-on-mobile]', function( setting ) {
 					setting.bind( function( stack ) {
 
-						var menu_div = jQuery( '#ast-mobile-header #ast-hf-menu-'+ index + ' .main-header-menu'  );
+						var menu_div = jQuery( '#ast-mobile-header #ast-hf-menu-'+ index + '.main-header-menu'  );
 						menu_div.removeClass('inline-on-mobile');
 						menu_div.removeClass('stack-on-mobile');
 


### PR DESCRIPTION
### Description
- Stack on the mobile option for Menu not working in the customizer preview.

### Types of changes
Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
 - Stack on mobile works in the customizer preview.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
