### PR TITLE
fix: Added missed ASTRA_THEME_SETTINGS to customizer controls

### DIFF
--- a/inc/addons/transparent-header/classes/sections/class-astra-customizer-colors-transparent-header-configs.php
+++ b/inc/addons/transparent-header/classes/sections/class-astra-customizer-colors-transparent-header-configs.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Astra_Customizer_Colors_Transparent_Header_Configs' ) ) {
 				 * Option: Header background overlay color
 				 */
 				array(
-					'name'       => 'transparent-header-bg-color-responsive',
+					'name'       => ASTRA_THEME_SETTINGS . '[transparent-header-bg-color-responsive]',
 					'default'    => $defaults['transparent-header-bg-color-responsive'],
 					'section'    => 'section-transparent-header',
 					'type'       => 'control',

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-above-footer-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-above-footer-configs.php
@@ -224,7 +224,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Option: Above Footer Background styling.
 				array(
-					'name'      => 'hba-footer-bg-obj-responsive',
+					'name'      => ASTRA_THEME_SETTINGS . '[hba-footer-bg-obj-responsive]',
 					'type'      => 'control',
 					'section'   => $_section,
 					'control'   => 'ast-responsive-background',

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-below-footer-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-below-footer-configs.php
@@ -226,7 +226,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Option: Below Footer Background styling.
 				array(
-					'name'      => 'hbb-footer-bg-obj-responsive',
+					'name'      => ASTRA_THEME_SETTINGS . '[hbb-footer-bg-obj-responsive]',
 					'type'      => 'control',
 					'section'   => $_section,
 					'control'   => 'ast-responsive-background',

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-primary-footer-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-primary-footer-configs.php
@@ -206,7 +206,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Sub Option: Footer Background.
 				array(
-					'name'       => 'hb-footer-bg-obj-responsive',
+					'name'       => ASTRA_THEME_SETTINGS . '[hb-footer-bg-obj-responsive]',
 					'section'    => $_section,
 					'type'       => 'control',
 					'control'    => 'ast-responsive-background',

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-above-header-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-above-header-configs.php
@@ -129,7 +129,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Option: Above Header Background styling.
 				array(
-					'name'      => 'hba-header-bg-obj-responsive',
+					'name'      => ASTRA_THEME_SETTINGS . '[hba-header-bg-obj-responsive]',
 					'type'      => 'control',
 					'section'   => $_section,
 					'control'   => 'ast-responsive-background',

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-below-header-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-below-header-configs.php
@@ -129,7 +129,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Option: Below Header Background styling.
 				array(
-					'name'      => 'hbb-header-bg-obj-responsive',
+					'name'      => ASTRA_THEME_SETTINGS . '[hbb-header-bg-obj-responsive]',
 					'type'      => 'control',
 					'section'   => $_section,
 					'control'   => 'ast-responsive-background',

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-primary-header-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-primary-header-configs.php
@@ -141,7 +141,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 				// Sub Option: Header Background.
 				array(
-					'name'       => 'hb-header-bg-obj-responsive',
+					'name'       => ASTRA_THEME_SETTINGS . '[hb-header-bg-obj-responsive]',
 					'section'    => $_section,
 					'type'       => 'control',
 					'control'    => 'ast-responsive-background',


### PR DESCRIPTION
### Description
- Added missed ASTRA_THEME_SETTINGS to customizer controls
- Ref PR - https://github.com/brainstormforce/astra/pull/2030
- This breaks controls which removed from setting group

### Screenshots
- https://i.imgur.com/Xs6cI5n.png

### Types of changes
- Added ASTRA_THEME_SETTINGS prefix to direct controls

### How has this been tested?
- With Transparent Header > BG Overlay Color
- Above header - BG Color
- Primary header - BG Color
- Below header - BG Color
- Above footer - BG Color
- Primary footer - BG Color
- Below footer - BG Color

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
