### PR TITLE
fix: Removed the astra-addon Text Domain used in the Theme.

### DIFF
--- a/inc/compatibility/edd/class-astra-edd.php
+++ b/inc/compatibility/edd/class-astra-edd.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'Astra_Edd' ) ) :
 			$cart_total_display = astra_get_option( 'edd-header-cart-total-display' );
 			$cart_count_display = apply_filters( 'astra_edd_header_cart_count', true );
 			$cart_title_display = astra_get_option( 'edd-header-cart-title-display' );
-			$cart_title         = apply_filters( 'astra_header_cart_title', __( 'Cart', 'astra-addon' ) );
+			$cart_title         = apply_filters( 'astra_header_cart_title', __( 'Cart', 'astra' ) );
 
 			$cart_title_markup = '<span class="ast-edd-header-cart-title">' . esc_html( $cart_title ) . '</span>';
 

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			$cart_total_display = astra_get_option( 'woo-header-cart-total-display' );
 			$cart_count_display = apply_filters( 'astra_header_cart_count', true );
 			$cart_title_display = astra_get_option( 'woo-header-cart-title-display' );
-			$cart_title         = apply_filters( 'astra_header_cart_title', __( 'Cart', 'astra-addon' ) );
+			$cart_title         = apply_filters( 'astra_header_cart_title', __( 'Cart', 'astra' ) );
 
 			$cart_title_markup = '<span class="ast-woo-header-cart-title">' . esc_html( $cart_title ) . '</span>';
 			$cart_total_markup = '';

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
@@ -162,7 +162,7 @@ class Astra_Customizer_Woo_Cart_Configs extends Astra_Customizer_Config_Base {
 					'name'     => $_section,
 					'type'     => 'section',
 					'priority' => 5,
-					'title'    => __( 'Woocommerce Cart', 'astra-addon' ),
+					'title'    => __( 'Woocommerce Cart', 'astra' ),
 					'panel'    => 'panel-header-builder-group',
 				),
 
@@ -189,7 +189,7 @@ class Astra_Customizer_Woo_Cart_Configs extends Astra_Customizer_Config_Base {
 				array(
 					'name'     => ASTRA_THEME_SETTINGS . '[header-cart-icon-divider]',
 					'section'  => $_section,
-					'title'    => __( 'Header Cart Icon', 'astra-addon' ),
+					'title'    => __( 'Header Cart Icon', 'astra' ),
 					'type'     => 'control',
 					'control'  => 'ast-heading',
 					'priority' => 30,


### PR DESCRIPTION
### Description
 - Theme check plugin gives an error if 2 Text domains are used in the Theme.

### Types of changes
Bugfix (a non-breaking change that fixes an issue)

### How has this been tested?
 - Check with the Theme Check plugin.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
