### PR TITLE
fix: Inconsistency between the responsive spacing control empty values.

### DIFF
--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -316,6 +316,35 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 							'mobile-unit'  => 'px',
 						);
 					}
+
+					if ( empty( $val ) ) {
+
+						$default_responsive_spacing = array(
+							'desktop'      => array(
+								'top'    => '',
+								'right'  => '',
+								'bottom' => '',
+								'left'   => '',
+							),
+							'tablet'       => array(
+								'top'    => '',
+								'right'  => '',
+								'bottom' => '',
+								'left'   => '',
+							),
+							'mobile'       => array(
+								'top'    => '',
+								'right'  => '',
+								'bottom' => '',
+								'left'   => '',
+							),
+							'desktop-unit' => 'px',
+							'tablet-unit'  => 'px',
+							'mobile-unit'  => 'px',
+						);
+
+						astra_update_option( $data[1], $default_responsive_spacing );
+					}
 					break;
 				case 'ast-radio-image':
 					$configuration['value'] = $val;


### PR DESCRIPTION
### Description
  - Trello task - https://trello.com/c/zz7twLsK/876-padding-control-bug

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
1. Check the initial value it is storing as an empty string.
2. Edit it with any value and clear it. ( not 0 )
3. It stores an array with all values empty string (non-integer) it should be store as an empty string as initially stored to maintain consistency.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
