### PR TITLE
fix: PHP notice in the Woocomerce Cart element.

### DIFF
--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -192,7 +192,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 		public function header_cart_icon_class( $classes ) {
 
 			if ( ! Astra_Builder_Helper::$is_header_footer_builder_active && ! defined( 'ASTRA_EXT_VER' ) ) {
-				return;
+				return $classes;
 			}
 
 			$header_cart_icon_style = astra_get_option( 'woo-header-cart-icon-style' );


### PR DESCRIPTION
### Description
 - PHP notice occurs in case of non-migrated users.

### Types of changes
 - Bugfix (a non-breaking change that fixes an issue)

### How has this been tested?
 - Import `Life Coach` Gutenberg Starter site in master Branch.
 - Switch to `v3-milestones` & deactivate Astra Addon.
 - Do not switch to `New Header Footer Builder`
 - You will see PHP notice in the debug log.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
