### PR TITLE
fix: EDD cart hover icon color issue for none style

### DIFF
--- a/inc/builder/type/header/edd-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/edd-cart/dynamic-css/dynamic.css.php
@@ -83,7 +83,7 @@ function astra_hb_edd_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 				'color'        => esc_attr( $header_cart_icon_color ),
 			),
 			// Outline icon hover colors.
-			$selector . ' .ast-edd-cart-menu-wrap:hover .count'        => array(
+			$selector . ' .ast-edd-cart-menu-wrap:hover .count' => array(
 				'color'            => esc_attr( $cart_h_color ),
 				'background-color' => esc_attr( $header_cart_icon_color ),
 			),

--- a/inc/builder/type/header/edd-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/edd-cart/dynamic-css/dynamic.css.php
@@ -42,15 +42,15 @@ function astra_hb_edd_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	 */
 	$css_output_desktop = array(
 
-		$selector . ' .ast-edd-cart-menu-wrap .count' => array(
+		$selector . ' .ast-edd-cart-menu-wrap .count, ' . $selector . ' .ast-edd-cart-menu-wrap .count:after' => array(
 			'color'        => $theme_color,
 			'border-color' => $theme_color,
 		),
-		$selector . ' .ast-edd-cart-menu-wrap .count:after' => array(
-			'color'        => $theme_color,
-			'border-color' => $theme_color,
+		$selector . ' .ast-edd-cart-menu-wrap:hover .count' => array(
+			'color'            => esc_attr( $cart_h_color ),
+			'background-color' => esc_attr( $theme_color ),
 		),
-		$selector . ' .ast-icon-shopping-cart'        => array(
+		$selector . ' .ast-icon-shopping-cart' => array(
 			'color' => $theme_color,
 		),
 	);
@@ -58,7 +58,7 @@ function astra_hb_edd_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	/**
 	 * Header Cart color
 	 */
-	if ( 'none' != $header_cart_icon_style ) {
+	if ( 'none' !== $header_cart_icon_style ) {
 
 		/**
 		 * Header Cart Icon colors
@@ -83,7 +83,7 @@ function astra_hb_edd_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 				'color'        => esc_attr( $header_cart_icon_color ),
 			),
 			// Outline icon hover colors.
-			'.ast-edd-cart-menu-wrap:hover .count'        => array(
+			$selector . ' .ast-edd-cart-menu-wrap:hover .count'        => array(
 				'color'            => esc_attr( $cart_h_color ),
 				'background-color' => esc_attr( $header_cart_icon_color ),
 			),


### PR DESCRIPTION
### Description
- EDD cart hover icon color issue for none style

### Screenshots
- https://d.pr/i/o3YBRA

### Types of changes
- Dynamic CSS updated

### How has this been tested?
- Test with EDD cart

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request