### PR TITLE
imprv: Revamp is_component_loaded function

### DIFF
--- a/inc/builder/type/base/dynamic-css/button/class-astra-button-component-dynamic-css.php
+++ b/inc/builder/type/base/dynamic-css/button/class-astra-button-component-dynamic-css.php
@@ -37,7 +37,7 @@ class Astra_Button_Component_Dynamic_CSS {
 
 		for ( $index = 1; $index <= $number_of_button; $index++ ) {
 
-			if ( ! Astra_Builder_Helper::is_component_loaded( 'button-' . $index, $builder_type ) ) {
+			if ( ! Astra_Builder_Helper::is_component_loaded( 'button-' . $index, 'all' ) ) {
 				continue;
 			}
 

--- a/inc/builder/type/base/dynamic-css/button/class-astra-button-component-dynamic-css.php
+++ b/inc/builder/type/base/dynamic-css/button/class-astra-button-component-dynamic-css.php
@@ -37,7 +37,7 @@ class Astra_Button_Component_Dynamic_CSS {
 
 		for ( $index = 1; $index <= $number_of_button; $index++ ) {
 
-			if ( ! Astra_Builder_Helper::is_component_loaded( 'button-' . $index, 'all' ) ) {
+			if ( ! Astra_Builder_Helper::is_component_loaded( 'button-' . $index, $builder_type ) ) {
 				continue;
 			}
 

--- a/inc/builder/type/header/mobile-menu/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/mobile-menu/dynamic-css/dynamic.css.php
@@ -26,7 +26,7 @@ add_filter( 'astra_dynamic_theme_css', 'astra_hb_mobile_menu_dynamic_css', 11 );
  */
 function astra_hb_mobile_menu_dynamic_css( $dynamic_css, $dynamic_css_filtered = '' ) {
 
-	if ( ! Astra_Builder_Helper::is_component_loaded( 'mobile-menu', 'header' ) ) {
+	if ( ! Astra_Builder_Helper::is_component_loaded( 'mobile-menu', 'header', 'mobile' ) ) {
 		return $dynamic_css;
 	}
 

--- a/inc/builder/type/header/mobile-trigger/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/mobile-trigger/dynamic-css/dynamic.css.php
@@ -26,7 +26,7 @@ add_filter( 'astra_dynamic_theme_css', 'astra_mobile_trigger_row_setting', 11 );
  */
 function astra_mobile_trigger_row_setting( $dynamic_css, $dynamic_css_filtered = '' ) {
 
-	if ( ! Astra_Builder_Helper::is_component_loaded( 'mobile-trigger', 'header' ) ) {
+	if ( ! Astra_Builder_Helper::is_component_loaded( 'mobile-trigger', 'header', 'mobile' ) ) {
 		return $dynamic_css;
 	}
 


### PR DESCRIPTION
### Description
- https://trello.com/c/SmhTYqTW/927-iscomponentloaded-params-function-improvement
- Added builder type and device type checks in `is_component_loaded ` function.
-  Added header-desktop, header-mobile, header-both, footer and all devices array to check device and builder wise components.
- For other function call their is no need to change parameters as it has already handled in both device Cases.

### Types of changes
- Improvements

### How has this been tested?
- Add component to specific header/footer and specific device and check if dynamic respective CSS is loaded or not.
- Load only that components dynamic CSS in which component is being loaded.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
