### PR TITLE
fix: This fix clears assets cache and regenerates new assets files.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v3.0.1
+- Fix: Astra assets cache regeneration issue when Astra Pro is updated to v3.0.0 prior to Astra theme.
+- Fix: UI Tab switching in color options for RTL websites.
+- Fix: Builder - Duplicate listing of social icons in customizer.
+
 v3.0.0
 - New: Account element added for Header Builder. ( https://wpastra.com/astra-3-0/ )
 - Improvement: Removed old CSS that is already supported by browsers.

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -404,6 +404,19 @@ function astra_header_builder_compatibility() {
 }
 
 /**
+ * Clears assets cache and regenerates new assets files.
+ *
+ * @since 3.0.1
+ *
+ * @return void
+ */
+function astra_clear_assets_cache() {
+	if ( is_callable( 'Astra_Minify::refresh_assets' ) ) {
+		Astra_Minify::refresh_assets();
+	}
+}
+
+/**
  * Header Footer builder - Migration of options.
  *
  * @since 3.0.0

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -435,8 +435,6 @@ function astra_header_builder_migration() {
 
 	$used_elements = array();
 
-	error_log( 'Astra: Migrating Header Footer Builder Options - Process Start' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-
 	$options = array(
 		'theme_options'  => $theme_options,
 		'used_elements'  => $used_elements,
@@ -464,8 +462,6 @@ function astra_header_builder_migration() {
 
 	update_option( 'astra-settings', $theme_options );
 	update_option( 'sidebars_widgets', $widget_options );
-
-	error_log( 'Astra: Migrating Header Footer Builder Options - Process Done' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 }
 

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -70,6 +70,9 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 			'3.0.0' => array(
 				'astra_header_builder_compatibility',
 			),
+			'3.0.1' => array(
+				'astra_clear_assets_cache',
+			),
 		);
 
 		/**


### PR DESCRIPTION
### Description
This issue occurs when the user updates Astra Pro first & then the theme.

### Screenshots
https://a.cl.ly/qGuleOdq

### Types of changes
Caching issue.

### How has this been tested?
https://a.cl.ly/qGuleOdq

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests