### PR TITLE
Fix: Megamenu default border not working

### DIFF
--- a/inc/builder/type/header/menu/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/menu/dynamic-css/dynamic.css.php
@@ -152,7 +152,7 @@ function astra_hb_menu_dynamic_css( $dynamic_css, $dynamic_css_filtered = '' ) {
 				'color' => $menu_resp_color_active_desktop,
 			),
 			// Sub Menu.
-			$selector . ' .sub-menu, ' . $selector . ' .inline-on-mobile .sub-menu' => array(
+			$selector . ' .sub-menu, ' . $selector . ' .inline-on-mobile .sub-menu, ' . $selector . ' .main-header-menu.submenu-with-border .astra-megamenu, ' . $selector . ' .main-header-menu.submenu-with-border .astra-full-megamenu-wrapper' => array(
 				'border-top-width'    => astra_get_css_value( $sub_menu_border_top, 'px' ),
 				'border-bottom-width' => astra_get_css_value( $sub_menu_border_bottom, 'px' ),
 				'border-right-width'  => astra_get_css_value( $sub_menu_border_right, 'px' ),


### PR DESCRIPTION
### Description

Problem Statement - Default border set from here - https://share.getcloudapp.com/GGu2GDr7 is not working if the mega menu is set as a submenu. This issue occurs only in the customizer.

### Screenshots
https://share.getcloudapp.com/GGu2GDr7

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
