### PR TITLE
fix: Font Size not working for HTML, Social, Copyright, Account for addon deactive or Typography options deactive  case.

### DIFF
--- a/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
+++ b/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
@@ -174,7 +174,7 @@ final class Astra_Builder_Base_Configuration {
 				 * Option: Font Size
 				 */
 				array(
-					'name'        => 'font-size-' . $section_id,
+					'name'        => ASTRA_THEME_SETTINGS . '[font-size-' . $section_id . ']',
 					'type'        => 'control',
 					'section'     => $section_id,
 					'control'     => 'ast-responsive',


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/RNMIxbwO/1103-font-size-isnt-applying-in-the-copyright-widget

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Check Font Size working for above mentioned elements  or not when the addon is deactive.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
