### PR TITLE
fix: Mobile/Desktop Header not visible if we switch contexts.

### DIFF
--- a/inc/builder/controllers/class-astra-builder-ui-controller.php
+++ b/inc/builder/controllers/class-astra-builder-ui-controller.php
@@ -236,6 +236,7 @@ if ( ! class_exists( 'Astra_Builder_UI_Controller' ) ) {
 
 			echo '<div class="ast-builder-button-wrap ast-builder-button-size-' . $button_size . '">'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo astra_get_custom_button( $builder_type . '-button' . $index . '-text', $builder_type . '-button' . $index . '-link-option', 'header-button' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		/**


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/toveEmYA/1150-mobile-header-not-visible

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Check by Switching devices the Desktop & Mobile headers should be visible.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
