### PR TITLE
WIP: Add webstories embed support with default customizer settings

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,6 +28,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 </head>
 
 <body <?php astra_schema_body(); ?> <?php body_class(); ?>>
+
+<?php
+
+	// Embed web stories above header with pre-configured customizer settings.
+	if ( class_exists( 'Google\Web_Stories\Customizer' ) ) {
+		$customizer = new Google\Web_Stories\Customizer();
+		echo $customizer->render_stories();
+	}
+
+?>
+
 <?php astra_body_top(); ?>
 <?php wp_body_open(); ?>
 <div 

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -175,6 +175,9 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 				);
 			}
 
+			// Enable Webstories.
+			add_theme_support( 'web-stories' );
+
 		}
 
 		/**


### PR DESCRIPTION
### Description
Adds web stories circles list above the header if webstories are enabled via customizer settings. 

### Screenshots
![Screenshot 2021-02-15 at 9 13 16 PM](https://user-images.githubusercontent.com/1139853/107967070-ad863080-6fd2-11eb-8936-00b8d62a7ce8.png)
![Screenshot 2021-02-15 at 9 13 30 PM](https://user-images.githubusercontent.com/1139853/107967082-b0812100-6fd2-11eb-9134-ab3117280c4c.png)


### Types of changes
- Changes `header.php` to add webstories embed code.
- Adds theme support using `add_theme_support( 'web-stories' );`

### How has this been tested?
Tested a few pages with embedded stories in Desktop, Tablet and Mobile devices.
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
