### PR TITLE
fix: Fatal error due to addon builder instance used in theme context

### DIFF
--- a/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
+++ b/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
@@ -271,7 +271,7 @@ class Astra_Button_Component_Configs {
 					'section'    => $_section,
 					'priority'   => 80,
 					'transport'  => 'postMessage',
-					'context'    => astra_addon_builder_helper()->design_tab,
+					'context'    => Astra_Builder_Helper::$design_tab,
 					'responsive' => true,
 				),
 


### PR DESCRIPTION
### Description
- Fixed error due to Addon's builder instance used in theme

### Screenshots
- https://share.getcloudapp.com/04uJ2WDw
- https://share.getcloudapp.com/4gu1n4AD

### Types of changes
- Fixing error

### How has this been tested?
- Check theme customizer when addon is deactiavted

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 