### PR TITLE
fix: Double divider case resolved in Site Identity section

### DIFF
--- a/inc/customizer/configurations/builder/header/class-astra-customizer-site-identity-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-site-identity-configs.php
@@ -35,12 +35,6 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 
 			$_section = 'title_tagline';
 
-			if ( defined( 'ASTRA_EXT_VER' ) ) {
-				$priority_of_divider = 11;
-			} else {
-				$priority_of_divider = 200;
-			}
-
 			$_configs = array(
 
 				/*
@@ -99,35 +93,6 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 						'render_callback'     => 'Astra_Builder_Header::site_identity',
 					),
 					'context'   => Astra_Builder_Helper::$general_tab,
-				),
-
-				/**
-				 * Option: Divider
-				 */
-				array(
-					'name'     => ASTRA_THEME_SETTINGS . '[header-logo-typography-divider]',
-					'type'     => 'control',
-					'section'  => 'title_tagline',
-					'control'  => 'ast-divider',
-					'priority' => $priority_of_divider,
-					'settings' => array(),
-					'context'  => array(
-						'relation' => 'AND',
-						Astra_Builder_Helper::$design_tab_config,
-						array(
-							'relation' => 'OR',
-							array(
-								'setting'  => ASTRA_THEME_SETTINGS . '[display-site-title]',
-								'operator' => '==',
-								'value'    => true,
-							),
-							array(
-								'setting'  => ASTRA_THEME_SETTINGS . '[display-site-tagline]',
-								'operator' => '==',
-								'value'    => true,
-							),
-						),
-					),
 				),
 
 				// Option: Site Title Color.

--- a/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
@@ -112,9 +112,9 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							'underline' => __( 'Underline', 'astra' ),
 							'overline'  => __( 'Overline', 'astra' ),
 						),
-						'context'   => Astra_Builder_Helper::$design_tab,
-						'transport' => 'postMessage',
-						'partial'   => array(
+						'context'    => Astra_Builder_Helper::$design_tab,
+						'transport'  => 'postMessage',
+						'partial'    => array(
 							'selector'         => '#ast-hf-menu-' . $index,
 							'render_callback'  => array( Astra_Builder_Header::get_instance(), 'menu_' . $index ),
 							'fallback_refresh' => false,
@@ -180,9 +180,9 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							'slide-up'   => __( 'Slide Up', 'astra' ),
 							'fade'       => __( 'Fade', 'astra' ),
 						),
-						'context'   => Astra_Builder_Helper::$general_tab,
-						'transport' => 'postMessage',
-						'partial'   => array(
+						'context'    => Astra_Builder_Helper::$general_tab,
+						'transport'  => 'postMessage',
+						'partial'    => array(
 							'selector'         => '#ast-hf-menu-' . $index,
 							'render_callback'  => array( Astra_Builder_Header::get_instance(), 'menu_' . $index ),
 							'fallback_refresh' => false,

--- a/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
@@ -77,6 +77,35 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							'em' => 'em',
 						),
 					),
+
+					/**
+					 * Option: Divider
+					 */
+					array(
+						'name'     => ASTRA_THEME_SETTINGS . '[header-logo-typography-divider]',
+						'type'     => 'control',
+						'section'  => 'title_tagline',
+						'control'  => 'ast-divider',
+						'priority' => 11,
+						'settings' => array(),
+						'context'  => array(
+							'relation' => 'AND',
+							Astra_Builder_Helper::$design_tab_config,
+							array(
+								'relation' => 'OR',
+								array(
+									'setting'  => ASTRA_THEME_SETTINGS . '[display-site-title]',
+									'operator' => '==',
+									'value'    => true,
+								),
+								array(
+									'setting'  => ASTRA_THEME_SETTINGS . '[display-site-tagline]',
+									'operator' => '==',
+									'value'    => true,
+								),
+							),
+						),
+					),
 				);
 			} else {
 


### PR DESCRIPTION
### Description
- Double divider appearing in site identity section

### Screenshots
- https://a.cl.ly/yAu6rAwX

### Types of changes
- Non breaking change

### How has this been tested?
- Check with addon deactivate

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 