### PR TITLE
fix: Added missing divider for Woo Pages toggle for Transparent header.

### DIFF
--- a/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-single-layout-configs.php
+++ b/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-single-layout-configs.php
@@ -59,6 +59,26 @@ if ( ! class_exists( 'Astra_Woo_Shop_Single_Layout_Configs' ) ) {
 				),
 
 				/**
+				 * Option: Divider on Transparent Header
+				 */
+				array(
+					'name'     => ASTRA_THEME_SETTINGS . '[transparent-header-disable-woo-products-divider]',
+					'type'     => 'control',
+					'section'  => 'section-transparent-header',
+					'control'  => 'ast-divider',
+					'priority' => 26,
+					'settings' => array(),
+					'context'  => array(
+						Astra_Builder_Helper::$general_tab_config,
+						array(
+							'setting'  => ASTRA_THEME_SETTINGS . '[transparent-header-enable]',
+							'operator' => '==',
+							'value'    => '1',
+						),
+					),
+				),
+
+				/**
 				 * Option: Disable Transparent Header on WooCommerce Product pages
 				 */
 				array(


### PR DESCRIPTION
### Description
The divider is missing in the transparent header setting

### Screenshots
https://a.cl.ly/P8ukGDDA

### Types of changes
Bug fix

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
