### PR TITLE
fix: Sonarlint attribute missing in element issue

### DIFF
--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -619,7 +619,7 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 					<span class="dashicons dashicons-admin-customizer"></span>
 					<span><?php echo esc_html( apply_filters( 'astra_sites_menu_page_title', __( 'Import Starter Template', 'astra' ) ) ); ?></span>
 				</h2>
-				<img class="ast-starter-sites-img" alt="Astra Starter Sites" src="<?php echo esc_url( ASTRA_THEME_URI . 'assets/images/astra-starter-sites.jpg' ); ?>">
+				<img class="ast-starter-sites-img" alt="Starter Templates" src="<?php echo esc_url( ASTRA_THEME_URI . 'assets/images/astra-starter-sites.jpg' ); ?>">
 				<div class="inside">
 					<p>
 						<?php

--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -619,7 +619,7 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 					<span class="dashicons dashicons-admin-customizer"></span>
 					<span><?php echo esc_html( apply_filters( 'astra_sites_menu_page_title', __( 'Import Starter Template', 'astra' ) ) ); ?></span>
 				</h2>
-				<img class="ast-starter-sites-img" src="<?php echo esc_url( ASTRA_THEME_URI . 'assets/images/astra-starter-sites.jpg' ); ?>">
+				<img class="ast-starter-sites-img" alt="Astra Starter Sites" src="<?php echo esc_url( ASTRA_THEME_URI . 'assets/images/astra-starter-sites.jpg' ); ?>">
 				<div class="inside">
 					<p>
 						<?php

--- a/template-parts/footer/builder/components.php
+++ b/template-parts/footer/builder/components.php
@@ -34,7 +34,7 @@ switch ( $component_slug ) {
 
 	case 'widget-1':
 		?>
-		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-1">
+		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-1" aria-label="Footer Widget 1">
 			<div class="footer-widget-area-inner site-info-inner">
 				<?php
 				astra_get_sidebar( 'footer-widget-1' );
@@ -46,7 +46,7 @@ switch ( $component_slug ) {
 
 	case 'widget-2':
 		?>
-		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-2">
+		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-2" aria-label="Footer Widget 2">
 			<div class="footer-widget-area-inner site-info-inner">
 				<?php
 				astra_get_sidebar( 'footer-widget-2' );
@@ -58,7 +58,7 @@ switch ( $component_slug ) {
 
 	case 'widget-3':
 		?>
-		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-3">
+		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-3" aria-label="Footer Widget 3">
 			<div class="footer-widget-area-inner site-info-inner">
 				<?php
 				astra_get_sidebar( 'footer-widget-3' );
@@ -70,7 +70,7 @@ switch ( $component_slug ) {
 
 	case 'widget-4':
 		?>
-		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-4">
+		<aside class="footer-widget-area widget-area site-footer-focus-item" data-section="sidebar-widgets-footer-widget-4" aria-label="Footer Widget 4">
 			<div class="footer-widget-area-inner site-info-inner">
 				<?php
 				astra_get_sidebar( 'footer-widget-4' );

--- a/template-parts/header/builder/components.php
+++ b/template-parts/header/builder/components.php
@@ -123,7 +123,7 @@ switch ( $component_slug ) {
 		break;
 	case 'widget-1':
 		?>
-		<aside class="header-widget-area widget-area site-header-focus-item" data-section="sidebar-widgets-header-widget-1">
+		<aside class="header-widget-area widget-area site-header-focus-item" data-section="sidebar-widgets-header-widget-1" aria-label="Header Widget 1">
 			<?php
 			if ( is_customize_preview() && class_exists( 'Astra_Builder_UI_Controller' ) ) {
 				Astra_Builder_UI_Controller::render_customizer_edit_button();
@@ -137,7 +137,7 @@ switch ( $component_slug ) {
 		break;
 	case 'widget-2':
 		?>
-		<aside class="header-widget-area widget-area site-header-focus-item" data-section="sidebar-widgets-header-widget-2">
+		<aside class="header-widget-area widget-area site-header-focus-item" data-section="sidebar-widgets-header-widget-2" aria-label="Header Widget 2">
 			<?php
 			if ( is_customize_preview() && class_exists( 'Astra_Builder_UI_Controller' ) ) {
 				Astra_Builder_UI_Controller::render_customizer_edit_button();


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fixed SonarLint issues related to missing attribute in HTML elements

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
