### PR TITLE
AST-266 - fix: Menu clone - SVG Icons missing when menu is changed from cloned menu to some other menu.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -392,7 +392,26 @@ function astra_dropdown_icon_to_menu_link( $title, $item, $args, $depth ) {
 	$tabindex = '0';
 	$icon     = '';
 
-	if ( ! ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'nav-menu' ) && ( isset( $args->container_class ) && 'account-main-header-bar-navigation' !== $args->container_class ) ) ) {
+	/**
+	 * These menus are not overriden by the 'Astra_Custom_Nav_Walker' class present in Addon - Nav Menu module.
+	 *
+	 * Hence skipping these menus from getting overriden by blank SVG Icons and adding the icons from theme.
+	 *
+	 * @since x.x.x
+	 */
+	$skip_menu_locations = array(
+		'ast-hf-account-menu',
+		'ast-hf-menu-3',
+		'ast-hf-menu-4',
+		'ast-hf-menu-5',
+		'ast-hf-menu-6',
+		'ast-hf-menu-7',
+		'ast-hf-menu-8',
+		'ast-hf-menu-9',
+		'ast-hf-menu-10',
+	);
+
+	if ( ! ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'nav-menu' ) && ( isset( $args->container_class ) && ! in_array( $args->menu_id, $skip_menu_locations ) ) ) ) {
 		$icon = Astra_Icons::get_icons( 'arrow' );
 	}
 	foreach ( $item->classes as $value ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Menu clone - SVG Icons missing when menu is changed from cloned menu to some other menu.

### Screenshots
<!-- if applicable -->
![Annotation on 2021-04-01 at 10-24-52](https://user-images.githubusercontent.com/36841355/113250370-fe7d8a00-92dd-11eb-8300-0b0e9e123c7f.png)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
