### PR TITLE
Rename he compressed size check action to CI

### DIFF
--- a/.github/workflows/auto-cancel.yml
+++ b/.github/workflows/auto-cancel.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.8.0
         with:
-          workflow_id: simple-size-check.yml
+          workflow_id: ci.yml
           access_token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
-name: Compressed Size
+name: CI
 
 # Run the deployment only when code is committed to the branch.
 on:
   pull_request:
+      branches:
+      - next-release
+      - milestones
+      - release-candidate
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
### Description
Don't run CI action on development branch.

We recently did the same change for Astra Pro.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
