### PR TITLE
AST-375 - refactor: Added context dependency for Title-meta & color settings based on post structure

### DIFF
--- a/inc/customizer/configurations/layout/class-astra-related-posts-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-related-posts-configs.php
@@ -332,10 +332,16 @@ if ( ! class_exists( 'Astra_Related_Posts_Configs' ) ) {
 					'context'   => array(
 						true === Astra_Builder_Helper::$is_header_footer_builder_active ?
 						Astra_Builder_Helper::$design_tab_config : Astra_Builder_Helper::$general_tab_config,
+						'relation' => 'AND',
 						array(
 							'setting'  => ASTRA_THEME_SETTINGS . '[enable-related-posts]',
 							'operator' => '==',
 							'value'    => true,
+						),
+						array(
+							'setting'  => ASTRA_THEME_SETTINGS . '[related-posts-structure]',
+							'operator' => 'contains',
+							'value'    => 'title-meta',
 						),
 					),
 					'title'     => __( 'Content Colors', 'astra' ),
@@ -376,10 +382,16 @@ if ( ! class_exists( 'Astra_Related_Posts_Configs' ) ) {
 					'context'   => array(
 						true === Astra_Builder_Helper::$is_header_footer_builder_active ?
 						Astra_Builder_Helper::$design_tab_config : Astra_Builder_Helper::$general_tab_config,
+						'relation' => 'AND',
 						array(
 							'setting'  => ASTRA_THEME_SETTINGS . '[enable-related-posts]',
 							'operator' => '==',
 							'value'    => true,
+						),
+						array(
+							'setting'  => ASTRA_THEME_SETTINGS . '[related-posts-structure]',
+							'operator' => 'contains',
+							'value'    => 'title-meta',
 						),
 					),
 					'title'     => __( 'Post Title Font', 'astra' ),
@@ -398,10 +410,16 @@ if ( ! class_exists( 'Astra_Related_Posts_Configs' ) ) {
 					'context'   => array(
 						true === Astra_Builder_Helper::$is_header_footer_builder_active ?
 						Astra_Builder_Helper::$design_tab_config : Astra_Builder_Helper::$general_tab_config,
+						'relation' => 'AND',
 						array(
 							'setting'  => ASTRA_THEME_SETTINGS . '[enable-related-posts]',
 							'operator' => '==',
 							'value'    => true,
+						),
+						array(
+							'setting'  => ASTRA_THEME_SETTINGS . '[related-posts-structure]',
+							'operator' => 'contains',
+							'value'    => 'title-meta',
 						),
 					),
 					'title'     => __( 'Meta Font', 'astra' ),


### PR DESCRIPTION
### Description
- Added context dependency for typography & color settings options which are based on title-meta in Related Posts structure

### Screenshots
- https://share.bsf.io/YEuRO8GO
- https://share.getcloudapp.com/E0uYj6Dw

### Types of changes
- Non breaking change

### How has this been tested?
- With Related Posts structure

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
