### PR TITLE
AST-376 - improvement: Added default line-height & margin space for post title in Related Posts

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3545,6 +3545,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			.ast-related-posts-title {
 				margin: 0 0 20px 0;
 			}
+			.ast-related-post-title {
+				margin: 10px 0;
+			}
 			.ast-page-builder-template .ast-related-posts-title-section {
 				padding: 0 20px;
 			}

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					'related-posts-title-font-family'      => 'inherit',
 					'related-posts-title-font-weight'      => 'inherit',
 					'related-posts-title-text-transform'   => '',
-					'related-posts-title-line-height'      => '',
+					'related-posts-title-line-height'      => '1',
 					'related-posts-title-font-size'        => array(
 						'desktop'      => '20',
 						'tablet'       => '',

--- a/inc/customizer/configurations/layout/class-astra-related-posts-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-related-posts-configs.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Astra_Related_Posts_Configs' ) ) {
 					'control'  => 'ast-toggle-control',
 					'title'    => __( 'Enable Related Posts', 'astra' ),
 					'section'  => 'section-blog-single',
-					'priority' => 9,
+					'priority' => 10,
 				),
 
 				/**


### PR DESCRIPTION
### Description
- Added default line-height to 1 & top-bottom margin space for individual post title & Related Posts 

### Screenshots
- https://share.getcloudapp.com/Blu4xgGB

### Types of changes
- Default updated
- Corrected priority of Enable Related Posts toggle control as one of addon's control overriding that
- Updated static CSS for top-bottom margin space

### How has this been tested?
- With Related Posts section

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
