### PR TITLE
AST-372 - fix: Full width Stretched layout width compatibility with Related Posts section

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3543,12 +3543,15 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				border-top: 1px solid #eeeeee;
 			}
 			.ast-related-posts-title {
+				margin: 20px 0;
+			}
+			.ast-separate-container .ast-related-posts-title {
 				margin: 0 0 20px 0;
 			}
-			.ast-page-builder-template .ast-related-posts-title-section {
+			.ast-page-builder-template .ast-related-posts-title-section, .ast-page-builder-template .ast-single-related-posts-container {
 				padding: 0 20px;
 			}
-			.ast-page-builder-template .ast-related-post .entry-header {
+			.ast-page-builder-template .ast-related-post .entry-header, .ast-related-post-content .entry-header, .ast-related-post-content .entry-meta {
 				margin: auto auto 1em auto;
 				padding: 0;
 			}
@@ -3564,17 +3567,10 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				padding: 0;
 				margin: 0;
 				width: 100%;
-				-js-display: flex;
-				display: flex;
 				position: relative;
 			}
 			.ast-related-post-content .entry-meta {
 				margin-top: 0.5em;
-				margin-bottom: 1em;
-			}
-			.ast-related-post-content .entry-header {
-				margin-bottom: 1em;
-				word-wrap: break-word;
 			}
 			.ast-related-posts-inner-section .post-thumb-img-content {
 				margin: 0;


### PR DESCRIPTION
### Description
- Section should be strict in container width when it is FullWidth Stretched

### Screenshots
- Issue - https://share.getcloudapp.com/wbuwbAvz

### Types of changes
- CSS updated
- Optimized static CSS with duplicate ones and make it common CSS with merging selectors

### How has this been tested?
- With Related Posts section 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
