### PR TITLE
AST-377 - fix: Spacing make equal to 1em in between all possible combinations in Related Posts

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3568,6 +3568,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				display: flex;
 				position: relative;
 			}
+			.ast-related-post-featured-section + .entry-header, .ast-related-post-featured-section + .entry-content {
+				margin-top: 1em;
+			}
 			.ast-related-post-content .entry-meta {
 				margin-top: 0.5em;
 				margin-bottom: 1em;


### PR DESCRIPTION
### Description
- Made equal spacings of 1em in all possible cases of Related Posts structure

### Screenshots
- https://share.getcloudapp.com/DOuDBWbW
- https://share.getcloudapp.com/RBuYLN84
- https://share.getcloudapp.com/WnuY01jY

### Types of changes
- In some cases already 1em spacing is there but after image section any section don't have much spacing
- So made this equal to 1em

### How has this been tested?
- With Related Posts

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
