### PR TITLE
AST-383 - fix: Elementor archive page layout issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.3
+- Fix: Elementor - Theme Builder archive page contents are not aligned center.
+
 v3.3.2
 - Fix: Transparent Header disappears if we add Widget 2 element.
 - Fix: Builder - Multiple headers visible on frontend.

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -120,6 +120,13 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 
 				$dynamic_css .= $parse_css;
 			}
+			
+			$elementor_archive_page_css = array(
+				'.elementor-template-full-width .ast-container' => array(
+					'display' => 'block',
+				),
+			);
+			$dynamic_css               .= astra_parse_css( $elementor_archive_page_css );
 
 			return $dynamic_css;
 		}


### PR DESCRIPTION
### Description
- Layout issue on an Archive page created using Elementor.
- https://wp-astra.atlassian.net/browse/AST-383
-  Due to flex property for primary and secondary content the elementor archive page without sidebar causing the layouts issue.
- I have also very with other theme like GP with same flex property for primary and secondary and they have managed by adding compatibility CSS.

### Screenshots
![image](https://user-images.githubusercontent.com/68580547/115663846-b7c00480-a35e-11eb-818c-a0866c2ca2bb.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
