### PR TITLE
AST-399 - fix: Lifter LMS section missing in customizer because file require code was missing from v3.0.0

### DIFF
--- a/inc/compatibility/lifterlms/class-astra-lifterlms.php
+++ b/inc/compatibility/lifterlms/class-astra-lifterlms.php
@@ -182,6 +182,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			 */
 			require ASTRA_THEME_DIR . 'inc/compatibility/lifterlms/customizer/sections/class-astra-lifter-container-configs.php';
 			require ASTRA_THEME_DIR . 'inc/compatibility/lifterlms/customizer/sections/class-astra-lifter-sidebar-configs.php';
+			require ASTRA_THEME_DIR . 'inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php';
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
 		}
 
@@ -768,7 +769,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 
 		/**
 		 * Llms single lesson static CSS move to dynamic to load conditionally.
-		 * 
+		 *
 		 * @since 3.3.0
 		 * @return string
 		 */
@@ -777,51 +778,51 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			.single-lesson.ast-separate-container .llms-lesson-preview .llms-lesson-link {
 				background: #fff;
 			}
-			  
+
 			.single-lesson.ast-separate-container .llms-lesson-preview .llms-lesson-link:hover {
 				background: #fafafa;
 			}
-			  
+
 			.single-lesson .ast-article-single .llms-lesson-button-wrapper {
 				font-weight: 600;
 			}
-			  
+
 			.single-lesson .ast-article-single .llms-lesson-button-wrapper .llms-complete-lesson-form .llms-field-button:before {
 				content: "\2714";
 				margin-right: .5em;
 			}
-			  
+
 			.single-lesson .llms-course-navigation {
 				padding: 2em 0 0;
 				border-top: 1px solid #eeeeee;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-lesson-preview {
 				vertical-align: top;
 				margin-top: 0;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-lesson-preview .llms-lesson-link {
 				padding-left: 20px;
 				padding-right: 20px;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-prev-lesson h6.llms-pre-text:before {
 				content: "\2190";
 				margin-right: .5em;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-back-to-course:first-child h6.llms-pre-text:before {
 				content: "\2190";
 				margin-right: .5em;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-prev-lesson ~ .llms-back-to-course h6.llms-pre-text:after,
 			.single-lesson .llms-course-navigation .llms-next-lesson h6.llms-pre-text:after {
 				content: "\2192";
 				margin-left: 5px;
 			}
-			  
+
 			.single-lesson .llms-course-navigation .llms-prev-lesson ~ .llms-back-to-course .llms-lesson-title,
 			.single-lesson .llms-course-navigation .llms-prev-lesson ~ .llms-back-to-course .llms-lesson-excerpt,
 			.single-lesson .llms-course-navigation .llms-prev-lesson ~ .llms-back-to-course h6.llms-pre-text,
@@ -830,7 +831,7 @@ if ( ! class_exists( 'Astra_LifterLMS' ) ) :
 			.single-lesson .llms-course-navigation .llms-next-lesson h6.llms-pre-text {
 				text-align: right;
 			}
-			  
+
 			@media (max-width: 544px) {
 				.single-lesson .llms-course-navigation {
 				  padding-top: 1.5em;

--- a/inc/compatibility/lifterlms/customizer/class-astra-liferlms-section-configs.php
+++ b/inc/compatibility/lifterlms/customizer/class-astra-liferlms-section-configs.php
@@ -38,6 +38,17 @@ if ( ! class_exists( 'Astra_Liferlms_Section_Configs' ) ) {
 					'priority' => 65,
 					'title'    => __( 'LifterLMS', 'astra' ),
 				),
+
+				/**
+				 * General Section
+				 */
+				array(
+					'name'     => 'section-lifterlms-general',
+					'type'     => 'section',
+					'title'    => __( 'General', 'astra-addon' ),
+					'section'  => 'section-lifterlms',
+					'priority' => 0,
+				),
 			);
 
 			return array_merge( $configurations, $_configs );

--- a/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
+++ b/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
@@ -30,6 +30,12 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 		 */
 		public function register_configuration( $configurations, $wp_customize ) {
 
+			if ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'lifterlms' ) ) {
+				$divider_array = array( 'ast_class' => 'ast-bottom-divider' );
+			} else {
+				$divider_array = array();
+			}
+
 			$_configs = array(
 
 				/**
@@ -83,7 +89,7 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 						'min'  => 1,
 						'max'  => 6,
 					),
-					'divider'           => array( 'ast_class' => 'ast-bottom-divider' ),
+					'divider'           => $divider_array,
 				),
 			);
 

--- a/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
+++ b/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
@@ -32,10 +32,10 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 
 			if ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'lifterlms' ) ) {
 				$divider_array = array( 'ast_class' => 'ast-bottom-divider' );
-				$section = 'section-lifterlms-general';
+				$section       = 'section-lifterlms-general';
 			} else {
 				$divider_array = array();
-				$section = 'section-lifterlms';
+				$section       = 'section-lifterlms';
 			}
 
 			$_configs = array(

--- a/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
+++ b/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
@@ -32,8 +32,10 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 
 			if ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'lifterlms' ) ) {
 				$divider_array = array( 'ast_class' => 'ast-bottom-divider' );
+				$section = 'section-lifterlms-general';
 			} else {
 				$divider_array = array();
+				$section = 'section-lifterlms';
 			}
 
 			$_configs = array(
@@ -46,7 +48,7 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 					'type'              => 'control',
 					'control'           => 'ast-responsive-slider',
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_responsive_slider' ),
-					'section'           => 'section-lifterlms-general',
+					'section'           => $section,
 					'default'           => astra_get_option(
 						'llms-course-grid',
 						array(
@@ -73,7 +75,7 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 					'type'              => 'control',
 					'control'           => 'ast-responsive-slider',
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_responsive_slider' ),
-					'section'           => 'section-lifterlms-general',
+					'section'           => $section,
 					'default'           => astra_get_option(
 						'llms-membership-grid',
 						array(

--- a/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
+++ b/inc/compatibility/lifterlms/customizer/sections/layout/class-astra-lifter-general-configs.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 					'type'              => 'control',
 					'control'           => 'ast-responsive-slider',
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_responsive_slider' ),
-					'section'           => 'section-lifterlms',
+					'section'           => 'section-lifterlms-general',
 					'default'           => astra_get_option(
 						'llms-course-grid',
 						array(
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Astra_Lifter_General_Configs' ) ) {
 					'type'              => 'control',
 					'control'           => 'ast-responsive-slider',
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_responsive_slider' ),
-					'section'           => 'section-lifterlms',
+					'section'           => 'section-lifterlms-general',
 					'default'           => astra_get_option(
 						'llms-membership-grid',
 						array(


### PR DESCRIPTION
### Description
- LifterLMS section missing in customizer because their controls file did not loaded
- Doc Link - https://wpastra.com/docs/lifterlms-free/ 

### Screenshots
- https://share.bsf.io/Blu4RJdg

### Types of changes
- Non-breaking change

### How has this been tested?
- With Lifter plugin
- With free Astra theme

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
