### PR TITLE
AST-380 -  fix: Removed unwanted divider in Off-Canvas settings section

### DIFF
--- a/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
@@ -153,6 +153,9 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							'value'    => true,
 						),
 					),
+					'divider'           => array(
+						'ast_class' => 'ast-bottom-divider',
+					),
 				),
 
 				// Option Group: Menu Color.
@@ -167,7 +170,6 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 					'context'    => Astra_Builder_Helper::$design_tab,
 					'responsive' => true,
 					'divider'    => array(
-						'ast_class' => 'ast-top-divider',
 						'ast_title' => __( 'Menu Color', 'astra' ),
 					),
 				),


### PR DESCRIPTION
### Description
Task - https://wp-astra.atlassian.net/browse/AST-380

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Checked if there are no unwanted dividers present in Off-Canvas settings section

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've included any necessary tests <!-- if applicable -->