### PR TITLE
fix: Cherry-pick Page Builder's menu elements shows double arrow icons when Astra's SVG icons are enabled.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v3.4.3
 - Fix: Search widget not working inside menu on mobile devices.
 - Fix: Elementor popup close on click of input fields.
+- Fix: Page Builder's menu elements show double arrow icons when Astra's SVG icons are enabled.
 
 v3.4.2
 - Fix: JS console error when Off-canvas type 'Dropdown' is selected.

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -399,8 +399,9 @@ function astra_dropdown_icon_to_menu_link( $title, $item, $args, $depth ) {
 	 *
 	 * @since 3.3.0
 	 */
-	$skip_menu_locations = array(
-		'ast-hf-account-menu',
+	$astra_menu_locations = array(
+		'ast-hf-menu-1',        // Builder - Primary menu.
+		'ast-hf-menu-2',        // Builder - Secondary menu.
 		'ast-hf-menu-3',
 		'ast-hf-menu-4',
 		'ast-hf-menu-5',
@@ -408,10 +409,30 @@ function astra_dropdown_icon_to_menu_link( $title, $item, $args, $depth ) {
 		'ast-hf-menu-7',
 		'ast-hf-menu-8',
 		'ast-hf-menu-9',
-		'ast-hf-menu-10',
+		'ast-hf-menu-10',       // Cloned builder menus.
+		'ast-hf-mobile-menu',   // Builder - Mobile Menu.
+		'ast-hf-account-menu',  // Builder - Login Account Menu.
+		'primary-menu',         // Old header - Primary Menu.
+		'above_header-menu',    // Old header - Above Menu.
+		'below_header-menu',    // Old header - Below Menu.
 	);
 
-	if ( ! ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'nav-menu' ) && ( isset( $args->container_class ) && ! in_array( $args->menu_id, $skip_menu_locations ) ) ) ) {
+	$load_svg_menu_icons = false;
+
+	if ( defined( 'ASTRA_EXT_VER' ) ) {
+		// Check whether Astra Pro is active + Nav menu addon is deactivate + menu registered by Astra only.
+		if ( ! Astra_Ext_Extension::is_active( 'nav-menu' ) && in_array( $args->menu_id, $astra_menu_locations ) ) {
+			$load_svg_menu_icons = true;
+		}
+	} else {
+		// Check menu registered by Astra only.
+		if ( in_array( $args->menu_id, $astra_menu_locations ) ) {
+			$load_svg_menu_icons = true;
+		}
+	}
+
+	if ( $load_svg_menu_icons ) {
+		// Assign icons to only those menu which are registered by Astra.
 		$icon = Astra_Icons::get_icons( 'arrow' );
 	}
 	foreach ( $item->classes as $value ) {


### PR DESCRIPTION
### Description
https://github.com/brainstormforce/astra/pull/2664 - cherry pick

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
