### PR TITLE
chore: Cherry-pick editor selection color not working in after wp-5.7 versions.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 v3.4.4
 - Fix: Dropdown menu disappears while scrolling on mobile device.
+- Fix: Editor selection color not visible on default background color setting.
+- Fix: Placeholder for title not visible when the default(white) background is set for the content.
+- Fix: Image caption not visible in the editor view.
 
 v3.4.3
 - Improvement: Builder - WooCommerce & EDD Cart - Compatibility with Border width option for cart outline style from Astra Pro. (https://wpastra.com/docs/remove-border-around-cart/)

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -192,9 +192,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'.block-editor-block-list__layout .block-editor-block-list__block ::selection,.block-editor-block-list__layout .block-editor-block-list__block.is-multi-selected .editor-block-list__block-edit' => array(
 					'color' => esc_attr( $selection_text_color ),
 				),
-				'.edit-post-layout .interface-interface-skeleton__content' => array(
-					'background' => 'transparent',
-				),
 				'.ast-separate-container .edit-post-visual-editor, .ast-page-builder-template .edit-post-visual-editor, .ast-plain-container .edit-post-visual-editor, .ast-separate-container #wpwrap #editor .edit-post-visual-editor' => astra_get_responsive_background_obj( $box_bg_obj, 'desktop' ),
 				'.editor-post-title__block,.editor-default-block-appender,.block-editor-block-list__block' => array(
 					'max-width' => astra_get_css_value( $site_content_width, 'px' ),
@@ -312,16 +309,43 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 			);
 
 			if ( astra_wp_version_compare( '5.7', '>=' ) ) {
+				$base_background_color = astra_get_responsive_background_obj( $box_bg_obj, 'desktop' );
+				if ( empty( $base_background_color ) ) {
+					$background_style_data = array(
+						'background-color' => '#ffffff',
+					);
+				} else {
+					$background_style_data = $base_background_color;
+				}
+
 				$desktop_css['.edit-post-visual-editor']                            = array(
-					'padding' => '20px',
+					'padding'     => '20px',
+					'padding-top' => 'calc(2em + 20px)',
 				);
 				$desktop_css['.ast-page-builder-template .edit-post-visual-editor'] = array(
+					'padding'     => '0',
+					'padding-top' => '2em',
+				);
+				$desktop_css['.ast-separate-container .editor-post-title']          = array(
+					'margin-top' => '0',
+				);
+				$desktop_css['.editor-styles-wrapper .block-editor-writing-flow']   = array(
+					'height'  => '100%',
 					'padding' => '10px',
 				);
 				$desktop_css['.edit-post-visual-editor .editor-styles-wrapper']     = array(
-					'padding'    => '0',
-					'background' => 'transparent',
+					'max-width' => astra_get_css_value( $site_content_width - 56, 'px' ),
+					'margin'    => '0 auto',
+					'padding'   => '0',
 				);
+				$desktop_css['.ast-page-builder-template .edit-post-visual-editor .editor-styles-wrapper'] = array(
+					'max-width' => '100%',
+				);
+				$desktop_css['.ast-separate-container .edit-post-visual-editor .block-editor-block-list__layout .wp-block[data-align="full"] figure.wp-block-image, .ast-separate-container .edit-post-visual-editor .wp-block[data-align="full"] .wp-block-cover'] = array(
+					'margin-left'  => 'calc(-4.8em - 10px)',
+					'margin-right' => 'calc(-4.8em - 10px)',
+				);
+				$desktop_css['.ast-page-builder-template .editor-styles-wrapper .block-editor-writing-flow, .ast-plain-container .editor-styles-wrapper .block-editor-writing-flow, #editor .edit-post-visual-editor'] = $background_style_data;
 			}
 
 			if ( ( ( ! in_array( 'single-title-meta', $single_post_title ) ) && ( 'post' === get_post_type() ) ) || ( 'disabled' === $title_enabled_from_meta ) ) {
@@ -725,9 +749,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				),
 				'.edit-post-visual-editor h6, .wp-block-heading h6, .wp-block-freeform.block-library-rich-text__tinymce h6, .edit-post-visual-editor .wp-block-heading h6, .wp-block-heading h6.editor-rich-text__tinymce, .editor-styles-wrapper .wp-block-uagb-advanced-heading h6' => array(
 					'font-size' => astra_responsive_font( $heading_h6_font_size, 'mobile' ),
-				),
-				'.edit-post-layout .interface-interface-skeleton__content' => array(
-					'background' => 'transparent',
 				),
 				'.ast-separate-container .edit-post-visual-editor, .ast-page-builder-template .edit-post-visual-editor, .ast-plain-container .edit-post-visual-editor, .ast-separate-container #wpwrap #editor .edit-post-visual-editor' => astra_get_responsive_background_obj( $box_bg_obj, 'mobile' ),
 			);

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1504,7 +1504,7 @@ function astra_get_responsive_background_obj( $bg_obj_res, $device ) {
 
 /**
  * Common function to check is pagination is enabled on current page.
- * 
+ *
  * @since 3.0.1
  * @return boolean
  */
@@ -1514,7 +1514,7 @@ function is_astra_pagination_enabled() {
 	return ( $wp_query->max_num_pages > 1 && apply_filters( 'astra_pagination_enabled', true ) );
 }
 
-/** 
+/**
  * Verify is current post comments are enabled or not for applying dynamic CSS.
  *
  * @since 3.0.1


### PR DESCRIPTION
### Description

- #2718
- This PR fixed the following Issues:
- Block selection color not working
- Place holders not visible when the default(white) background is set for the content.
- Image caption not visible in the editor view.

### Screenshots
https://share.getcloudapp.com/Jru4Q0B0

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Cases mentioned in task - https://wp-astra.atlassian.net/browse/AST-464

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
