### PR TITLE
Update customizer call as per web stories refactored code

### DIFF
--- a/inc/compatibility/class-astra-web-stories.php
+++ b/inc/compatibility/class-astra-web-stories.php
@@ -7,8 +7,6 @@
  * @package Astra
  */
 
-use Google\Web_Stories;
-
 /**
  * Astra Web_Stories Compatibility
  *
@@ -45,12 +43,12 @@ class Astra_Web_Stories {
 	 * @return void
 	 */
 	public function web_stories_embed() {
-		if ( ! function_exists( 'Google\Web_Stories\render_theme_stories' ) ) {
+		if ( ! function_exists( '\Google\Web_Stories\render_theme_stories' ) ) {
 			return;
 		}
 
 		// Embed web stories above header with pre-configured customizer settings.
-		Web_Stories\render_theme_stories();
+		\Google\Web_Stories\render_theme_stories();
 	}
 
 	/**
@@ -65,10 +63,10 @@ class Astra_Web_Stories {
 	 */
 	public function web_stories_css( $dynamic_css, $dynamic_css_filtered = '' ) {
 		// Using function check instead of class as there can be changes in the web stories plugin later, see 1.7.1 release https://github.com/google/web-stories-wp/pull/7266/files.
-		if ( ! function_exists( 'Google\Web_Stories\render_theme_stories' ) ) {
+		if ( ! function_exists( '\Google\Web_Stories\render_theme_stories' ) ) {
 			return;
 		}
-		
+
 		$options = get_option( 'web_stories_customizer_settings' );
 
 		// bail if web stories are not enabled on the frontend.

--- a/inc/compatibility/class-astra-web-stories.php
+++ b/inc/compatibility/class-astra-web-stories.php
@@ -9,7 +9,11 @@
 
 use Google\Web_Stories;
 
-// If plugin - 'Google\Web_Stories' not exist then return.
+/**
+ * If plugin - 'Google\Web_Stories' not exist then return.
+ * Uses Web_Stories\Admin\Customizer per web stories 1.7.1 release.
+ * See https://github.com/google/web-stories-wp/pull/7266/files
+ */
 if ( ! class_exists( 'Google\Web_Stories\Admin\Customizer' ) ) {
 	return;
 }
@@ -69,6 +73,7 @@ class Astra_Web_Stories {
 	 * @return String Generated dynamic CSS for Heading Colors.
 	 */
 	public function web_stories_css( $dynamic_css, $dynamic_css_filtered = '' ) {
+		// Use Web_Stories\Admin\Customizer per web stories 1.7.1 release. See https://github.com/google/web-stories-wp/pull/7266/files
 		$options = get_option( Web_Stories\Admin\Customizer::STORY_OPTION );
 
 		// bail if web stories are not enabled on the frontend.

--- a/inc/compatibility/class-astra-web-stories.php
+++ b/inc/compatibility/class-astra-web-stories.php
@@ -10,7 +10,7 @@
 use Google\Web_Stories;
 
 // If plugin - 'Google\Web_Stories' not exist then return.
-if ( ! class_exists( 'Google\Web_Stories\Customizer' ) ) {
+if ( ! class_exists( 'Google\Web_Stories\Admin\Customizer' ) ) {
 	return;
 }
 
@@ -69,7 +69,7 @@ class Astra_Web_Stories {
 	 * @return String Generated dynamic CSS for Heading Colors.
 	 */
 	public function web_stories_css( $dynamic_css, $dynamic_css_filtered = '' ) {
-		$options = get_option( Web_Stories\Customizer::STORY_OPTION );
+		$options = get_option( Web_Stories\Admin\Customizer::STORY_OPTION );
 
 		// bail if web stories are not enabled on the frontend.
 		if ( empty( $options['show_stories'] ) || true !== $options['show_stories'] ) {

--- a/inc/compatibility/class-astra-web-stories.php
+++ b/inc/compatibility/class-astra-web-stories.php
@@ -10,15 +10,6 @@
 use Google\Web_Stories;
 
 /**
- * If plugin - 'Google\Web_Stories' not exist then return.
- * Uses Web_Stories\Admin\Customizer per web stories 1.7.1 release.
- * See https://github.com/google/web-stories-wp/pull/7266/files
- */
-if ( ! class_exists( 'Google\Web_Stories\Admin\Customizer' ) ) {
-	return;
-}
-
-/**
  * Astra Web_Stories Compatibility
  *
  * @since 3.2.0
@@ -73,8 +64,12 @@ class Astra_Web_Stories {
 	 * @return String Generated dynamic CSS for Heading Colors.
 	 */
 	public function web_stories_css( $dynamic_css, $dynamic_css_filtered = '' ) {
-		// Use Web_Stories\Admin\Customizer per web stories 1.7.1 release. See https://github.com/google/web-stories-wp/pull/7266/files
-		$options = get_option( Web_Stories\Admin\Customizer::STORY_OPTION );
+		// Using function check instead of class as there can be changes in the web stories plugin later, see 1.7.1 release https://github.com/google/web-stories-wp/pull/7266/files.
+		if ( ! function_exists( 'Google\Web_Stories\render_theme_stories' ) ) {
+			return;
+		}
+		
+		$options = get_option( 'web_stories_customizer_settings' );
 
 		// bail if web stories are not enabled on the frontend.
 		if ( empty( $options['show_stories'] ) || true !== $options['show_stories'] ) {


### PR DESCRIPTION
### Description
In the web stories plugin version 1.7.1, the code was refactored and plugin structure got changed. 
Updated web stories code as per the refactoring of web stories. See https://github.com/google/web-stories-wp/pull/7266/files

### Types of changes
Bug fix - web stories customizer disappeared due to recent web stories refactor changes. 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 