### PR TITLE
AST-511 - fix: spacing CSS missing when inline logo and title option is enabled

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -583,7 +583,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 
 			$page_header_logo = ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'advanced-headers' ) && Astra_Ext_Advanced_Headers_Loader::astra_advanced_headers_design_option( 'logo-url' ) ) ? true : false;
 
-			if ( true === astra_get_option( 'logo-title-inline' ) ) {
+			if ( astra_get_option( 'logo-title-inline' ) ) {
 				$css_output['.ast-logo-title-inline .site-logo-img'] = array(
 					'padding-right' => '1em',
 				);

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -583,15 +583,17 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 
 			$page_header_logo = ( defined( 'ASTRA_EXT_VER' ) && Astra_Ext_Extension::is_active( 'advanced-headers' ) && Astra_Ext_Advanced_Headers_Loader::astra_advanced_headers_design_option( 'logo-url' ) ) ? true : false;
 
+			if ( true === astra_get_option( 'logo-title-inline' ) ) {
+				$css_output['.ast-logo-title-inline .site-logo-img'] = array(
+					'padding-right' => '1em',
+				);
+			}
+			
 			if ( get_theme_mod( 'custom_logo' ) 
 				|| astra_get_option( 'transparent-header-logo' ) 
 				|| astra_get_option( 'sticky-header-logo' ) 
 				|| $page_header_logo 
 				|| is_customize_preview() ) {
-
-				$css_output['.ast-logo-title-inline .site-logo-img'] = array(
-					'padding-right' => '1em',
-				);
 
 				$css_output['.site-logo-img img'] = array(
 					' transition' => 'all 0.2s linear',


### PR DESCRIPTION
### Description
- Spacing css missing when inline logo and title option is enabled.
- https://wp-astra.atlassian.net/browse/AST-511

### Screenshots

fix - https://share.bsf.io/Wnux1p5q

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
