### PR TITLE
AST-554 Fix: Customizer not working when Gutenberg plugin v10.7.0 and above is active.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@ v3.5.0 (Unreleased)
 - Fix: Footer Builder - Hide on mobile/tablet for above footer is not working on frontend.
 
 v3.4.8
-- Fix: Customizer not working when latest Gutenberg plugin is active.
+- Fix: Customizer not working when Gutenberg plugin v10.7.0 and above is active.
 
 v3.4.7
 - Updated the theme screenshot and added license information for the images used in the screenshot.

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,9 @@ v3.5.0 (Unreleased)
 - Fix: WooCommerce - "Product Categories" widget's child elements have missing icon when Astra's SVGs enabled.
 - Fix: Footer Builder - Hide on mobile/tablet for above footer is not working on frontend.
 
+v3.4.8
+- Fix: Customizer not working when latest Gutenberg plugin is active.
+
 v3.4.7
 - Updated the theme screenshot and added license information for the images used in the screenshot.
 

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			}
 			
 			// Disable block editor for widgets in the customizer.
-			if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.7.1', '>=' ) && is_customize_preview() ) {
+			if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.6.2', '>' ) && is_customize_preview() ) {
 				add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
 			}
 

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -113,12 +113,6 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			add_action( 'customize_preview_init', array( $this, 'preview_init' ) );
 
 			if ( is_admin() || is_customize_preview() ) {
-
-				// Disable block editor for widgets in the customizer.
-				if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.7.1', '>=' ) ) {
-					add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
-				}
-
 				add_action( 'customize_register', array( $this, 'include_configurations' ), 2 );
 				add_action( 'customize_register', array( $this, 'prepare_customizer_javascript_configs' ) );
 				add_action( 'customize_register', array( $this, 'astra_pro_upgrade_configurations' ), 2 );
@@ -127,6 +121,11 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 				add_filter( 'customize_dynamic_setting_args', array( $this, 'filter_dynamic_setting_args' ), 10, 2 );
 				add_filter( 'customize_dynamic_partial_args', array( $this, 'filter_dynamic_partial_args' ), 10, 2 );
 
+			}
+			
+			// Disable block editor for widgets in the customizer.
+			if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.7.1', '>=' ) && is_customize_preview() ) {
+				add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
 			}
 
 			add_action( 'customize_controls_enqueue_scripts', array( $this, 'controls_scripts' ) );

--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -113,6 +113,12 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			add_action( 'customize_preview_init', array( $this, 'preview_init' ) );
 
 			if ( is_admin() || is_customize_preview() ) {
+
+				// Disable block editor for widgets in the customizer.
+				if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.7.1', '>=' ) ) {
+					add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
+				}
+
 				add_action( 'customize_register', array( $this, 'include_configurations' ), 2 );
 				add_action( 'customize_register', array( $this, 'prepare_customizer_javascript_configs' ) );
 				add_action( 'customize_register', array( $this, 'astra_pro_upgrade_configurations' ), 2 );


### PR DESCRIPTION
### Description
There is a console error in the customizer view when the plugin is active. This error is from the JS which is added for the block editor support for widgets from the Gutenberg plugin. As of now I have added a filter to disable block editor support.

### Screenshots
https://share.getcloudapp.com/xQu7ZlE8

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Checked the working of customizer with and without the Gutenberg plugin.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
