### PR TITLE
AST-604 - 'Preload Local Fonts' option affects on height of Gutenberg Cover edit block

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 v3.6.2
-- Fix: 'Preload Local Fonts' option affects on height of Gutenberg Cover edit block.
+- Fix: Enable 'Preload Local Fonts' option affects on height of Gutenberg Cover edit block.
 
 v3.6.1
 - Fix: Theme check warning - Replaced search form markup with get_search_form().

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.6.2
+- Fix: 'Preload Local Fonts' option affects on height of Gutenberg Cover edit block.
+
 v3.6.1
 - Fix: Theme check warning - Replaced search form markup with get_search_form().
 - Fix: Both desktop and mobile headers appearing on desktop due to Astra's cache.

--- a/inc/customizer/class-astra-fonts.php
+++ b/inc/customizer/class-astra-fonts.php
@@ -123,7 +123,7 @@ final class Astra_Fonts {
 		 *
 		 * @since 3.6.0
 		 */
-		if ( astra_get_option( 'load-google-fonts-locally' ) && ! is_customize_preview() ) {
+		if ( astra_get_option( 'load-google-fonts-locally' ) && ! is_customize_preview() && ! is_admin() ) {
 			if ( astra_get_option( 'preload-local-fonts' ) ) {
 				ast_load_preload_local_fonts( $google_font_url );
 			}


### PR DESCRIPTION
### Description
- Preloading option affects height 100% for cover edit block

### Screenshots
- https://drive.google.com/file/d/1DoaLJf_oaRAujnJYDDogosqxP4XwvS0R/view

### Types of changes
- Bug fix 

### How has this been tested?
- As steps mentioned here - https://wp-astra.atlassian.net/browse/AST-604

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request
