### PR TITLE
AST-596 - Individual related post article showing meta markup based on current post filters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.6.2
+- Fix: Related Posts articles showing meta structure based on current active post.
+
 v3.6.1
 - Fix: Theme check warning - Replaced search form markup with get_search_form().
 - Fix: Both desktop and mobile headers appearing on desktop due to Astra's cache.

--- a/inc/modules/related-posts/class-astra-related-posts-markup.php
+++ b/inc/modules/related-posts/class-astra-related-posts-markup.php
@@ -51,7 +51,6 @@ class Astra_Related_Posts_Markup {
 		$related_posts_title       = astra_get_option( 'related-posts-title' );
 		$related_post_meta         = astra_get_option( 'related-posts-meta-structure' );
 		$related_post_structure    = astra_get_option_meta( 'related-posts-structure' );
-		$output_str                = astra_get_post_meta( $related_post_meta );
 		$exclude_ids               = apply_filters( 'astra_related_posts_exclude_post_ids', array( $post_id ), $post_id );
 		$related_posts_total_count = absint( astra_get_option( 'related-posts-total-count', 2 ) );
 
@@ -88,6 +87,7 @@ class Astra_Related_Posts_Markup {
 			while ( $query_posts->have_posts() && $post_counter < $total_posts_count ) {
 				$query_posts->the_post();
 				$post_id = get_the_ID();
+				$output_str = astra_get_post_meta( $related_post_meta );
 
 				if ( is_array( $exclude_ids ) && ! in_array( $post_id, $exclude_ids ) ) {
 

--- a/inc/modules/related-posts/class-astra-related-posts-markup.php
+++ b/inc/modules/related-posts/class-astra-related-posts-markup.php
@@ -86,7 +86,7 @@ class Astra_Related_Posts_Markup {
 
 			while ( $query_posts->have_posts() && $post_counter < $total_posts_count ) {
 				$query_posts->the_post();
-				$post_id = get_the_ID();
+				$post_id    = get_the_ID();
 				$output_str = astra_get_post_meta( $related_post_meta );
 
 				if ( is_array( $exclude_ids ) && ! in_array( $post_id, $exclude_ids ) ) {


### PR DESCRIPTION
### Description
- Meta markup structure for Related Posts showing structure based on active post

### Screenshots
- Issue - https://drive.google.com/file/d/1hhdVBekMi1SdRPrHw4tg4PwUZGh9aGM7/view
- Issue with master - https://share.bsf.io/xQu7jLgr
- With this PR - https://share.bsf.io/4gunP9yD

### Types of changes
- Bug fix
- Moved meta query structure from before loop to inside loop

### How has this been tested?
- With above explanatory video

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
