### PR TITLE
AST-529 - fix: Due to CSS priority Header and Menu are not aligned after dynamic break point changes.

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -2266,14 +2266,14 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			
 			if ( Astra_Builder_Helper::apply_flex_based_css() ) {
 				$max_site_container_css = array(
-					'.ast-container' => array(
+					'.site-content .ast-container' => array(
 						'display' => 'flex',
 					),
 				);
 				$parse_css             .= astra_parse_css( $max_site_container_css, astra_get_tablet_breakpoint( '', 1 ) );
 
 				$min_site_container_css = array(
-					'.ast-container' => array(
+					'.site-content .ast-container' => array(
 						'flex-direction' => 'column',
 					),
 				);


### PR DESCRIPTION
### Description
- Due to CSS priority Header and Menu are not aligned after dynamic breakpoint changes.
- https://wp-astra.atlassian.net/browse/AST-529
- Link PR- https://github.com/brainstormforce/astra/pull/2845

<!-- Please describe what you have changed or added -->

### Screenshots
Issue - https://share.getcloudapp.com/yAurkl0o
Fix - https://share.getcloudapp.com/4gunZJZy

### Types of changes
Bug fix (non-breaking change which fixes an issue)


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
