### PR TITLE
AST-622 - Builder - WooCommerce & EDD cart - Cart and Checkout buttons not visible when multiple products added to cart flyout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ v3.7.0 (Unreleased)
 - Fix: Global headings font family not working in the Gutenberg editor.
 - Fix: Footer Builder - Widgets - Right margin space not working.
 - Fix: Search icon color is not applying to the Standard and Transparent Header Search Box style.
+- Fix: Builder - WooCommerce & EDD cart - Cart and Checkout buttons not visible when multiple products added to cart flyout.
 
 v3.6.2
 - Fix: Enable 'Preload Local Fonts' option affects on height of Gutenberg Cover edit block.

--- a/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
@@ -11,6 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Heading Colors
+ */
+add_filter( 'astra_dynamic_theme_css', 'astra_fb_widget_dynamic_css' );
+
+/**
  * Whether to fix the footer right-margin space not working case or not.
  * As this is frontend reflecting change added this backwards for existing users.
  *
@@ -22,11 +27,6 @@ function is_support_footer_widget_right_margin() {
 	$astra_settings['support-footer-widget-right-margin'] = isset( $astra_settings['support-footer-widget-right-margin'] ) ? false : true;
 	return apply_filters( 'astra_apply_right_margin_footer_widget_css', $astra_settings['support-footer-widget-right-margin'] );
 }
-
-/**
- * Heading Colors
- */
-add_filter( 'astra_dynamic_theme_css', 'astra_fb_widget_dynamic_css' );
 
 /**
  * Dynamic CSS

--- a/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
@@ -11,11 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Heading Colors
- */
-add_filter( 'astra_dynamic_theme_css', 'astra_fb_widget_dynamic_css' );
-
-/**
  * Whether to fix the footer right-margin space not working case or not.
  * As this is frontend reflecting change added this backwards for existing users.
  *
@@ -27,6 +22,11 @@ function is_support_footer_widget_right_margin() {
 	$astra_settings['support-footer-widget-right-margin'] = isset( $astra_settings['support-footer-widget-right-margin'] ) ? false : true;
 	return apply_filters( 'astra_apply_right_margin_footer_widget_css', $astra_settings['support-footer-widget-right-margin'] );
 }
+
+/**
+ * Heading Colors
+ */
+add_filter( 'astra_dynamic_theme_css', 'astra_fb_widget_dynamic_css' );
 
 /**
  * Dynamic CSS

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3393,7 +3393,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				position: fixed;
 				display: block;
 				visibility: hidden;
-				overflow: hidden;
+				overflow: auto;
 				-webkit-overflow-scrolling: touch;
 				z-index: 9999;
 				background-color: #fff;

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3490,7 +3490,18 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			}
 
 			body.admin-bar .astra-cart-drawer {
-				top: 46px;
+				padding-top: 32px;
+			}
+			body.admin-bar .astra-cart-drawer .astra-cart-drawer-close {
+				top: 32px;
+			}
+			@media (max-width: 782px) {
+				body.admin-bar .astra-cart-drawer {
+					padding-top: 46px;
+				}
+				body.admin-bar .astra-cart-drawer .astra-cart-drawer-close {
+					top: 46px;
+				}
 			}
 
 			.ast-mobile-cart-active body.ast-hfb-header {


### PR DESCRIPTION
### Description
- The Cart, on responsive devices such as Mobile, when adding too many Products, It can’t scroll to get Cart & Checkout buttons
- Dev site - http://ast-dev.xka9ibwowp-jqp3vd915350.p.runcloud.link/local-google-fonts/testing-fonts/

### Screenshots
- https://share.bsf.io/z8uOrP6e

### Types of changes
- Bug fix

### How has this been tested?
- Add multiple products to the cart 
- Check on responsive devices inside the flyout

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request
