### PR TITLE
AST-629 - fix : backward compatibility is missing for sidebar and post meta settings option.

### DIFF
--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -116,9 +116,10 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					'blog-single-width'                    => 'default',
 					'blog-single-max-width'                => 1200,
 					'blog-single-meta'                     => array(
+						! $apply_new_default_values ? 'comments' : '',
 						'category',
 						'author',
-						'date',
+						$apply_new_default_values ? 'date' : '',
 					),
 					// Blog.
 					'blog-post-structure'                  => array(
@@ -129,9 +130,10 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					'blog-max-width'                       => 1200,
 					'blog-post-content'                    => 'excerpt',
 					'blog-meta'                            => array(
+						! $apply_new_default_values ? 'comments' : '',
 						'category',
 						'author',
-						'date',
+						$apply_new_default_values ? 'date' : '',
 					),
 					// Colors.
 					'text-color'                           => '#3a3a3a',

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -466,7 +466,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					),
 
 					// Sidebar.
-					'site-sidebar-layout'                  => 'no-sidebar',
+					'site-sidebar-layout'                  => $apply_new_default_values ? 'no-sidebar' : 'right-sidebar',
 					'site-sidebar-width'                   => 30,
 					'single-page-sidebar-layout'           => 'default',
 					'single-post-sidebar-layout'           => 'default',


### PR DESCRIPTION
### Description
- Backward compatibility is missing for the sidebar and post meta settings option.
- https://wp-astra.atlassian.net/browse/AST-629

### Screenshots
<!-- if applicable -->

### Types of changes
Bug fix (non-breaking change which fixes an issue) .


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
