### PR TITLE
GCP-23 - fix- Applied default text color to widget content

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -545,6 +545,14 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 
 			);
 
+			// Default widget content color.
+			if ( self::is_support_link_default_color() ) {
+				// Widget Title.
+				$css_output['.textwidget'] = array(
+					'color' => esc_attr( $text_color ),
+				);
+			}
+
 			// Remove this condition after 2-3 updates of add-on.
 			if ( defined( 'ASTRA_EXT_VER' ) && version_compare( ASTRA_EXT_VER, '3.0.1', '>=' ) ) {
 				$css_output['.single .ast-author-details .author-title'] = array(
@@ -2703,6 +2711,19 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 
 			return apply_filters( 'astra_theme_dynamic_css', $parse_css );
 
+		}
+
+		/**
+		 * Whether to apply link default color or not.
+		 * As this is frontend reflecting change added this backwards for existing users.
+		 *
+		 * @since x.x.x
+		 * @return boolean false if it is an existing user, true if not.
+		 */
+		public function is_support_link_default_color() {
+			$astra_settings                               = get_option( ASTRA_THEME_SETTINGS );
+			$astra_settings['support-link-default-color'] = isset( $astra_settings['support-link-default-color'] ) ? false : true;
+			return apply_filters( 'astra_apply_link_default_color_css', $astra_settings['support-link-default-color'] );
 		}
 
 		/**

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -3084,3 +3084,18 @@ function astra_clear_all_assets_cache() {
 		$astra_addon_cache_base_instance->refresh_assets( 'astra-addon' );
 	}
 }
+
+/**
+ * Link default color compatibility.
+ *
+ * @since x.x.x
+ * @return void.
+ */
+function astra_link_default_color() {
+	$theme_options = get_option( 'astra-settings', array() );
+
+	if ( ! isset( $theme_options['support-link-default-color'] ) ) {
+		$theme_options['support-link-default-color'] = false;
+		update_option( 'astra-settings', $theme_options );
+	}
+}

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -93,6 +93,9 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 			'3.6.1' => array(
 				'astra_clear_all_assets_cache',
 			),
+			'3.6.2' => array(
+				'astra_link_default_color',
+			),
 		);
 
 		/**


### PR DESCRIPTION
### Description
Task - https://wp-astra.atlassian.net/browse/GCP-23

### Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

### How has this been tested?
Checked if the new default color is applied only for new users and not the existing one.

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
