### PR TITLE
AST-739 - Offcanvas header's preview is displaying on Legacy widget's preview in customizer of WordPress 5.8.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v3.6.8 (Unreleased)
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.
+- Fix: Header Footer Widgets: Offcanvas header's preview is displaying on Legacy widget's preview in customizer of WordPress 5.8.
 
 v3.6.7
 - Improvement: Rendered Addon dependent toggle code conditionally and removed unwanted code.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 v3.6.8 (Unreleased)
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.
-- Fix: Header Footer Widgets: Offcanvas header's preview is displaying on Legacy widget's preview in customizer of WordPress 5.8.
+- Fix: Header Footer Widgets: Offcanvas header's is displaying over Legacy widget's preview in customizer of WordPress 5.8.
 
 v3.6.7
 - Improvement: Rendered Addon dependent toggle code conditionally and removed unwanted code.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 v3.6.8 (Unreleased)
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.
-- Fix: Header Footer Widgets: Offcanvas header's is displaying over Legacy widget's preview in customizer of WordPress 5.8.
+- Fix: Header Footer Widgets: Off-canvas content is displaying over Legacy widget's preview in the customizer for WordPress 5.8.
 
 v3.6.7
 - Improvement: Rendered Addon dependent toggle code conditionally and removed unwanted code.

--- a/inc/builder/markup/class-astra-builder-header.php
+++ b/inc/builder/markup/class-astra-builder-header.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'Astra_Builder_Header' ) ) {
 				add_action( 'astra_mobile_below_header', array( $this, 'mobile_below_header' ) );
 				add_action( 'astra_render_mobile_header_column', array( $this, 'render_mobile_column' ), 10, 2 );
 				// Load Off-Canvas Markup on Footer.
-				add_action( 'wp_footer', array( $this, 'mobile_popup' ) );
+				add_action( 'astra_footer', array( $this, 'mobile_popup' ) );
 				add_action( 'astra_mobile_header_content', array( $this, 'render_mobile_column' ), 10, 2 );
 				add_action( 'astra_render_mobile_popup', array( $this, 'render_mobile_column' ), 10, 2 );
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'Astra_Builder_Header' ) ) {
 				add_action( 'astra_header_mobile_trigger', array( $this, 'header_mobile_trigger' ) );
 
 				// Load Cart Flyout Markup on Footer.
-				add_action( 'wp_footer', array( $this, 'mobile_cart_flyout' ) );
+				add_action( 'astra_footer', array( $this, 'mobile_cart_flyout' ) );
 				add_action( 'astra_header_menu_mobile', array( $this, 'header_mobile_menu_markup' ) );
 			}
 


### PR DESCRIPTION
### Description
- Offcanvas header & cart flyout menu's content displaying over preview of Legacy widgets in customizer WP5.8

### Screenshots
- https://share.bsf.io/wbubA5wL

### Types of changes
- Bug fix 

### How has this been tested?
- Test cases as follows -
- 1. Use Legacy widget (of any Menu/Archive widget)
- 2. Then set header Offcanvas style as Flyout or Fullscreen
- 3. Reload the customizer page
- 4. You will see the content from offcanvas & from flyout cart on widget preview screens
- Other test cases to test
- As we are changing wp_footer action here which loaded flyouts markup for header offcanvas & for Woo/Edd cart
- Make sure to test those functionalities as well
- Header flyout/full-screen
- Cart flyout

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
