### PR TITLE
AST-634 - Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+- Fix: Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts.
+
 v3.6.8 (Unreleased)
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
-- Fix: Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts.
-
 v3.6.8 (Unreleased)
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
+- Fix: Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.
 - Fix: Header Footer Widgets: Off-canvas content is displaying over Legacy widget's preview in the customizer for WordPress 5.8.
 

--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -279,10 +279,9 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_header() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'header' );
 			if ( $did_location ) {
+				remove_action( 'astra_header', 'astra_header_markup' );
 				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
-					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'prepare_header_builder_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
-				} else {
-					remove_action( 'astra_header', 'astra_header_markup' );
+					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'header_builder_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 				}
 			}
 		}
@@ -296,10 +295,9 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_footer() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'footer' );
 			if ( $did_location ) {
+				remove_action( 'astra_footer', 'astra_footer_markup' );
 				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
-				} else {
-					remove_action( 'astra_footer', 'astra_footer_markup' );
 				}
 			}
 		}

--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -279,8 +279,8 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_header() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'header' );
 			if ( $did_location ) {
-				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) {
-					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'prepare_header_builder_markup' ) );
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'prepare_header_builder_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 				} else {
 					remove_action( 'astra_header', 'astra_header_markup' );
 				}
@@ -296,8 +296,8 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_footer() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'footer' );
 			if ( $did_location ) {
-				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) {
-					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) );
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 				} else {
 					remove_action( 'astra_footer', 'astra_footer_markup' );
 				}

--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -279,7 +279,7 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_header() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'header' );
 			if ( $did_location ) {
-				if ( true === astra_is_header_footer_builder_active() ) {
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) {
 					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'prepare_header_builder_markup' ) );
 				} else {
 					remove_action( 'astra_header', 'astra_header_markup' );
@@ -296,7 +296,7 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_footer() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'footer' );
 			if ( $did_location ) {
-				if ( true === astra_is_header_footer_builder_active() ) {
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) {
 					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) );
 				} else {
 					remove_action( 'astra_footer', 'astra_footer_markup' );

--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -279,7 +279,11 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_header() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'header' );
 			if ( $did_location ) {
-				remove_action( 'astra_header', 'astra_header_markup' );
+				if ( true === astra_is_header_footer_builder_active() ) {
+					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'prepare_header_builder_markup' ) );
+				} else {
+					remove_action( 'astra_header', 'astra_header_markup' );
+				}
 			}
 		}
 
@@ -292,7 +296,11 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 		public function do_footer() {
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'footer' );
 			if ( $did_location ) {
-				remove_action( 'astra_footer', 'astra_footer_markup' );
+				if ( true === astra_is_header_footer_builder_active() ) {
+					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) );
+				} else {
+					remove_action( 'astra_footer', 'astra_footer_markup' );
+				}
 			}
 		}
 

--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -1152,13 +1152,3 @@ final class Astra_Builder_Helper {
  *  Kicking this off by calling 'get_instance()' method
  */
 Astra_Builder_Helper::get_instance();
-
-/**
- * Creating global function to Check if Astra's Header-Footer builder is active.
- *
- * @since x.x.x
- * @return boolean True|False
- */
-function astra_is_header_footer_builder_active() {
-	return Astra_Builder_Helper::$is_header_footer_builder_active;
-}

--- a/inc/core/builder/class-astra-builder-helper.php
+++ b/inc/core/builder/class-astra-builder-helper.php
@@ -1152,3 +1152,13 @@ final class Astra_Builder_Helper {
  *  Kicking this off by calling 'get_instance()' method
  */
 Astra_Builder_Helper::get_instance();
+
+/**
+ * Creating global function to Check if Astra's Header-Footer builder is active.
+ *
+ * @since x.x.x
+ * @return boolean True|False
+ */
+function astra_is_header_footer_builder_active() {
+	return Astra_Builder_Helper::$is_header_footer_builder_active;
+}


### PR DESCRIPTION
### Description
- Elementor Pro's built header/footer layouts not override Astra's new Header-Footer builder layouts where as it works with oild header-footer layout

### Screenshots
- Issue- - https://share.bsf.io/E0uAZ5YQ
- Working with old header-footer layout - https://share.bsf.io/qGu5xj8z

### Types of changes
- Bug fix 

### How has this been tested?
- Design header-footer layouts from Elementor+Elementor pro
- Check if its override Astra's header-footer in both old & new HFB cases

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
