### PR TITLE
chore: Cherry picked 3073 PR

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v3.6.8
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.
+- Fix: Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts.
 - Fix: Bulk action selection not working on any WordPress list table when theme's "Get Started" notice is active.
 - Fix: Header Footer Widgets: Off-canvas content is displaying over Legacy widget's preview in the customizer for WordPress 5.8.
 - Deprecated: Header Footer Widgets - Deprecated design specific options for better compatibility with WordPress 5.8. ( Needs Doc )

--- a/inc/compatibility/class-astra-elementor-pro.php
+++ b/inc/compatibility/class-astra-elementor-pro.php
@@ -280,6 +280,9 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'header' );
 			if ( $did_location ) {
 				remove_action( 'astra_header', 'astra_header_markup' );
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+					remove_action( 'astra_header', array( \Astra_Builder_Header::get_instance(), 'header_builder_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+				}
 			}
 		}
 
@@ -293,6 +296,9 @@ if ( ! class_exists( 'Astra_Elementor_Pro' ) ) :
 			$did_location = Module::instance()->get_locations_manager()->do_location( 'footer' );
 			if ( $did_location ) {
 				remove_action( 'astra_footer', 'astra_footer_markup' );
+				if ( true === \Astra_Builder_Helper::$is_header_footer_builder_active ) { // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+					remove_action( 'astra_footer', array( \Astra_Builder_Footer::get_instance(), 'footer_markup' ) ); // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_namespaceFound, PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description
- Cherry-picked PR - https://github.com/brainstormforce/astra/pull/3073
- Elementor Pro's Header-Footer theme builder layouts does not override theme's Header-Footer builder layouts
- Task- https://wp-astra.atlassian.net/browse/AST-634

### Types of changes
- non-breaking change 

### How has this been tested?
- Design header-footer layouts from Elementor+Elementor pro
- Check if its override Astra's header-footer in both old & new HFB cases

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've included developer documentation
- [x] I've added proper labels to this pull request 
