### PR TITLE
Added responsive cases for site title and tagline font size

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/Site-identity/site-tagline.test.js
+++ b/tests/e2e/specs/customizer/header-builder/Site-identity/site-tagline.test.js
@@ -1,4 +1,4 @@
-import { createURL } from '@wordpress/e2e-test-utils';
+import { createURL, setBrowserViewport, } from '@wordpress/e2e-test-utils';
 import { setCustomize } from '../../../../utils/set-customize';
 
 describe( 'Site Tagline Typography settings and color settings in the customizer', () => {
@@ -14,7 +14,7 @@ describe( 'Site Tagline Typography settings and color settings in the customizer
 			'body-font-weight': '800',
 			'body-text-transform': 'uppercase',
 			'font-size-site-tagline': {
-				desktop: 22,
+				desktop: 50,
 				tablet: 20,
 				mobile: 18,
 				'desktop-unit': 'px',
@@ -35,13 +35,6 @@ describe( 'Site Tagline Typography settings and color settings in the customizer
 
 		await expect( {
 			selector: '.site-header .site-description',
-			property: 'font-size',
-		} ).cssValueToBe(
-			`${ siteTagline[ 'font-size-site-tagline' ].desktop }${ siteTagline[ 'font-size-site-tagline' ][ 'desktop-unit' ] }`,
-		);
-
-		await expect( {
-			selector: '.site-header .site-description',
 			property: 'color',
 		} ).cssValueToBe( `${ siteTagline[ 'header-color-site-tagline' ] }` );
 
@@ -49,5 +42,31 @@ describe( 'Site Tagline Typography settings and color settings in the customizer
 			selector: '.site-header .site-description',
 			property: 'font-family',
 		} ).cssValueToBe( `${ siteTagline[ 'body-font-family' ] }` );
+
+		await expect( {
+			selector: '.site-header .site-description',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ siteTagline[ 'font-size-site-tagline' ].desktop }${ siteTagline[ 'font-size-site-tagline' ][ 'desktop-unit' ] }`,
+		);
+		
+		await setBrowserViewport( 'medium' );
+
+		await expect( {
+			selector: '.site-header .site-description',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ siteTagline[ 'font-size-site-tagline' ].tablet }${ siteTagline[ 'font-size-site-tagline' ][ 'desktop-unit' ] }`,
+		);
+
+		await setBrowserViewport( 'small' );
+		
+		await expect( {
+			selector: '.site-header .site-description',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ siteTagline[ 'font-size-site-tagline' ].mobile }${ siteTagline[ 'font-size-site-tagline' ][ 'desktop-unit' ] }`,
+		);
+
 	} );
 } );

--- a/tests/e2e/specs/customizer/header-builder/Site-identity/site-title.test.js
+++ b/tests/e2e/specs/customizer/header-builder/Site-identity/site-title.test.js
@@ -1,4 +1,4 @@
-import { createURL } from '@wordpress/e2e-test-utils';
+import { createURL, setBrowserViewport, } from '@wordpress/e2e-test-utils';
 import { setCustomize } from '../../../../utils/set-customize';
 
 describe( 'Site Title Typography settings and color settings in the customizer', () => {
@@ -27,6 +27,13 @@ describe( 'Site Title Typography settings and color settings in the customizer',
 		} );
 
 		await page.waitForSelector( '#ast-desktop-header .site-title a' );
+		
+		await expect( {
+			selector: '#ast-desktop-header .site-title a',
+			property: 'color',
+		} ).cssValueToBe(
+			`${ sitetitleTypography[ 'header-color-site-title' ] }`,
+		);
 
 		await expect( {
 			selector: '.site-title',
@@ -34,12 +41,23 @@ describe( 'Site Title Typography settings and color settings in the customizer',
 		} ).cssValueToBe(
 			`${ sitetitleTypography[ 'font-size-site-title' ].desktop }${ sitetitleTypography[ 'font-size-site-title' ][ 'desktop-unit' ] }`,
 		);
-
+		
+		await setBrowserViewport( 'medium' );
+		
 		await expect( {
-			selector: '#ast-desktop-header .site-title a',
-			property: 'color',
+			selector: '.site-title',
+			property: 'font-size',
 		} ).cssValueToBe(
-			`${ sitetitleTypography[ 'header-color-site-title' ] }`,
+			`${ sitetitleTypography[ 'font-size-site-title' ].tablet }${ sitetitleTypography[ 'font-size-site-title' ][ 'desktop-unit' ] }`,
+		);
+
+		await setBrowserViewport( 'small' );
+		
+		await expect( {
+			selector: '.site-title',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ sitetitleTypography[ 'font-size-site-title' ].mobile }${ sitetitleTypography[ 'font-size-site-title' ][ 'desktop-unit' ] }`,
 		);
 	} );
 } );


### PR DESCRIPTION
### Description
Added responsive option test case for site title and site tagline font size option.

### Screenshots
https://share.bsf.io/7KuE2GL8

### How has this been tested?
1. For site title - 
Run Single test - npm run test:e2e:interactive -- tests/e2e/specs/customizer/header-builder/site-identity/site-tagline.test.js

2. For Site tagline - 
Run single test - npm run test:e2e:interactive -- tests/e2e/specs/customizer/global/site-title.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
