### PR TITLE
AST-794 - fix: desktop logo width is applying for a moment on mobile device

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v3.6.9
 - Improvement: Clear asset cache of theme and addon on every new update of theme.
 - Fix: Auto scroll isssue on clicking Footer Builder in customiser preview.
 - Fix: WooCommerce - Cart icon broken on Tab & Mobile devices.
+- Fix: Desktop logo width is applying on the mobile devices for a moment.
 
 v3.6.8
 - Improvement: Added WPML translation support for all customizer's strings through wpml-config.xml file.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -2279,7 +2279,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				'.astra-logo-svg:not(.sticky-custom-logo .astra-logo-svg, .transparent-custom-logo .astra-logo-svg, .advanced-header-logo .astra-logo-svg)' => array(
 					'height' => astra_get_css_value( ( ! empty( $header_logo_width['mobile-svg-height'] ) && ! is_customize_preview() ) ? $header_logo_width['mobile-svg-height'] : '', 'px' ),
 				),
-				'.ast-header-break-point .site-logo-img .custom-mobile-logo-link img' => array(
+				'header .custom-logo-link img, .ast-header-break-point .site-logo-img .custom-mobile-logo-link img' => array(
 					'max-width' => astra_get_css_value( $header_logo_width['mobile'], 'px' ),
 				),
 				'body, .ast-separate-container'  => astra_get_responsive_background_obj( $box_bg_obj, 'mobile' ),

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -2270,7 +2270,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				'.ast-single-post .entry-title, .page-title' => array(
 					'font-size' => astra_responsive_font( $single_post_title_font_size, 'mobile', 30 ),
 				),
-				'.ast-header-break-point .site-branding img, .ast-header-break-point .custom-logo-link img' => array(
+				'header .custom-logo-link img, .ast-header-break-point .site-branding img, .ast-header-break-point .custom-logo-link img' => array(
 					'max-width' => astra_get_css_value( $header_logo_width['mobile'], 'px' ),
 				),
 				'.astra-logo-svg'                => array(
@@ -2279,7 +2279,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				'.astra-logo-svg:not(.sticky-custom-logo .astra-logo-svg, .transparent-custom-logo .astra-logo-svg, .advanced-header-logo .astra-logo-svg)' => array(
 					'height' => astra_get_css_value( ( ! empty( $header_logo_width['mobile-svg-height'] ) && ! is_customize_preview() ) ? $header_logo_width['mobile-svg-height'] : '', 'px' ),
 				),
-				'header .custom-logo-link img, .ast-header-break-point .site-logo-img .custom-mobile-logo-link img' => array(
+				'.ast-header-break-point .site-logo-img .custom-mobile-logo-link img' => array(
 					'max-width' => astra_get_css_value( $header_logo_width['mobile'], 'px' ),
 				),
 				'body, .ast-separate-container'  => astra_get_responsive_background_obj( $box_bg_obj, 'mobile' ),


### PR DESCRIPTION
### Description
- https://wp-astra.atlassian.net/browse/AST-794
- Logo is flickering on mobile device due to mobile logo width is getting appllied late.
- REf- https://websitedemos.net/online-health-coach-02/

### Screenshots
<!-- if applicable -->

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
