### PR TITLE
Gutenberg nightly auto installed from wp-env

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,8 @@
   "core": null,
   "themes": ["./astra"],
   "plugins": [
-    "./tests/e2e/e2e-plugin"
+    "./tests/e2e/e2e-plugin",
+    "https://gutenbergtimes.com/wp-content/uploads/2020/11/gutenberg.zip"
   ],
   "config": {
     "WP_DEBUG_LOG": true

--- a/bin/scripts/pre-e2e-tests.sh
+++ b/bin/scripts/pre-e2e-tests.sh
@@ -1,6 +1,3 @@
 
 # Set permalinks for the environment.
 npm run env run cli rewrite structure '%postname%' --hard --quiet
-
-# Install gutenberg-nightly version
-npm run env run cli wp plugin install https://gutenbergtimes.com/wp-content/uploads/2020/11/gutenberg.zip

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -15,6 +15,7 @@ import {
 	isOfflineMode,
 	setBrowserViewport,
 	trashAllPosts,
+	deactivatePlugin,
 } from '@wordpress/e2e-test-utils';
 
 import './expect-extensions';
@@ -204,6 +205,7 @@ beforeAll( async () => {
 	enablePageDialogAccept();
 	observeConsoleLogging();
 	await setupBrowser();
+	await deactivatePlugin( 'gutenberg' ); // by default keep the Gutenberg plugin deactive, Activate when needed.
 	await trashAllPosts();
 	await siteReset();
 	await page.setDefaultNavigationTimeout( 10000 );


### PR DESCRIPTION
### Description
Currently, Gutenberg nightly gets auto-installed each time you run the tests locally, After several runs you get too many copies installed.

This PR installs this plugin from wp-env. wp-env auto-activates any plugins/themes that are installed, so this is deactivated as before ll tests. This can be activated in each test with Gutenberg editor.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
Passing e2e tests

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
