### PR TITLE
use separate wp-env for theme-check and e2e tests

### DIFF
--- a/.github/.wp-env-themecheck.json
+++ b/.github/.wp-env-themecheck.json
@@ -1,0 +1,9 @@
+{
+    "core": null,
+    "themes": ["./astra"],
+    "plugins": [],
+    "config": {
+      "WP_DEBUG_LOG": true
+    }
+}
+ 

--- a/.github/.wp-env-themecheck.json
+++ b/.github/.wp-env-themecheck.json
@@ -6,4 +6,3 @@
       "WP_DEBUG_LOG": true
     }
 }
- 

--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -43,6 +43,12 @@ jobs:
             - name: Install Dependencies
               run: npm install
 
+            - name: Setup custom wp-env for theme-check
+              run: cp .github/.wp-env-themecheck.json .wp-env.json
+
+            - name: Build the Astra theme
+              run: grunt release-no-clean
+
             - name: Start Local Environment
               run: npm run env:start
               env:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "core": null,
-  "themes": ["./astra"],
+  "themes": ["."],
   "plugins": [
     "./tests/e2e/e2e-plugin"
   ],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint:js:fix": "npm run format && wp-scripts lint-js tests/ --fix",
     "env:activate-astra": "wp-env run cli wp theme activate astra",
     "env:deactivate-gutenberg": "wp-env run cli wp plugin deactivate gutenberg",
-    "env:start": "grunt release-no-clean && wp-env start && npm run env:activate-astra",
+    "env:start": "wp-env start && npm run env:activate-astra",
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy",
     "env:reset-site": "wp-env clean all",


### PR DESCRIPTION
### Description
We run theme-check in GitHub actions and theme-check cannot have all extra build/development files in the theme for eg `.git`, `phpcs.xml.dist` etc.

To fix this we have been building the Astra theme and including the built directory in the wp-env. but this causes limitations when writing e2e tests as now your working directory in the local environment is not mounted in the docker but the "built" directory is.

To fix this, this PR creates separate wp-env environments for all other cases and theme checks, for theme check we still keep the existing approach to build the theme and mount the built directory but for e2e test we are mounting the current working directory of the theme.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Passing e2e tests

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
