### PR TITLE
Loading typography section for H3-H6 conditionally

### DIFF
--- a/inc/customizer/class-astra-customizer.php
+++ b/inc/customizer/class-astra-customizer.php
@@ -1083,8 +1083,14 @@ if ( ! class_exists( 'Astra_Customizer' ) ) {
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/colors-background/class-astra-body-colors-configs.php';
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-archive-typo-configs.php';
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-body-typo-configs.php';
-			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-content-typo-configs.php';
-			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-headings-typo-configs.php';
+
+
+			if( astra_maybe_load_h4_to_h6_typo_options() ) {
+				require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-headings-typo-configs.php';
+			} else {
+				require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-content-typo-configs.php';
+			}
+
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-header-typo-configs.php';
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-single-typo-configs.php';
 			require ASTRA_THEME_DIR . 'inc/customizer/configurations/typography/class-astra-global-typo-configs.php';

--- a/inc/customizer/configurations/typography/class-astra-body-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-body-typo-configs.php
@@ -30,6 +30,8 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 		 */
 		public function register_configuration( $configurations, $wp_customize ) {
 
+			$typo_section = astra_maybe_load_h4_to_h6_typo_options() ? 'section-typography' : 'section-body-typo';
+
 			$_configs = array(
 
 				/**
@@ -42,7 +44,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'font-type'   => 'ast-font-family',
 					'ast_inherit' => __( 'Default System Font', 'astra' ),
 					'default'     => astra_get_option( 'body-font-family' ),
-					'section'     => 'section-typography',
+					'section'     => $typo_section,
 					'priority'    => 6,
 					'title'       => __( 'Body Font Family', 'astra' ),
 					'connect'     => ASTRA_THEME_SETTINGS . '[body-font-weight]',
@@ -59,7 +61,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_variant' ),
 					'default'           => astra_get_option( 'body-font-variant' ),
 					'ast_inherit'       => __( 'Default', 'astra' ),
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'priority'          => 6,
 					'title'             => __( 'Variants', 'astra' ),
 					'variant'           => ASTRA_THEME_SETTINGS . '[body-font-family]',
@@ -76,7 +78,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
 					'default'           => astra_get_option( 'body-font-weight' ),
 					'ast_inherit'       => __( 'Default', 'astra' ),
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'priority'          => 15,
 					'title'             => __( 'Weight', 'astra' ),
 					'connect'           => ASTRA_THEME_SETTINGS . '[body-font-family]',
@@ -89,7 +91,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'name'     => ASTRA_THEME_SETTINGS . '[body-text-transform]',
 					'type'     => 'control',
 					'control'  => 'ast-select',
-					'section'  => 'section-typography',
+					'section'  => $typo_section,
 					'default'  => astra_get_option( 'body-text-transform' ),
 					'priority' => 20,
 					'lazy'     => true,
@@ -110,7 +112,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'name'        => ASTRA_THEME_SETTINGS . '[font-size-body]',
 					'type'        => 'control',
 					'control'     => 'ast-responsive-slider',
-					'section'     => 'section-typography',
+					'section'     => $typo_section,
 					'default'     => astra_get_option( 'font-size-body' ),
 					'priority'    => 10,
 					'lazy'        => true,
@@ -131,7 +133,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'name'              => ASTRA_THEME_SETTINGS . '[body-line-height]',
 					'type'              => 'control',
 					'control'           => 'ast-slider',
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'lazy'              => true,
 					'default'           => astra_get_option( 'body-line-height' ),
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
@@ -155,7 +157,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'default'           => astra_get_option( 'para-margin-bottom' ),
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
 					'transport'         => 'postMessage',
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'priority'          => 25,
 					'title'             => __( 'Paragraph Margin Bottom', 'astra' ),
 					'suffix'            => 'em',
@@ -167,25 +169,6 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					),
 					'divider'           => array( 'ast_class' => 'ast-bottom-divider' ),
 				),
-				array(
-					'name'       => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-					'default'    => astra_get_option( 'heading-typo-selector', 'h1' ),
-					'type'       => 'control',
-					'section'    => 'section-typography',
-					'priority'   => 27,
-					'transport'  => 'postMessage',
-					'control'    => 'ast-selector',
-					'choices'    => array(
-						'h1' => __( 'H1', 'astra' ),
-						'h2' => __( 'H2', 'astra' ),
-						'h3' => __( 'H3', 'astra' ),
-						'h4' => __( 'H4', 'astra' ),
-						'h5' => __( 'H5', 'astra' ),
-						'h6' => __( 'H6', 'astra' ),
-					),
-					'responsive' => false,
-					'renderAs'   => 'text',
-				),
 
 				/**
 				 * Option: Underline links in entry-content.
@@ -195,7 +178,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'default'   => astra_get_option( 'underline-content-links' ),
 					'type'      => 'control',
 					'control'   => 'ast-toggle-control',
-					'section'   => 'section-typography',
+					'section'   => $typo_section,
 					'priority'  => 32,
 					'title'     => __( 'Underline Content Links', 'astra' ),
 					'transport' => 'postMessage',
@@ -211,7 +194,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'font-type' => 'ast-font-family',
 					'default'   => astra_get_option( 'headings-font-family' ),
 					'title'     => __( 'Heading Font Family', 'astra' ),
-					'section'   => 'section-typography',
+					'section'   => $typo_section,
 					'priority'  => 26,
 					'connect'   => ASTRA_THEME_SETTINGS . '[headings-font-weight]',
 					'variant'   => ASTRA_THEME_SETTINGS . '[headings-font-variant]',
@@ -227,7 +210,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_variant' ),
 					'default'           => astra_get_option( 'headings-font-variant' ),
 					'ast_inherit'       => __( 'Default', 'astra' ),
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'priority'          => 26,
 					'title'             => __( 'Variants', 'astra' ),
 					'variant'           => ASTRA_THEME_SETTINGS . '[headings-font-family]',
@@ -244,7 +227,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
 					'default'           => astra_get_option( 'headings-font-weight' ),
 					'title'             => __( 'Weight', 'astra' ),
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'priority'          => 26,
 					'connect'           => ASTRA_THEME_SETTINGS . '[headings-font-family]',
 				),
@@ -256,7 +239,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'name'     => ASTRA_THEME_SETTINGS . '[headings-text-transform]',
 					'type'     => 'control',
 					'control'  => 'ast-select',
-					'section'  => 'section-typography',
+					'section'  => $typo_section,
 					'title'    => __( 'Text Transform', 'astra' ),
 					'lazy'     => true,
 					'default'  => astra_get_option( 'headings-text-transform' ),
@@ -275,7 +258,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 				 */
 				array(
 					'name'              => ASTRA_THEME_SETTINGS . '[headings-line-height]',
-					'section'           => 'section-typography',
+					'section'           => $typo_section,
 					'default'           => astra_get_option( 'headings-line-height' ),
 					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
 					'type'              => 'control',
@@ -293,6 +276,29 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'divider'           => array( 'ast_class' => 'ast-bottom-divider' ),
 				),
 			);
+
+			if( astra_maybe_load_h4_to_h6_typo_options() ) {
+
+				$_configs[] = array(
+					'name'       => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+					'default'    => astra_get_option( 'heading-typo-selector', 'h1' ),
+					'type'       => 'control',
+					'section'    => $typo_section,
+					'priority'   => 27,
+					'transport'  => 'postMessage',
+					'control'    => 'ast-selector',
+					'choices'    => array(
+						'h1' => __( 'H1', 'astra' ),
+						'h2' => __( 'H2', 'astra' ),
+						'h3' => __( 'H3', 'astra' ),
+						'h4' => __( 'H4', 'astra' ),
+						'h5' => __( 'H5', 'astra' ),
+						'h6' => __( 'H6', 'astra' ),
+					),
+					'responsive' => false,
+					'renderAs'   => 'text',
+				);
+			}
 
 			return array_merge( $configurations, $_configs );
 		}

--- a/inc/customizer/configurations/typography/class-astra-content-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-content-typo-configs.php
@@ -33,85 +33,16 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 			$_configs = array(
 
 				/**
-				 * Heading Typography starts here - h1 - h3
-				 */
-
-				/**
-				 * Option: Heading <H1> Font Family
+				 * Option: Heading 1 (H1) Divider
 				 */
 				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[font-family-h1]',
-					'type'      => 'control',
-					'control'   => 'ast-font',
-					'font-type' => 'ast-font-family',
-					'default'   => astra_get_option( 'font-family-h1' ),
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h1',
-						),
-					),
-					'title'     => __( 'Font Family', 'astra' ),
-					'section'   => 'section-typography',
-					'priority'  => 28,
-					'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h1]',
-					'transport' => 'postMessage',
-				),
-
-				/**
-				 * Option: Heading <H1> Font Weight
-				 */
-				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h1]',
-					'type'              => 'control',
-					'control'           => 'ast-font',
-					'font-type'         => 'ast-font-weight',
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h1',
-						),
-					),
-					'title'             => __( 'Weight', 'astra' ),
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
-					'default'           => astra_get_option( 'font-weight-h1' ),
-					'section'           => 'section-typography',
-					'priority'          => 28,
-					'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h1]',
-					'transport'         => 'postMessage',
-				),
-
-				/**
-				 * Option: Heading <H1> Text Transform
-				 */
-				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h1]',
-					'section'   => 'section-typography',
-					'default'   => astra_get_option( 'text-transform-h1' ),
-					'title'     => __( 'Text Transform', 'astra' ),
-					'type'      => 'control',
-					'control'   => 'ast-select',
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h1',
-						),
-					),
-					'priority'  => 28,
-					'choices'   => array(
-						''           => __( 'Inherit', 'astra' ),
-						'none'       => __( 'None', 'astra' ),
-						'capitalize' => __( 'Capitalize', 'astra' ),
-						'uppercase'  => __( 'Uppercase', 'astra' ),
-						'lowercase'  => __( 'Lowercase', 'astra' ),
-					),
-					'transport' => 'postMessage',
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h1]',
+					'type'     => 'control',
+					'control'  => 'ast-heading',
+					'section'  => 'section-content-typo',
+					'priority' => 4,
+					'title'    => __( 'Heading 1', 'astra' ),
+					'settings' => array(),
 				),
 
 				/**
@@ -121,18 +52,10 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h1]',
 					'type'        => 'control',
 					'control'     => 'ast-responsive',
-					'section'     => 'section-typography',
+					'section'     => 'section-content-typo',
 					'default'     => astra_get_option( 'font-size-h1' ),
 					'transport'   => 'postMessage',
-					'context'     => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h1',
-						),
-					),
-					'priority'    => 28,
+					'priority'    => 6,
 					'title'       => __( 'Size', 'astra' ),
 					'input_attrs' => array(
 						'min' => 0,
@@ -144,111 +67,16 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 				),
 
 				/**
-				 * Option: Heading <H1> Line Height
+				 * Option: Heading 2 (H2) Divider
 				 */
 				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[line-height-h1]',
-					'section'           => 'section-typography',
-					'default'           => astra_get_option( 'line-height-h1' ),
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
-					'type'              => 'control',
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h1',
-						),
-					),
-					'control'           => 'ast-slider',
-					'title'             => __( 'Line Height', 'astra' ),
-					'transport'         => 'postMessage',
-					'priority'          => 28,
-					'suffix'            => 'em',
-					'input_attrs'       => array(
-						'min'  => 1,
-						'step' => 0.01,
-						'max'  => 5,
-					),
-				),
-
-				/**
-				 * Option: Heading <H2> Font Family
-				 */
-				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[font-family-h2]',
-					'type'      => 'control',
-					'control'   => 'ast-font',
-					'font-type' => 'ast-font-family',
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h2',
-						),
-					),
-					'title'     => __( 'Font Family', 'astra' ),
-					'default'   => astra_get_option( 'font-family-h2' ),
-					'section'   => 'section-typography',
-					'priority'  => 28,
-					'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h2]',
-					'transport' => 'postMessage',
-				),
-
-				/**
-				 * Option: Heading <H2> Font Weight
-				 */
-				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h2]',
-					'type'              => 'control',
-					'control'           => 'ast-font',
-					'font-type'         => 'ast-font-weight',
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h2',
-						),
-					),
-					'title'             => __( 'Weight', 'astra' ),
-					'section'           => 'section-typography',
-					'default'           => astra_get_option( 'font-weight-h2' ),
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
-					'priority'          => 28,
-					'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h2]',
-					'transport'         => 'postMessage',
-				),
-
-				/**
-				 * Option: Heading <H2> Text Transform
-				 */
-				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h2]',
-					'section'   => 'section-typography',
-					'default'   => astra_get_option( 'text-transform-h2' ),
-					'title'     => __( 'Text Transform', 'astra' ),
-					'type'      => 'control',
-					'lazy'      => true,
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h2',
-						),
-					),
-					'control'   => 'ast-select',
-					'transport' => 'postMessage',
-					'priority'  => 28,
-					'choices'   => array(
-						''           => __( 'Inherit', 'astra' ),
-						'none'       => __( 'None', 'astra' ),
-						'capitalize' => __( 'Capitalize', 'astra' ),
-						'uppercase'  => __( 'Uppercase', 'astra' ),
-						'lowercase'  => __( 'Lowercase', 'astra' ),
-					),
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h2]',
+					'type'     => 'control',
+					'control'  => 'ast-heading',
+					'section'  => 'section-content-typo',
+					'priority' => 9,
+					'title'    => __( 'Heading 2', 'astra' ),
+					'settings' => array(),
 				),
 
 				/**
@@ -258,19 +86,10 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h2]',
 					'type'        => 'control',
 					'control'     => 'ast-responsive',
-					'section'     => 'section-typography',
-					'lazy'        => true,
+					'section'     => 'section-content-typo',
 					'default'     => astra_get_option( 'font-size-h2' ),
 					'transport'   => 'postMessage',
-					'context'     => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h2',
-						),
-					),
-					'priority'    => 28,
+					'priority'    => 11,
 					'title'       => __( 'Size', 'astra' ),
 					'input_attrs' => array(
 						'min' => 0,
@@ -282,114 +101,18 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 				),
 
 				/**
-				 * Option: Heading <H2> Line Height
-				 */
-
-				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[line-height-h2]',
-					'section'           => 'section-typography',
-					'type'              => 'control',
-					'control'           => 'ast-slider',
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h2',
-						),
-					),
-					'default'           => astra_get_option( 'line-height-h2' ),
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
-					'transport'         => 'postMessage',
-					'title'             => __( 'Line Height', 'astra' ),
-					'priority'          => 30,
-					'lazy'              => true,
-					'suffix'            => 'em',
-					'input_attrs'       => array(
-						'min'  => 1,
-						'step' => 0.01,
-						'max'  => 5,
-					),
-				),
-
-				/**
-				 * Option: Heading <H3> Font Family
+				 * Option: Heading 3 (H3) Divider
 				 */
 				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[font-family-h3]',
-					'type'      => 'control',
-					'control'   => 'ast-font',
-					'font-type' => 'ast-font-family',
-					'default'   => astra_get_option( 'font-family-h3' ),
-					'title'     => __( 'Font Family', 'astra' ),
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h3',
-						),
-					),
-					'section'   => 'section-typography',
-					'priority'  => 28,
-					'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h3]',
-					'transport' => 'postMessage',
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h3]',
+					'type'     => 'control',
+					'control'  => 'ast-heading',
+					'section'  => 'section-content-typo',
+					'priority' => 15,
+					'title'    => __( 'Heading 3', 'astra' ),
+					'settings' => array(),
 				),
 
-				/**
-				 * Option: Heading <H3> Font Weight
-				 */
-				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h3]',
-					'type'              => 'control',
-					'control'           => 'ast-font',
-					'font-type'         => 'ast-font-weight',
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
-					'default'           => astra_get_option( 'font-weight-h3' ),
-					'title'             => __( 'Weight', 'astra' ),
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h3',
-						),
-					),
-					'section'           => 'section-typography',
-					'priority'          => 28,
-					'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h3]',
-					'transport'         => 'postMessage',
-				),
-
-				/**
-				 * Option: Heading <H3> Text Transform
-				 */
-				array(
-					'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h3]',
-					'type'      => 'control',
-					'section'   => 'section-typography',
-					'lazy'      => true,
-					'title'     => __( 'Text Transform', 'astra' ),
-					'default'   => astra_get_option( 'text-transform-h3' ),
-					'transport' => 'postMessage',
-					'control'   => 'ast-select',
-					'context'   => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h3',
-						),
-					),
-					'priority'  => 28,
-					'choices'   => array(
-						''           => __( 'Inherit', 'astra' ),
-						'none'       => __( 'None', 'astra' ),
-						'capitalize' => __( 'Capitalize', 'astra' ),
-						'uppercase'  => __( 'Uppercase', 'astra' ),
-						'lowercase'  => __( 'Lowercase', 'astra' ),
-					),
-				),
 				/**
 				 * Option: Heading 3 (H3) Font Size
 				 */
@@ -397,19 +120,10 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h3]',
 					'type'        => 'control',
 					'control'     => 'ast-responsive',
-					'section'     => 'section-typography',
-					'priority'    => 28,
-					'lazy'        => true,
+					'section'     => 'section-content-typo',
+					'priority'    => 16,
 					'default'     => astra_get_option( 'font-size-h3' ),
 					'transport'   => 'postMessage',
-					'context'     => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h3',
-						),
-					),
 					'title'       => __( 'Size', 'astra' ),
 					'input_attrs' => array(
 						'min' => 0,
@@ -421,32 +135,104 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 				),
 
 				/**
-				 * Option: Heading <H3> Line Height
+				 * Option: Heading 4 (H4) Divider
 				 */
 				array(
-					'name'              => ASTRA_THEME_SETTINGS . '[line-height-h3]',
-					'type'              => 'control',
-					'control'           => 'ast-slider',
-					'section'           => 'section-typography',
-					'lazy'              => true,
-					'title'             => __( 'Line Height', 'astra' ),
-					'context'           => array(
-						'',
-						array(
-							'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
-							'operator' => '===',
-							'value'    => 'h3',
-						),
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h4]',
+					'type'     => 'control',
+					'title'    => __( 'Heading 4', 'astra' ),
+					'section'  => 'section-content-typo',
+					'control'  => 'ast-heading',
+					'priority' => 20,
+					'settings' => array(),
+				),
+
+				/**
+				 * Option: Heading 4 (H4) Font Size
+				 */
+				array(
+					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h4]',
+					'type'        => 'control',
+					'control'     => 'ast-responsive',
+					'section'     => 'section-content-typo',
+					'default'     => astra_get_option( 'font-size-h4' ),
+					'transport'   => 'postMessage',
+					'priority'    => 21,
+					'title'       => __( 'Size', 'astra' ),
+					'input_attrs' => array(
+						'min' => 0,
 					),
-					'transport'         => 'postMessage',
-					'default'           => astra_get_option( 'line-height-h3' ),
-					'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
-					'priority'          => 28,
-					'suffix'            => 'em',
-					'input_attrs'       => array(
-						'min'  => 1,
-						'step' => 0.01,
-						'max'  => 5,
+					'units'       => array(
+						'px' => 'px',
+						'em' => 'em',
+					),
+				),
+
+				/**
+				 * Option: Heading 5 (H5) Divider
+				 */
+				array(
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h5]',
+					'type'     => 'control',
+					'control'  => 'ast-heading',
+					'section'  => 'section-content-typo',
+					'priority' => 25,
+					'title'    => __( 'Heading 5', 'astra' ),
+					'settings' => array(),
+				),
+
+				/**
+				 * Option: Heading 5 (H5) Font Size
+				 */
+				array(
+					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h5]',
+					'type'        => 'control',
+					'control'     => 'ast-responsive',
+					'section'     => 'section-content-typo',
+					'default'     => astra_get_option( 'font-size-h5' ),
+					'transport'   => 'postMessage',
+					'priority'    => 26,
+					'title'       => __( 'Size', 'astra' ),
+					'input_attrs' => array(
+						'min' => 0,
+					),
+					'units'       => array(
+						'px' => 'px',
+						'em' => 'em',
+					),
+				),
+
+				/**
+				 * Option: Heading 6 (H6) Divider
+				 */
+				array(
+					'name'     => ASTRA_THEME_SETTINGS . '[divider-section-h6]',
+					'type'     => 'control',
+					'control'  => 'ast-heading',
+					'title'    => __( 'Heading 6', 'astra' ),
+					'section'  => 'section-content-typo',
+					'priority' => 30,
+					'settings' => array(),
+				),
+
+				/**
+				 * Option: Heading 6 (H6) Font Size
+				 */
+				array(
+					'name'        => ASTRA_THEME_SETTINGS . '[font-size-h6]',
+					'type'        => 'control',
+					'control'     => 'ast-responsive',
+					'section'     => 'section-content-typo',
+					'default'     => astra_get_option( 'font-size-h6' ),
+					'transport'   => 'postMessage',
+					'priority'    => 31,
+					'title'       => __( 'Size', 'astra' ),
+					'input_attrs' => array(
+						'min' => 0,
+					),
+					'units'       => array(
+						'px' => 'px',
+						'em' => 'em',
 					),
 				),
 			);
@@ -464,8 +250,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'name'     => ASTRA_THEME_SETTINGS . '[ast-content-typography-more-feature-description]',
 						'type'     => 'control',
 						'control'  => 'ast-description',
-						'section'  => 'section-typography',
-						'lazy'     => true,
+						'section'  => 'section-content-typo',
 						'priority' => 999,
 						'title'    => '',
 						'help'     => '<p>' . __( 'More Options Available in Astra Pro!', 'astra' ) . '</p><a href="' . astra_get_pro_url( 'https://wpastra.com/pro/', 'customizer', 'learn-more', 'upgrade-to-pro' ) . '" class="button button-secondary"  target="_blank" rel="noopener">' . __( 'Learn More', 'astra' ) . '</a>',
@@ -483,5 +268,4 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 }
 
 new Astra_Content_Typo_Configs();
-
 

--- a/inc/customizer/configurations/typography/class-astra-global-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-global-typo-configs.php
@@ -473,7 +473,7 @@ class Astra_Global_Typo_Configs extends Astra_Customizer_Config_Base {
 						'line-height-h6'        => 1.2,
 					),
 				),
-				'section'   => 'section-typography',
+				'section'   => astra_maybe_load_h4_to_h6_typo_options() ? 'section-typography' : 'section-body-typo',
 				'transport' => 'postMessage',
 				'priority'  => 5,
 				'title'     => __( 'Presets', 'astra' ),

--- a/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
@@ -34,6 +34,424 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 		$_configs = array(
 
 			/**
+			 * Heading Typography starts here - h1 - h3
+			 */
+
+			/**
+			 * Option: Heading <H1> Font Family
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[font-family-h1]',
+				'type'      => 'control',
+				'control'   => 'ast-font',
+				'font-type' => 'ast-font-family',
+				'default'   => astra_get_option( 'font-family-h1' ),
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h1',
+					),
+				),
+				'title'     => __( 'Font Family', 'astra' ),
+				'section'   => $section,
+				'priority'  => 28,
+				'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h1]',
+				'transport' => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H1> Font Weight
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h1]',
+				'type'              => 'control',
+				'control'           => 'ast-font',
+				'font-type'         => 'ast-font-weight',
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h1',
+					),
+				),
+				'title'             => __( 'Weight', 'astra' ),
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
+				'default'           => astra_get_option( 'font-weight-h1' ),
+				'section'           => $section,
+				'priority'          => 28,
+				'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h1]',
+				'transport'         => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H1> Text Transform
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h1]',
+				'section'   => $section,
+				'default'   => astra_get_option( 'text-transform-h1' ),
+				'title'     => __( 'Text Transform', 'astra' ),
+				'type'      => 'control',
+				'control'   => 'ast-select',
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h1',
+					),
+				),
+				'priority'  => 28,
+				'choices'   => array(
+					''           => __( 'Inherit', 'astra' ),
+					'none'       => __( 'None', 'astra' ),
+					'capitalize' => __( 'Capitalize', 'astra' ),
+					'uppercase'  => __( 'Uppercase', 'astra' ),
+					'lowercase'  => __( 'Lowercase', 'astra' ),
+				),
+				'transport' => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading 1 (H1) Font Size
+			 */
+			array(
+				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h1]',
+				'type'        => 'control',
+				'control'     => 'ast-responsive',
+				'section'     => $section,
+				'default'     => astra_get_option( 'font-size-h1' ),
+				'transport'   => 'postMessage',
+				'context'     => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h1',
+					),
+				),
+				'priority'    => 28,
+				'title'       => __( 'Size', 'astra' ),
+				'input_attrs' => array(
+					'min' => 0,
+				),
+				'units'       => array(
+					'px' => 'px',
+					'em' => 'em',
+				),
+			),
+
+			/**
+			 * Option: Heading <H1> Line Height
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[line-height-h1]',
+				'section'           => $section,
+				'default'           => astra_get_option( 'line-height-h1' ),
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
+				'type'              => 'control',
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h1',
+					),
+				),
+				'control'           => 'ast-slider',
+				'title'             => __( 'Line Height', 'astra' ),
+				'transport'         => 'postMessage',
+				'priority'          => 28,
+				'suffix'            => 'em',
+				'input_attrs'       => array(
+					'min'  => 1,
+					'step' => 0.01,
+					'max'  => 5,
+				),
+			),
+
+			/**
+			 * Option: Heading <H2> Font Family
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[font-family-h2]',
+				'type'      => 'control',
+				'control'   => 'ast-font',
+				'font-type' => 'ast-font-family',
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h2',
+					),
+				),
+				'title'     => __( 'Font Family', 'astra' ),
+				'default'   => astra_get_option( 'font-family-h2' ),
+				'section'   => $section,
+				'priority'  => 28,
+				'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h2]',
+				'transport' => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H2> Font Weight
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h2]',
+				'type'              => 'control',
+				'control'           => 'ast-font',
+				'font-type'         => 'ast-font-weight',
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h2',
+					),
+				),
+				'title'             => __( 'Weight', 'astra' ),
+				'section'           => $section,
+				'default'           => astra_get_option( 'font-weight-h2' ),
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
+				'priority'          => 28,
+				'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h2]',
+				'transport'         => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H2> Text Transform
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h2]',
+				'section'   => $section,
+				'default'   => astra_get_option( 'text-transform-h2' ),
+				'title'     => __( 'Text Transform', 'astra' ),
+				'type'      => 'control',
+				'lazy'      => true,
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h2',
+					),
+				),
+				'control'   => 'ast-select',
+				'transport' => 'postMessage',
+				'priority'  => 28,
+				'choices'   => array(
+					''           => __( 'Inherit', 'astra' ),
+					'none'       => __( 'None', 'astra' ),
+					'capitalize' => __( 'Capitalize', 'astra' ),
+					'uppercase'  => __( 'Uppercase', 'astra' ),
+					'lowercase'  => __( 'Lowercase', 'astra' ),
+				),
+			),
+
+			/**
+			 * Option: Heading 2 (H2) Font Size
+			 */
+			array(
+				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h2]',
+				'type'        => 'control',
+				'control'     => 'ast-responsive',
+				'section'     => $section,
+				'lazy'        => true,
+				'default'     => astra_get_option( 'font-size-h2' ),
+				'transport'   => 'postMessage',
+				'context'     => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h2',
+					),
+				),
+				'priority'    => 28,
+				'title'       => __( 'Size', 'astra' ),
+				'input_attrs' => array(
+					'min' => 0,
+				),
+				'units'       => array(
+					'px' => 'px',
+					'em' => 'em',
+				),
+			),
+
+			/**
+			 * Option: Heading <H2> Line Height
+			 */
+
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[line-height-h2]',
+				'section'           => $section,
+				'type'              => 'control',
+				'control'           => 'ast-slider',
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h2',
+					),
+				),
+				'default'           => astra_get_option( 'line-height-h2' ),
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
+				'transport'         => 'postMessage',
+				'title'             => __( 'Line Height', 'astra' ),
+				'priority'          => 30,
+				'lazy'              => true,
+				'suffix'            => 'em',
+				'input_attrs'       => array(
+					'min'  => 1,
+					'step' => 0.01,
+					'max'  => 5,
+				),
+			),
+
+			/**
+			 * Option: Heading <H3> Font Family
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[font-family-h3]',
+				'type'      => 'control',
+				'control'   => 'ast-font',
+				'font-type' => 'ast-font-family',
+				'default'   => astra_get_option( 'font-family-h3' ),
+				'title'     => __( 'Font Family', 'astra' ),
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h3',
+					),
+				),
+				'section'   => $section,
+				'priority'  => 28,
+				'connect'   => ASTRA_THEME_SETTINGS . '[font-weight-h3]',
+				'transport' => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H3> Font Weight
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[font-weight-h3]',
+				'type'              => 'control',
+				'control'           => 'ast-font',
+				'font-type'         => 'ast-font-weight',
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_font_weight' ),
+				'default'           => astra_get_option( 'font-weight-h3' ),
+				'title'             => __( 'Weight', 'astra' ),
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h3',
+					),
+				),
+				'section'           => $section,
+				'priority'          => 28,
+				'connect'           => ASTRA_THEME_SETTINGS . '[font-family-h3]',
+				'transport'         => 'postMessage',
+			),
+
+			/**
+			 * Option: Heading <H3> Text Transform
+			 */
+			array(
+				'name'      => ASTRA_THEME_SETTINGS . '[text-transform-h3]',
+				'type'      => 'control',
+				'section'   => $section,
+				'lazy'      => true,
+				'title'     => __( 'Text Transform', 'astra' ),
+				'default'   => astra_get_option( 'text-transform-h3' ),
+				'transport' => 'postMessage',
+				'control'   => 'ast-select',
+				'context'   => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h3',
+					),
+				),
+				'priority'  => 28,
+				'choices'   => array(
+					''           => __( 'Inherit', 'astra' ),
+					'none'       => __( 'None', 'astra' ),
+					'capitalize' => __( 'Capitalize', 'astra' ),
+					'uppercase'  => __( 'Uppercase', 'astra' ),
+					'lowercase'  => __( 'Lowercase', 'astra' ),
+				),
+			),
+			/**
+			 * Option: Heading 3 (H3) Font Size
+			 */
+			array(
+				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h3]',
+				'type'        => 'control',
+				'control'     => 'ast-responsive',
+				'section'     => $section,
+				'priority'    => 28,
+				'lazy'        => true,
+				'default'     => astra_get_option( 'font-size-h3' ),
+				'transport'   => 'postMessage',
+				'context'     => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h3',
+					),
+				),
+				'title'       => __( 'Size', 'astra' ),
+				'input_attrs' => array(
+					'min' => 0,
+				),
+				'units'       => array(
+					'px' => 'px',
+					'em' => 'em',
+				),
+			),
+
+			/**
+			 * Option: Heading <H3> Line Height
+			 */
+			array(
+				'name'              => ASTRA_THEME_SETTINGS . '[line-height-h3]',
+				'type'              => 'control',
+				'control'           => 'ast-slider',
+			'section'           => $section,
+				'lazy'              => true,
+				'title'             => __( 'Line Height', 'astra' ),
+				'context'           => array(
+					'',
+					array(
+						'setting'  => ASTRA_THEME_SETTINGS . '[heading-typo-selector]',
+						'operator' => '===',
+						'value'    => 'h3',
+					),
+				),
+				'transport'         => 'postMessage',
+				'default'           => astra_get_option( 'line-height-h3' ),
+				'sanitize_callback' => array( 'Astra_Customizer_Sanitizes', 'sanitize_number_n_blank' ),
+				'priority'          => 28,
+				'suffix'            => 'em',
+				'input_attrs'       => array(
+					'min'  => 1,
+					'step' => 0.01,
+					'max'  => 5,
+				),
+			),
+
+			/**
 			 * Option: Heading <H4> Font Family
 			 */
 			array(
@@ -119,7 +537,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h4]',
 				'type'        => 'control',
 				'control'     => 'ast-responsive',
-				'section'     => 'section-typography',
+				'section'     => $section,
 				'default'     => astra_get_option( 'font-size-h4' ),
 				'transport'   => 'postMessage',
 				'lazy'        => true,
@@ -258,7 +676,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h5]',
 				'type'        => 'control',
 				'control'     => 'ast-responsive',
-				'section'     => 'section-typography',
+				'section'     => $section,
 				'lazy'        => true,
 				'default'     => astra_get_option( 'font-size-h5' ),
 				'transport'   => 'postMessage',
@@ -343,7 +761,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 				'name'        => ASTRA_THEME_SETTINGS . '[font-size-h6]',
 				'type'        => 'control',
 				'control'     => 'ast-responsive',
-				'section'     => 'section-typography',
+				'section'     => $section,
 				'lazy'        => true,
 				'default'     => astra_get_option( 'font-size-h6' ),
 				'transport'   => 'postMessage',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
