### PR TITLE
GCP-151 Added backward compatibility for copyright text color

### DIFF
--- a/inc/builder/type/footer/copyright/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/copyright/dynamic-css/dynamic.css.php
@@ -52,7 +52,7 @@ function astra_fb_copyright_dynamic_css( $dynamic_css, $dynamic_css_filtered = '
 			'text-align' => $desktop_alignment,
 		),
 		$selector               => array(
-			'color'         => astra_get_option( 'footer-copyright-color' ),
+			'color'         => astra_get_option( 'footer-copyright-color', astra_get_option( 'text-color' ) ),
 			// Margin CSS.
 			'margin-top'    => astra_responsive_spacing( $margin, 'top', 'desktop' ),
 			'margin-bottom' => astra_responsive_spacing( $margin, 'bottom', 'desktop' ),

--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -570,7 +570,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 * Footer Copyright.
 	 */
 	$defaults['footer-copyright-editor']                 = 'Copyright [copyright] [current_year] [site_title] | Powered by [theme_author]';
-	$defaults['footer-copyright-color']                  = 'var(' . $palette_css_var_prefix . '3)';
+	$defaults['footer-copyright-color']                  = '';
 	$defaults['line-height-section-footer-copyright']    = 2;
 	$defaults['footer-copyright-alignment']              = array(
 		'desktop' => 'center',

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -3175,8 +3175,14 @@ function astra_global_color_compatibility() {
 
 	if ( ! isset( $theme_options['support-global-color-format'] ) ) {
 		$theme_options['support-global-color-format'] = false;
-		update_option( 'astra-settings', $theme_options );
 	}
+
+	// Set Footer copyright text color for existing users to #3a3a3a.
+	if( ! isset( $theme_options['footer-copyright-color'] ) ) {
+		$theme_options['footer-copyright-color'] = '#3a3a3a';
+ 	}
+
+	update_option( 'astra-settings', $theme_options );
 }
 
 /**

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -3178,9 +3178,9 @@ function astra_global_color_compatibility() {
 	}
 
 	// Set Footer copyright text color for existing users to #3a3a3a.
-	if( ! isset( $theme_options['footer-copyright-color'] ) ) {
+	if ( ! isset( $theme_options['footer-copyright-color'] ) ) {
 		$theme_options['footer-copyright-color'] = '#3a3a3a';
- 	}
+	}
 
 	update_option( 'astra-settings', $theme_options );
 }


### PR DESCRIPTION
### Description
Copyright text color is linked with text color option. Added backward compatibility for the same. 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
