### PR TITLE
GCP-150 Modified labels for Palette colors

### DIFF
--- a/inc/class-astra-global-palette.php
+++ b/inc/class-astra-global-palette.php
@@ -113,15 +113,15 @@ class Astra_Global_Palette {
 	 */
 	public static function get_palette_labels() {
 		return array(
-			__( 'Theme Color', 'astra' ),
-			__( 'Link Hover Color', 'astra' ),
-			__( 'Heading Color', 'astra' ),
-			__( 'Text Color', 'astra' ),
-			__( 'Site Background Color', 'astra' ),
-			__( 'Content Background', 'astra' ),
-			__( 'Extra Color 1', 'astra' ),
-			__( 'Extra Color 2', 'astra' ),
-			__( 'Extra Color 3', 'astra' ),
+			__( 'Color  1', 'astra' ),
+			__( 'Color  2', 'astra' ),
+			__( 'Color  3', 'astra' ),
+			__( 'Color  4', 'astra' ),
+			__( 'Color  5', 'astra' ),
+			__( 'Color  6', 'astra' ),
+			__( 'Color  7', 'astra' ),
+			__( 'Color  8', 'astra' ),
+			__( 'Color  9', 'astra' ),
 		);
 	}
 
@@ -197,19 +197,14 @@ class Astra_Global_Palette {
 	 * @return array
 	 */
 	public function format_global_palette( $global_palette ) {
-		$editor_palette    = array();
-		$extra_color_index = 1;
-		$color_index       = 0;
+		$editor_palette = array();
+		$color_index    = 0;
+		$labels         = self::get_palette_labels();
 
 		if ( isset( $global_palette['palette'] ) ) {
 			foreach ( $global_palette['palette'] as $key => $color ) {
 
-				if ( isset( $global_palette['labels'][ $color_index ] ) ) {
-					$label = $global_palette['labels'][ $color_index ];
-				} else {
-					$label = __( 'Extra Color', 'astra' ) . $extra_color_index;
-					$extra_color_index++;
-				}
+				$label = 'Theme ' . $labels[ $key ];
 
 				$editor_palette[] = array(
 					'name'  => $label,

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -295,6 +295,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 			$global_palette = astra_get_option( 'global-color-palette' );
 			$data           = $response->get_data();
 			$slugs          = Astra_Global_Palette::get_palette_slugs();
+			$labels         = Astra_Global_Palette::get_palette_labels();
 
 			foreach ( $global_palette['palette'] as $key => $color ) {
 
@@ -304,7 +305,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 
 				$data['colors'][ $no_hyphens ] = array(
 					'id'    => esc_attr( $no_hyphens ),
-					'title' => $global_palette['labels'][ $key ],
+					'title' => 'Theme ' . $labels[ $key ],
 					'value' => $color,
 				);
 			}

--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -819,7 +819,6 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 * Global Color Palette.
 	 */
 	$defaults['global-color-palette'] = array(
-		'labels'  => Astra_Global_Palette::get_palette_labels(),
 		'palette' => array(
 			'#0274be',
 			'#3a3a3a',


### PR DESCRIPTION
### Description
Modified Palette color labels to Color 1, color 2 ... Also displaying labels as Theme color 1, Theme color 2 .. in Gutenberg and Elementor Color editor. 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
