### PR TITLE
AST-733 chore: added divider for third party plugin compatibility options in customizer.

### DIFF
--- a/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
+++ b/inc/addons/breadcrumbs/dynamic-css/dynamic.css.php
@@ -320,13 +320,13 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 
 		/* SEOPress CSS - Desktop */
 		$breadcrumbs_desktop = array(
-			'.ast-breadcrumbs-inner .breadcrumb-item a'          => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a' => array(
 				'color' => esc_attr( $breadcrumb_text_color['desktop'] ),
 			),
-			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active'      => array(
+			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active' => array(
 				'color' => esc_attr( $breadcrumb_active_color['desktop'] ),
 			),
-			'.ast-breadcrumbs-inner .breadcrumb-item a:hover'    => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a:hover' => array(
 				'color' => esc_attr( $breadcrumb_hover_color['desktop'] ),
 			),
 			'.ast-breadcrumbs-inner .breadcrumb-item:after' => array(
@@ -343,13 +343,13 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 
 		/* SEOPress CSS - Tablet */
 		$breadcrumbs_tablet = array(
-			'.ast-breadcrumbs-inner .breadcrumb-item a'          => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a' => array(
 				'color' => esc_attr( $breadcrumb_text_color['tablet'] ),
 			),
-			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active'      => array(
+			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active' => array(
 				'color' => esc_attr( $breadcrumb_active_color['tablet'] ),
 			),
-			'.ast-breadcrumbs-inner .breadcrumb-item a:hover'    => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a:hover' => array(
 				'color' => esc_attr( $breadcrumb_hover_color['tablet'] ),
 			),
 			'.ast-breadcrumbs-inner .breadcrumb-item:after' => array(
@@ -362,13 +362,13 @@ function astra_breadcrumb_section_dynamic_css( $dynamic_css, $dynamic_css_filter
 
 		/* SEOPress CSS - Mobile */
 		$breadcrumbs_mobile = array(
-			'.ast-breadcrumbs-inner .breadcrumb-item a'          => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a' => array(
 				'color' => esc_attr( $breadcrumb_text_color['mobile'] ),
 			),
-			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active'      => array(
+			'.ast-breadcrumbs-inner, .ast-breadcrumbs-inner .breadcrumb-item.active' => array(
 				'color' => esc_attr( $breadcrumb_active_color['mobile'] ),
 			),
-			'.ast-breadcrumbs-inner .breadcrumb-item a:hover'    => array(
+			'.ast-breadcrumbs-inner .breadcrumb-item a:hover' => array(
 				'color' => esc_attr( $breadcrumb_hover_color['mobile'] ),
 			),
 			'.ast-breadcrumbs-inner .breadcrumb-item:after' => array(

--- a/inc/compatibility/learndash/customizer/sections/class-astra-learndash-container-configs.php
+++ b/inc/compatibility/learndash/customizer/sections/class-astra-learndash-container-configs.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'Astra_Learndash_Container_Configs' ) ) {
 						'plain-container'         => __( 'Full Width / Contained', 'astra' ),
 						'page-builder'            => __( 'Full Width / Stretched', 'astra' ),
 					),
+					'divider'     => array( 'ast_class' => 'ast-top-divider' ),
 				),
 			);
 

--- a/inc/compatibility/lifterlms/customizer/sections/class-astra-lifter-container-configs.php
+++ b/inc/compatibility/lifterlms/customizer/sections/class-astra-lifter-container-configs.php
@@ -52,6 +52,7 @@ if ( ! class_exists( 'Astra_Lifter_Container_Configs' ) ) {
 						'plain-container'         => __( 'Full Width / Contained', 'astra' ),
 						'page-builder'            => __( 'Full Width / Stretched', 'astra' ),
 					),
+					'divider'  => array( 'ast_class' => 'ast-top-divider' ),
 				),
 			);
 


### PR DESCRIPTION

### Description
<!-- Please describe what you have changed or added -->
Need divider in the customizer setting for third-party plugin settings as shown in the screenshot below.

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/rRubpn0v

### Types of changes

Bugfix (non-breaking change which fixes an issue)


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Checked the layout options for the learn dash and lifterLMS plugins.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
