### PR TITLE
To test right & left sidebar width on page, post & archives

### DIFF
--- a/tests/e2e/specs/customizer/sidebar/leftSidebar.js
+++ b/tests/e2e/specs/customizer/sidebar/leftSidebar.js
@@ -1,0 +1,69 @@
+import {
+	createURL,
+	createNewPost,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../utils/set-customize';
+describe( 'To test Left Sidebar size in the customizer ', () => {
+    it( 'Left Sidebar size should apply correctly on post', async () => {
+        const postLeftSidebarSize = {
+            'site-sidebar-layout': 'left-sidebar',
+            'site-post-sidebar-layout': 'left-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( postLeftSidebarSize );
+        await createNewPost( { postType: 'post', title: 'sidebar post' } );
+        await publishPost();
+        await page.goto( createURL( '/sidebar-post/' ), {
+            waitUntil: 'networkidle0',
+        } );
+
+        await page.waitForSelector( '.ast-separate-container.ast-left-sidebar #secondary' );
+
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ postLeftSidebarSize[ 'inspector-input-control-0' ] }` );
+
+    } );
+
+    it( 'Left Sidebar size should apply correctly on page', async () => {
+        const pageLeftSidebarSize = {
+            'site-sidebar-layout': 'left-sidebar',
+            'site-page-sidebar-layout': 'left-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( pageLeftSidebarSize );
+        await createNewPost( { postType: 'page', title: 'sidebar page' } );
+        await publishPost();
+        await page.goto( createURL( '/sidebar-page/' ), {
+            waitUntil: 'networkidle0',
+        } );
+
+        await page.waitForSelector( '.ast-separate-container.ast-left-sidebar #secondary' );
+
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ pageLeftSidebarSize[ 'inspector-input-control-0' ] }` );
+    });
+
+    it( 'Left Sidebar size should apply correctly on archive archive posts', async () => {
+        const archiveLeftSidebarSize = {
+            'site-sidebar-layout': 'left-sidebar',
+            'archive-post-sidebar-layout': 'left-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( pageLeftSidebarSize );
+        await page.goto( createURL( '/category/uncategorized' ), {
+            waitUntil: 'networkidle0',
+        } );
+
+        await page.waitForSelector( '.ast-separate-container.ast-left-sidebar #secondary' );
+
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ archiveLeftSidebarSize[ 'inspector-input-control-0' ] }` );
+    });
+} );

--- a/tests/e2e/specs/customizer/sidebar/rightSidebar.js
+++ b/tests/e2e/specs/customizer/sidebar/rightSidebar.js
@@ -1,0 +1,64 @@
+import {
+	createURL,
+	createNewPost,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../utils/set-customize';
+describe( 'To test Right Sidebar size in the customizer ', () => {
+    it( 'Right Sidebar size should apply correctly on post', async () => {
+        const postRightSidebarSize = {
+            'site-sidebar-layout': 'right-sidebar',
+            'site-post-sidebar-layout': 'right-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( postRightSidebarSize );
+        await createNewPost( { postType: 'post', title: 'sidebar post' } );
+        await publishPost();
+        await page.goto( createURL( '/sidebar-post/' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector( '.ast-separate-container.ast-right-sidebar #secondary' );
+
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ postRightSidebarSize[ 'inspector-input-control-0' ] }` );
+
+    } );
+
+    it( 'Right Sidebar size should apply correctly on page', async () => {
+        const pageRightSidebarSize = {
+            'site-sidebar-layout': 'right-sidebar',
+            'site-page-sidebar-layout': 'right-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( pageRightSidebarSize );
+        await createNewPost( { postType: 'page', title: 'sidebar page' } );
+        await publishPost();
+        await page.goto( createURL( '/sidebar-page/' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector( '.ast-separate-container.ast-right-sidebar #secondary' );
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ pageRightSidebarSize[ 'inspector-input-control-0' ] }` );
+    });
+
+    it( 'Right Sidebar size should apply correctly on archive archive posts', async () => {
+        const archiveRightSidebarSize = {
+            'site-sidebar-layout': 'right-sidebar',
+            'archive-post-sidebar-layout': 'right-sidebar',
+            'inspector-input-control-0' : '35%'
+        };
+        await setCustomize( archiveRightSidebarSize );
+        await page.goto( createURL( '/category/uncategorized' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector( '.ast-separate-container.ast-right-sidebar #secondary' );
+        await expect( {
+            selector: '#secondary',
+            property: 'width',
+        } ).cssValueToBe( `${ archiveRightSidebarSize[ 'inspector-input-control-0' ] }` );
+    });
+} );


### PR DESCRIPTION
### Description
Added e2e cases to test right & left sidebar width on page, post & archives

### Screenshots
https://share.bsf.io/E0ujR2QK

### How has this been tested?
1. To test left sidebar width  -   npm run test:e2e:interactive -- tests/e2e/specs/customizer/sidebar/leftSidebar.js
2. To test right sidebar width  -   npm run test:e2e:interactive -- tests/e2e/specs/customizer/sidebar/rightSidebar.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
