### PR TITLE
Modified color palette slugs used in Elementor compatibility for palette

### DIFF
--- a/inc/class-astra-global-palette.php
+++ b/inc/class-astra-global-palette.php
@@ -184,15 +184,15 @@ class Astra_Global_Palette {
 	 */
 	public static function get_palette_slugs() {
 		return array(
-			'text-color',
-			'theme-color',
-			'link-hover',
-			'link-hover-color',
-			'heading-color',
-			'extra-color-1',
-			'extra-color-2',
-			'extra-color-3',
-			'extra-color-4',
+			'ast-global-color-0',
+			'ast-global-color-1',
+			'ast-global-color-2',
+			'ast-global-color-3',
+			'ast-global-color-4',
+			'ast-global-color-5',
+			'ast-global-color-6',
+			'ast-global-color-7',
+			'ast-global-color-8',
 		);
 	}
 

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -299,7 +299,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 
 			foreach ( $global_palette['palette'] as $key => $color ) {
 
-				$slug = 'astra' . $slugs[ $key ];
+				$slug = $slugs[ $key ];
 				// Remove hyphens from slug.
 				$no_hyphens = str_replace( '-', '', $slug );
 
@@ -335,7 +335,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 
 			foreach ( $palette_slugs as $key => $slug ) {
 				// Remove hyphens as hyphens do not work with Elementor global styles.
-				$no_hyphens              = 'astra' . str_replace( '-', '', $slug );
+				$no_hyphens              = str_replace( '-', '', $slug );
 				$slug_map[ $no_hyphens ] = $key;
 			}
 
@@ -372,7 +372,7 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 
 			if ( isset( $global_palette['palette'] ) ) {
 				foreach ( $global_palette['palette'] as $color_index => $color ) {
-					$variable_key           = '--e-global-color-astra' . str_replace( '-', '', $slugs[ $color_index ] );
+					$variable_key           = '--e-global-color-' . str_replace( '-', '', $slugs[ $color_index ] );
 					$style[ $variable_key ] = $color;
 				}
 

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -29,84 +29,84 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 		 * @var array
 		 */
 		private static $db_updates = array(
-			'2.1.3'        => array(
+			'2.1.3' => array(
 				'astra_submenu_below_header',
 			),
-			'2.2.0'        => array(
+			'2.2.0' => array(
 				'astra_page_builder_button_color_compatibility',
 				'astra_vertical_horizontal_padding_migration',
 			),
-			'2.3.0'        => array(
+			'2.3.0' => array(
 				'astra_header_button_new_options',
 			),
-			'2.3.3'        => array(
+			'2.3.3' => array(
 				'astra_elementor_default_color_typo_comp',
 			),
-			'2.3.4'        => array(
+			'2.3.4' => array(
 				'astra_breadcrumb_separator_fix',
 			),
-			'2.4.0'        => array(
+			'2.4.0' => array(
 				'astra_responsive_base_background_option',
 				'astra_update_theme_tablet_breakpoint',
 			),
-			'2.4.4'        => array(
+			'2.4.4' => array(
 				'astra_gtn_full_wide_image_group_css',
 			),
-			'2.5.0'        => array(
+			'2.5.0' => array(
 				'astra_global_button_woo_css',
 				'astra_gtn_full_wide_group_cover_css',
 			),
-			'2.5.2'        => array(
+			'2.5.2' => array(
 				'astra_footer_widget_bg',
 			),
-			'2.6.0'        => array(
+			'2.6.0' => array(
 				'astra_bg_control_migration',
 				'astra_bg_responsive_control_migration',
 				'astra_gutenberg_core_blocks_design_compatibility',
 			),
-			'2.6.1'        => array(
+			'2.6.1' => array(
 				'astra_gutenberg_media_text_block_css_compatibility',
 			),
-			'3.0.0'        => array(
+			'3.0.0' => array(
 				'astra_header_builder_compatibility',
 			),
-			'3.0.1'        => array(
+			'3.0.1' => array(
 				'astra_clear_assets_cache',
 			),
-			'3.3.0'        => array(
+			'3.3.0' => array(
 				'astra_gutenberg_pattern_compatibility',
 				'astra_icons_svg_compatibility',
 				'astra_check_flex_based_css',
 			),
-			'3.4.0'        => array(
+			'3.4.0' => array(
 				'astra_update_cart_style',
 			),
-			'3.5.0'        => array(
+			'3.5.0' => array(
 				'astra_update_related_posts_grid_layout',
 				'astra_site_title_tagline_responsive_control_migration',
 			),
-			'3.6.0'        => array(
+			'3.6.0' => array(
 				'astra_headings_font_support',
 				'astra_remove_logo_max_width',
 				'astra_transparent_header_default_value',
 			),
-			'3.6.3'        => array(
+			'3.6.3' => array(
 				'astra_button_default_values_updated',
 			),
-			'3.6.4'        => array(
+			'3.6.4' => array(
 				'astra_update_underline_link_setting',
 			),
-			'3.6.5'        => array(
+			'3.6.5' => array(
 				'astra_support_block_editor',
 			),
-			'3.6.7'        => array(
+			'3.6.7' => array(
 				'astra_fix_footer_widget_right_margin_case',
 				'astra_remove_elementor_toc_margin',
 			),
-			'3.6.8'        => array(
+			'3.6.8' => array(
 				'astra_set_removal_widget_design_options_flag',
 			),
-			'3.6.9'        => array(
+			'3.6.9' => array(
 				'astra_zero_font_size_comp',
 				'astra_unset_builder_elements_underline',
 				'astra_remove_responsive_account_menu_colors_support',


### PR DESCRIPTION
### Description
Modified color palette slugs according to color 1, color 2 .. format to be used in Elementor global color slugs. 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
