### PR TITLE
Breadcrumb responsive options

### DIFF
--- a/tests/e2e/specs/customizer/breadcrumbs/test-breadcrumbs.js
+++ b/tests/e2e/specs/customizer/breadcrumbs/test-breadcrumbs.js
@@ -1,71 +1,168 @@
-import { createURL } from '@wordpress/e2e-test-utils';
+import {createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
 import { setCustomize } from '../../../utils/set-customize';
+import { setBrowserViewport } from '../../../utils/set-browser-viewport';
 describe( 'breadcrumb Typography settings in the customizer', () => {
-	it( 'breadcrumb typography should apply correctly', async () => {
-		const breadcrumbTypography = {
-			'breadcrumb-position': 'astra_header_primary_container_after',
-			'breadcrumb-font-family': 'Pacifico, handwriting',
-			'breadcrumb-font-weight': '800',
-			'breadcrumb-text-transform': 'lowercase',
-			'breadcrumb-font-size': {
-				desktop: 50,
-				tablet: 22,
-				mobile: 18,
-				'desktop-unit': 'px',
-				'tablet-unit': 'px',
-				'mobile-unit': 'px',
-			},
-			'breadcrumb-line-height': '70px',
-			'breadcrumb-active-color-responsive': {
-				desktop: 'rgb(255, 77, 0)',
-				tablet: 'rgb(0, 11, 255)',
-				mobile: 'rgb(7, 140, 0)',
-			},
-		};
-		await setCustomize( breadcrumbTypography );
+    it( 'breadcrumb typography should apply correctly', async () => {
+        const breadcrumbTypography = {
+            'breadcrumb-position': 'astra_header_primary_container_after',
+            'breadcrumb-font-family': 'Pacifico, handwriting',
+            'breadcrumb-font-weight': '800',
+            'breadcrumb-text-transform': 'lowercase',
+            'breadcrumb-font-size': {
+                desktop: 50,
+                tablet: 22,
+                mobile: 18,
+                'desktop-unit': 'px',
+                'tablet-unit': 'px',
+                'mobile-unit': 'px',
+            },
+            'breadcrumb-line-height': '70px',
+            'breadcrumb-active-color-responsive': {
+                desktop: 'rgb(255, 77, 0)',
+                tablet: 'rgb(0, 11, 255)',
+                mobile: 'rgb(7, 140, 0)',
+            },
+            'breadcrumb-bg-color': {
+                desktop: 'rgb(128, 45, 45)',
+                tablet: 'rgb(220, 198, 198)',
+                mobile: 'rgb(60, 110, 110)',
+            },
+            'breadcrumb-seperator-color': {
+                desktop: 'rgb(34, 5, 5)',
+                tablet: 'rgb(22, 19, 18)',
+                mobile: 'rgb(6, 11, 110)',
+            },
+        };
+        await setCustomize( breadcrumbTypography );
+        await createNewPost( { postType: 'post', title: 'test post' } );
+        await publishPost();
+        await page.goto( createURL( '/test-post/' ), {
+            waitUntil: 'networkidle0',
+        });		
+        await page.goto( createURL( '/category/uncategorized' ), {
+            waitUntil: 'networkidle0',
+        } );
 
-		await page.goto( createURL( '/' ), {
-			waitUntil: 'networkidle0',
-		} );
+        await page.waitForSelector( '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li' );
 
-		await page.waitForSelector( '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li' );
+//to test breadcrumb font size on desktop
+        await expect( {
+            selector: '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li ',
+            property: 'font-size',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-font-size' ].desktop }${ breadcrumbTypography[ 'breadcrumb-font-size' ][ 'desktop-unit' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li ',
-			property: 'font-size',
-		} ).cssValueToBe(
-			`${ breadcrumbTypography[ 'breadcrumb-font-size' ].desktop }${ breadcrumbTypography[ 'breadcrumb-font-size' ][ 'desktop-unit' ] }`,
-		);
+//to test breadcrumb font size on tablet
+        await setBrowserViewport( 'medium' );
+        await expect( {
+            selector: '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li ',
+            property: 'font-size',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-font-size' ].tablet }${ breadcrumbTypography[ 'breadcrumb-font-size' ][ 'tablet-unit' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs-wrapper, .ast-breadcrumbs-wrapper a',
-			property: 'font-weight',
-		} ).cssValueToBe(
-			`${ breadcrumbTypography[ 'breadcrumb-font-weight' ] }`,
-		);
+//to test breadcrumb font size on mobile
+        await setBrowserViewport( 'small' );
+        await expect( {
+            selector: '.ast-breadcrumbs .trail-browse, .ast-breadcrumbs .trail-items, .ast-breadcrumbs .trail-items li ',
+            property: 'font-size',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-font-size' ].mobile }${ breadcrumbTypography[ 'breadcrumb-font-size' ][ 'mobile-unit' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs-wrapper',
-			property: 'line-height',
-		} ).cssValueToBe(
-			`${ breadcrumbTypography[ 'breadcrumb-line-height' ] }`,
-		);
+//to test breadcrumb font weight
+        await setBrowserViewport( 'large' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper, .ast-breadcrumbs-wrapper a',
+            property: 'font-weight',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-font-weight' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs-wrapper',
-			property: 'text-transform',
-		} ).cssValueToBe(
-			`${ breadcrumbTypography[ 'breadcrumb-text-transform' ] }`,
-		);
+//to test breadcrumb line height
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper',
+            property: 'line-height',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-line-height' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs-wrapper, .ast-breadcrumbs-wrapper a',
-			property: 'font-family',
-		} ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-font-family' ] }` );
+//to test breadcrum text transform
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper',
+            property: 'text-transform',
+        } ).cssValueToBe(
+            `${ breadcrumbTypography[ 'breadcrumb-text-transform' ] }`,
+        );
 
-		await expect( {
-			selector: '.ast-breadcrumbs-wrapper .trail-items .trail-end',
-			property: 'color',
-		} ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-active-color-responsive' ].desktop }` );
-	} );
+//to test breadcrumb font family
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper, .ast-breadcrumbs-wrapper a',
+            property: 'font-family',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-font-family' ] }` );
+
+//to test active text color
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items .trail-end',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-active-color-responsive' ].desktop }` );
+
+//to test active text color on tablet 
+        await setBrowserViewport( 'medium' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items .trail-end',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-active-color-responsive' ].tablet }` );
+
+//to test active text color on mobile
+        await setBrowserViewport( 'small' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items .trail-end',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-active-color-responsive' ].mobile }` );
+
+//to test background color on desktop
+        await setBrowserViewport( 'large' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper',
+            property: 'background-color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-bg-color' ].desktop }` );
+
+//to test background color on tablet
+        await setBrowserViewport( 'medium' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper',
+            property: 'background-color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-bg-color' ].tablet }` );
+
+//to test background color on mobile
+        await setBrowserViewport( 'small' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper',
+            property: 'background-color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-bg-color' ].mobile }` );
+
+//to test separator color on desktop
+        await setBrowserViewport( 'large' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items li::after',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-seperator-color' ].desktop }` );
+
+//to test separator color on tablet
+        await setBrowserViewport( 'medium' );
+        await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items li::after',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-seperator-color' ].tablet }` );
+
+//to test separator color on mobile
+            await setBrowserViewport( 'small' );
+            await expect( {
+            selector: '.ast-breadcrumbs-wrapper .trail-items li::after',
+            property: 'color',
+        } ).cssValueToBe( `${ breadcrumbTypography[ 'breadcrumb-seperator-color' ].mobile }` );
+
+    } );
 } );

--- a/tests/e2e/utils/set-browser-viewport.js
+++ b/tests/e2e/utils/set-browser-viewport.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+ import { waitForWindowDimensions } from '@wordpress/e2e-test-utils';
+
+ /**
+  * Named viewport options.
+  *
+  * @typedef {"large"|"medium"|"small"} WPDimensionsName
+  */
+
+ /**
+  * Viewport dimensions object.
+  *
+  * @typedef {Object} WPViewportDimensions
+  * @property {number} width  Width, in pixels.
+  * @property {number} height Height, in pixels.
+  */
+
+ /**
+  * Predefined viewport dimensions to reference by name.
+  *
+  * @enum {WPViewportDimensions}
+  * @type {Object<WPDimensionsName,WPViewportDimensions>}
+  */
+ export const PREDEFINED_DIMENSIONS = {
+     large: { width: 960, height: 700 },
+     medium: { width: 920, height: 700 },
+     small: { width: 544, height: 700 },
+ };
+
+ /**
+  * Valid argument argument type from which to derive viewport dimensions.
+  *
+  * @typedef {WPDimensionsName|WPViewportDimensions} WPViewport
+  */
+
+ /**
+  * Sets browser viewport to specified type.
+  *
+  * @param {WPViewport} viewport Viewport name or dimensions object to assign.
+  */
+ export async function setBrowserViewport( viewport ) {
+     const dimensions =
+         typeof viewport === 'string'
+             ? PREDEFINED_DIMENSIONS[ viewport ]
+             : viewport;
+
+     await page.setViewport( dimensions );
+     await waitForWindowDimensions( dimensions.width, dimensions.height );
+ }


### PR DESCRIPTION
### Description
Added cases for Background color & Separator color & Responsive for existing

### Screenshots
https://share.bsf.io/Wnu0pJX1

### Types of changes
1. Added responsive cases for text color
2. Added responsive for font size
3. Added case for responsive background-color
4. Added case for responsive separator color
5. Added a util file for set browser viewport

### How has this been tested?
 npm run test:e2e:interactive -- tests/e2e/specs/customizer/breadcrumbs/test-breadcrumbs.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
