### PR TITLE
Test case for global color setting under the customizer

### DIFF
--- a/tests/e2e/specs/customizer/global/colors/color-test.js
+++ b/tests/e2e/specs/customizer/global/colors/color-test.js
@@ -1,0 +1,75 @@
+import { setCustomize } from "../../../../utils/set-customize";
+import {createURL, createNewPost, publishPost,} from '@wordpress/e2e-test-utils';
+describe( 'Testing color option in the global setting, under the customizer', () => {
+	it( 'Text color should apply correctly', async () => {
+        const textColor = {
+            'text-color': 'rgb(254, 51, 51)',
+        };
+        await setCustomize( textColor );
+        await page.goto( createURL( 'testing' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector('body, h1, .entry-title a, .entry-content h1, h2, .entry-content h2, h3, .entry-content h3, h4, .entry-content h4, h5, .entry-content h5, h6, .entry-content h6');
+        await expect( {
+            selector: 'body, h1, .entry-title a, .entry-content h1, h2, .entry-content h2, h3, .entry-content h3, h4, .entry-content h4, h5, .entry-content h5, h6, .entry-content h6',
+            property: 'color',
+        } ).cssValueToBe( `${ textColor[ 'text-color' ]}` );
+	} );
+    it( 'The color for Heading should apply correctly', async () => {
+        const headingColor = {
+            'heading-base-color': 'rgb(82, 165, 121)',
+        };
+        await setCustomize( headingColor );
+        await createNewPost( {
+            postType: 'post',
+            title: 'heading-color',
+        } );
+        await publishPost();
+        await page.goto( createURL( 'heading-color' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector('h1, .entry-content h1, h2, .entry-content h2, h3, .entry-content h3, h4, .entry-content h4, h5, .entry-content h5, h6, .entry-content h6');
+        await expect( {
+            selector: 'h1, .entry-content h1, h2, .entry-content h2, h3, .entry-content h3, h4, .entry-content h4, h5, .entry-content h5, h6, .entry-content h6',
+              property: 'color',
+        } ).cssValueToBe( `${ headingColor[ 'heading-base-color' ]}` );
+	} );
+    it( 'Link color should apply correctly', async () => {
+        const linkColor = {
+            'link-color': 'rgb(105, 1, 183)',
+        };
+        await setCustomize( linkColor );
+        await createNewPost( {
+            postType: 'post',
+            title: 'link-color',
+        } );
+        await publishPost();
+        await page.goto( createURL( 'link-color' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector('.entry-meta, .entry-meta *');
+        await expect( {
+            selector: '.entry-meta, .entry-meta *',
+              property: 'color',
+        } ).cssValueToBe( `${ linkColor[ 'link-color' ]}` );
+	} );
+    it( 'Theme color should apply correctly', async () => {
+        const themeColor = {
+            'theme-color': 'rgb(141, 198, 235)',
+        };
+        await setCustomize( themeColor );
+        await createNewPost( {
+            postType: 'post',
+            title: 'theme-color',
+        } );
+        await publishPost();
+        await page.goto( createURL( 'theme-color' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector('.wp-block-search__button');
+        await expect( {
+            selector: '.wp-block-search__button',
+              property: 'background-color',
+        } ).cssValueToBe( `${ themeColor[ 'theme-color' ]}` );
+	} );
+});

--- a/tests/e2e/specs/customizer/global/colors/color-test.js
+++ b/tests/e2e/specs/customizer/global/colors/color-test.js
@@ -41,20 +41,20 @@ describe( 'Testing Global Color setting, under the customizer', () => {
 	} );
     it( 'Link color should apply correctly', async () => {
         const linkColor = {
-            'link-color': 'rgb(105, 1, 183)',
+            'link-color': 'rgb(240, 240, 241)',
         };
         await setCustomize( linkColor );
         await createNewPost( {
             postType: 'post',
-            title: 'link-color',
+            title: 'link-colors',
         } );
         await publishPost();
-        await page.goto( createURL( 'link-color' ), {
+        await page.goto( createURL( 'link-colors' ), {
             waitUntil: 'networkidle0',
         } );
-        await page.waitForSelector('.entry-meta, .entry-meta *');
+        await page.waitForSelector('a, .page-title');
         await expect( {
-            selector: '.entry-meta, .entry-meta *',
+            selector: 'a, .page-title',
               property: 'color',
         } ).cssValueToBe( `${ linkColor[ 'link-color' ]}` );
 	} );

--- a/tests/e2e/specs/customizer/global/colors/color-test.js
+++ b/tests/e2e/specs/customizer/global/colors/color-test.js
@@ -1,6 +1,6 @@
 import { setCustomize } from "../../../../utils/set-customize";
 import {createURL, createNewPost, publishPost,} from '@wordpress/e2e-test-utils';
-describe( 'Testing color option in the global setting, under the customizer', () => {
+describe( 'Testing Global Color setting, under the customizer', () => {
 	it( 'Global text color should apply correctly', async () => {
         const textColor = {
             'text-color': 'rgb(254, 51, 51)',

--- a/tests/e2e/specs/customizer/global/colors/color-test.js
+++ b/tests/e2e/specs/customizer/global/colors/color-test.js
@@ -1,12 +1,17 @@
 import { setCustomize } from "../../../../utils/set-customize";
 import {createURL, createNewPost, publishPost,} from '@wordpress/e2e-test-utils';
 describe( 'Testing color option in the global setting, under the customizer', () => {
-	it( 'Text color should apply correctly', async () => {
+	it( 'Global text color should apply correctly', async () => {
         const textColor = {
             'text-color': 'rgb(254, 51, 51)',
         };
         await setCustomize( textColor );
-        await page.goto( createURL( 'testing' ), {
+        await createNewPost( {
+            postType: 'post',
+            title: 'text-color',
+        } );
+        await publishPost();
+        await page.goto( createURL( 'text-color' ), {
             waitUntil: 'networkidle0',
         } );
         await page.waitForSelector('body, h1, .entry-title a, .entry-content h1, h2, .entry-content h2, h3, .entry-content h3, h4, .entry-content h4, h5, .entry-content h5, h6, .entry-content h6');
@@ -53,7 +58,7 @@ describe( 'Testing color option in the global setting, under the customizer', ()
               property: 'color',
         } ).cssValueToBe( `${ linkColor[ 'link-color' ]}` );
 	} );
-    it( 'Theme color should apply correctly', async () => {
+    it( 'Theme color the should apply correctly', async () => {
         const themeColor = {
             'theme-color': 'rgb(141, 198, 235)',
         };

--- a/tests/e2e/specs/hello.test.js
+++ b/tests/e2e/specs/hello.test.js
@@ -1,14 +1,2 @@
-/**
- * WordPress dependencies
- */
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
-
-describe( 'Hello World', () => {
-	it( 'should load properly', async () => {
-		await visitAdminPage( '/' );
-		const nodes = await page.$x(
-			'//h2[contains(text(), "Welcome to WordPress!")]',
-		);
-		await expect( nodes ).not.toHaveLength( 0 );
-	} );
-} );
+import { setCustomize } from '../utils/set-customize';
+import { createURL,createNewPost,publishPost } from '@wordpress/e2e-test-utils';

--- a/tests/e2e/specs/hello.test.js
+++ b/tests/e2e/specs/hello.test.js
@@ -1,2 +1,0 @@
-import { setCustomize } from '../utils/set-customize';
-import { createURL,createNewPost,publishPost } from '@wordpress/e2e-test-utils';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Created test case for color option available in the Customizer--> Global-->Color.
1. Text Color
2. Theme Color
3. Link Color
4. Heading Color 
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Branch name:- colors
Execution :- npm run test:e2e:interactive — tests/e2e/specs/customizer/global/colors/color-test.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
