### PR TITLE
AST-678 - Fix: Gutenberg editor and frontend font weight was not the same for heading typographies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ v3.7.3 (Unreleased)
 - Fix: Builder - Offcanvas content directly visible on frontend even 'Toggle Button' component is not added in builder area.
 - Fix: Global color palette - customizer preview for Elementor pages not working.
 - Fix: Button Preset preview not working for an edge case.
+- Fix: Fix: Gutenberg editor and frontend font weight was not the same for heading typographies.
 
 v3.7.2
 - Fix: Incorrect Site Background Color on pages with Full Width layout.

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -219,7 +219,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 				'.edit-post-visual-editor.editor-styles-wrapper p,.block-editor-block-list__block p, .block-editor-block-list__layout, .editor-post-title' => array(
 					'font-size' => astra_responsive_font( $body_font_size, 'desktop' ),
 				),
-				'.edit-post-visual-editor.editor-styles-wrapper p,.block-editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .block-editor-block-list__block, .block-editor-block-list__block h1, .block-editor-block-list__block h2, .block-editor-block-list__block h3, .block-editor-block-list__block h4, .block-editor-block-list__block h5, .block-editor-block-list__block h6, .edit-post-visual-editor .editor-styles-wrapper' => array(
+				'.edit-post-visual-editor.editor-styles-wrapper p,.block-editor-block-list__block p, .wp-block-latest-posts a,.editor-default-block-appender textarea.editor-default-block-appender__content, .block-editor-block-list__block, .editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6, .edit-post-visual-editor .editor-styles-wrapper' => array(
 					'font-family'    => astra_get_font_family( $body_font_family ),
 					'font-weight'    => esc_attr( $body_font_weight ),
 					'font-size'      => astra_responsive_font( $body_font_size, 'desktop' ),


### PR DESCRIPTION
### Description
Gutenberg editor and frontend font weight was not the same for heading typographies.

### Screenshots
- GB Editor - https://share.getcloudapp.com/geuAXRPJ
- Frontend - https://share.getcloudapp.com/Jrux9oeJ

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Reproduced by adding headings.
- Verified result in the front end.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards 
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
