### PR TITLE
Test case for copyright footer in the customizer

### DIFF
--- a/tests/e2e/specs/customizer/footer/copyright-test.js
+++ b/tests/e2e/specs/customizer/footer/copyright-test.js
@@ -1,0 +1,46 @@
+import { setCustomize } from '../../../utils/set-customize';
+import { createURL,createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+describe( 'Test case for copyright footer under the customizer', () => {
+it( 'Font size for footer should apply correctly', async () => {
+        const footerFont = {
+            'font-size-section-footer-copyright': {
+                desktop: 100,
+            'desktop-unit': 'px',
+        },
+        };
+        await setCustomize( footerFont );
+        await createNewPost( {
+            postType: 'post',
+            title: 'copyright',
+        } );
+        await publishPost();
+
+        await page.goto( createURL( 'copyright' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.goto( createURL( '/' ), {
+            waitUntil: 'networkidle0',
+        } );
+        await page.waitForSelector( '.ast-footer-copyright' );
+        await expect( {
+            selector: '.ast-footer-copyright',
+            property: 'font-size',
+        } ).cssValueToBe( `${ footerFont[ 'font-size-section-footer-copyright' ].desktop }${ footerFont[ 'font-size-section-footer-copyright' ][ 'desktop-unit' ] }`);
+
+    });
+    it( 'copyright footer color  should apply corectly', async () => {
+        const copyrightcolor = {
+            'footer-copyright-color': 'rgb(206, 20, 20)',
+
+        };
+        await setCustomize( copyrightcolor );
+
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+        await expect( {
+            selector: '.ast-footer-copyright',
+            property: 'color',
+        } ).cssValueToBe( `${ copyrightcolor[ 'footer-copyright-color' ]}` );  
+    });
+}); 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Test case for changing color and size of copyright footer
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Branch name :- copyright 
Execution :- npm run test:e2e:interactive — tests/e2e/specs/customizer/footer/copyright-test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
