### PR TITLE
E2E test case for button preset, button text color and background col…

### DIFF
--- a/tests/e2e/specs/customizer/global/button/btn-txt-color.js
+++ b/tests/e2e/specs/customizer/global/button/btn-txt-color.js
@@ -1,0 +1,24 @@
+import { setCustomize } from '../../../../utils/set-customize';
+import { createURL } from '@wordpress/e2e-test-utils';
+describe( 'global button presets, button text and background color setting under the Customizer', () => {
+	it( 'button text and background color should apply correctly', async () => {
+		const btnColor = {
+			'button-color': 'rgb(214, 10, 10)',
+			'button-bg-color': 'rgb(98, 39, 165)',
+		};
+		await setCustomize( btnColor );
+		await page.goto( createURL( 'category/markup' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button' );
+		await expect( {
+			selector: '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button',
+			property: 'color',
+		} ).cssValueToBe( `${ btnColor[ 'button-color' ] 	}` );
+		await page.waitForSelector( '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button' );
+		await expect( {
+			selector: '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button',
+			property: 'background-color',
+		} ).cssValueToBe( `${ btnColor[ 'button-bg-color' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/global/button/button-test.js
+++ b/tests/e2e/specs/customizer/global/button/button-test.js
@@ -1,0 +1,18 @@
+import { setCustomize } from '../../../../utils/set-customize';
+import { createURL } from '@wordpress/e2e-test-utils';
+describe( 'global button presets, button text and background color setting under the Customizer', () => {
+	it( 'button text and background color should apply correctly', async () => {
+		const buttonCustomize = {
+			'button-preset-style': 'Layer_1',
+		};
+		await setCustomize( buttonCustomize );
+		await page.goto( createURL( 'category/markup' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button' );
+		await expect( {
+			selector: '.menu-toggle, button, .ast-button, .ast-custom-button, .button, input#submit, input[type="button"], input[type="submit"], input[type="reset"], form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button, body .wp-block-file .wp-block-file__button',
+			property: '',
+		} ).cssValueToBe( `` );
+	} );
+} );


### PR DESCRIPTION
…or in the customizer

### Description
<!-- Please describe what you have changed or added -->
Test case for button setting options in the customizer
### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/d5uRZvdR
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Branch name :- button-customize
Execution :- npm run test:e2e:interactive — tests/e2e/specs/customizer/global/button/btn-txt-color.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
