### PR TITLE
AST-991 -  Fix : The Gutenberg plugin v11.5.0 reduces the title space.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ v3.7.4 (Unreleased)
 - Fix: W3 validator - Duplicate HTML id 'site-navigation' if there are multiple menus on a single page.
 - Fix: W3 validator - CSS parse error for '.menu-link' & '.wp-block-button__link'.
 - Fix: Image and Text blocks alignment not working properly with Image size - Medium in the editor.
+- Fix: The Gutenberg plugin v11.4.1 breaks the title / reduces the title space.
 
 v3.7.3
 - Fix: Builder - Offcanvas content directly visible on frontend even 'Toggle Button' component is not added in builder area.

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -364,10 +364,10 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'background' => 'inherit !important',
 				);
 				$desktop_css['.ast-page-builder-template .editor-styles-wrapper, .ast-plain-container .editor-styles-wrapper'] = $background_style_data;
-				$desktop_css['.wp-block[data-align=left]>*'] = array(
+				$desktop_css['.wp-block[data-align=left]>*']                            = array(
 					'float' => 'left',
 				);
-				$desktop_css['.wp-block[data-align=right]>*'] = array(
+				$desktop_css['.wp-block[data-align=right]>*']                           = array(
 					'float' => 'right',
 				);
 				$desktop_css['.wp-block[data-align=left], .wp-block[data-align=right]'] = array(
@@ -1013,14 +1013,14 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'padding-right'  => 'calc( 6.67em - 28px )',
 				),
 				'.ast-separate-container .editor-post-title' => array(
-					'padding-top'    => 'calc( 5.34em - 19px)',
+					'padding-top'    => '62px',
 					'padding-bottom' => '5.34em',
-					'padding-left'   => 'calc( 6.67em - 28px )',
-					'padding-right'  => 'calc( 6.67em - 28px )',
+					'padding-left'   => '72px',
+					'padding-right'  => '72px',
 				),
 
 				'.ast-separate-container .editor-post-title, .ast-two-container .editor-post-title'         => array(
-					'padding-bottom' => '0',
+					'padding-bottom' => '20px',
 				),
 				'.ast-separate-container .editor-block-list__block, .ast-two-container .editor-block-list__block'  => array(
 					'max-width' => 'calc(' . astra_get_css_value( $site_content_width, 'px' ) . ' - 6.67em)',
@@ -1117,9 +1117,9 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 
 			$ast_gtn_mobile_css = array(
 				'.ast-separate-container .editor-post-title' => array(
-					'padding-top'   => 'calc( 2.34em - 19px)',
-					'padding-left'  => 'calc( 3.67em - 28px )',
-					'padding-right' => 'calc( 3.67em - 28px )',
+					'padding-top'   => '19px',
+					'padding-left'  => '28px',
+					'padding-right' => '28px',
 				),
 				'.ast-separate-container .block-editor-block-list__layout' => array(
 					'padding-bottom' => '2.34em',

--- a/template-parts/advanced-footer/layout-4.php
+++ b/template-parts/advanced-footer/layout-4.php
@@ -23,7 +23,7 @@ if ( ! is_user_logged_in() ) {
 	}
 }
 
-$astra_footer_classes = array();
+$astra_footer_classes   = array();
 $astra_footer_classes[] = 'footer-adv';
 $astra_footer_classes[] = 'footer-adv-layout-4';
 $astra_footer_classes   = implode( ' ', $astra_footer_classes );


### PR DESCRIPTION
### Description
- The Gutenberg plugin v11.4.1 breaks the title / reduces the title space.

### Screenshots
<!-- if applicable -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 


### How has this been tested?
1. Install the Gutenberg plugin v11.4.1
2. Created a new page or post.
3. Try adding the title to the page or post, the page title was the same as when the Gutenberg plugin was disabled.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards
- [ ] I've included any necessary tests
- [ ] I've added proper labels to this pull request
