### PR TITLE
AST-1175 - E2E Test case for Gutenberg table block to test default width, margin and padding

### DIFF
--- a/tests/e2e/specs/block-editor/table-block/table-default-width.test.js
+++ b/tests/e2e/specs/block-editor/table-block/table-default-width.test.js
@@ -1,0 +1,92 @@
+import {
+	clickButton,
+	createNewPost,
+	getEditedPostContent,
+	insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+const createButtonLabel = 'Create Table';
+
+describe( 'Table', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'displays a form for choosing the row and column count of the table', async () => {
+		await insertBlock( 'Table' );
+
+		// Check for existence of the column count field.
+		const columnCountLabel = await page.$x(
+			"//figure[@data-type='core/table']//label[text()='Column count']"
+		);
+		expect( columnCountLabel ).toHaveLength( 1 );
+
+		// Modify the column count.
+		await columnCountLabel[ 0 ].click();
+		const currentColumnCount = await page.evaluate(
+			() => document.activeElement.value
+		);
+		expect( currentColumnCount ).toBe( '2' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '5' );
+
+		// Check for existence of the row count field.
+		const rowCountLabel = await page.$x(
+			"//figure[@data-type='core/table']//label[text()='Row count']"
+		);
+		expect( rowCountLabel ).toHaveLength( 1 );
+
+		// Modify the row count.
+		await rowCountLabel[ 0 ].click();
+		const currentRowCount = await page.evaluate(
+			() => document.activeElement.value
+		);
+		expect( currentRowCount ).toBe( '2' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '10' );
+
+		// Create the table.
+		await clickButton( createButtonLabel );
+
+		// Expect the post content to have a correctly sized table.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.waitForSelector( '.block-editor-block-list__block' );
+		await expect( {
+			selector: '.block-editor-block-list__block',
+			property: 'width',
+		} ).cssValueToBe( `974.9px` );
+		await expect( {
+			selector: '.wp-block-table',
+			property: 'margin-top',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.wp-block-table',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.wp-block-table',
+			property: 'margin-left',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.wp-block-table',
+			property: 'margin-right',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.edit-post-visual-editor .block-editor-block-list__block',
+			property: 'padding-right',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.edit-post-visual-editor .block-editor-block-list__block',
+			property: 'padding-left',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.edit-post-visual-editor .block-editor-block-list__block',
+			property: 'padding-top',
+		} ).cssValueToBe( `0px` );
+		await expect( {
+			selector: '.edit-post-visual-editor .block-editor-block-list__block',
+			property: 'padding-bottom',
+		} ).cssValueToBe( `0px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
E2E test case for table block default block, padding and margin.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test : npm run test:e2e:interactive tests/e2e/specs/block-editor/table-block/table-default-width.test.js 

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
