### PR TITLE
AST-1284 - fix: disable above header option is not visible in the meta settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v3.7.5
 - Improvement: Added compatibility for Elementor Pro v3.5.0 WooCommerce widgets.
+- Fix: 'Disable Below Header' option is not visible in Astra meta settings.
 
 v3.7.4
 - New: Breadcrumb compatibility with SEOPress plugin. ( https://wpastra.com/docs/add-breadcrumbs-with-astra/#support-for-third-party-plugins )

--- a/inc/metabox/class-astra-meta-boxes.php
+++ b/inc/metabox/class-astra-meta-boxes.php
@@ -460,7 +460,12 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 		 * @return void
 		 */
 		public function load_scripts() {
-			$post_type    = get_post_type();
+			$post_type = get_post_type();
+
+			if ( defined( 'ASTRA_ADVANCED_HOOKS_POST_TYPE' ) && ASTRA_ADVANCED_HOOKS_POST_TYPE === $post_type ) {
+				return;
+			}
+			
 			$metabox_name = sprintf(
 				// Translators: %s is the theme name.
 				__( '%s Settings', 'astra' ),
@@ -537,6 +542,10 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 				array(
 					'key'   => 'ast-main-header-display',
 					'label' => __( 'Disable Primary Header', 'astra' ),
+				),
+				array(
+					'key'   => 'ast-hfb-below-header-display',
+					'label' => __( 'Disable Below Header', 'astra' ),
 				),
 				array(
 					'key'   => 'ast-hfb-mobile-header-display',
@@ -651,6 +660,16 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 			register_post_meta(
 				'',
 				'ast-hfb-above-header-display',
+				array(
+					'show_in_rest'  => true,
+					'single'        => true,
+					'type'          => 'string',
+					'auth_callback' => '__return_true',
+				)
+			);
+			register_post_meta(
+				'',
+				'ast-hfb-below-header-display',
 				array(
 					'show_in_rest'  => true,
 					'single'        => true,


### PR DESCRIPTION
### Description
- Disable above header option is not visible in the meta settings.
- Alos Astra meta settings are visible in Custom Layouts
- https://wp-astra.atlassian.net/browse/AST-1284

### Screenshots
https://share.getcloudapp.com/X6ub9dRv

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
