### PR TITLE
E2E test case for typography heading h4 h5 and h6 font size

### DIFF
--- a/tests/e2e/specs/customizer/global/typography/heading-font-size.test.js
+++ b/tests/e2e/specs/customizer/global/typography/heading-font-size.test.js
@@ -1,0 +1,177 @@
+import {
+	createURL,
+	createNewPost,
+	setPostContent,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { TPOGRAPHY_TEST_POST_CONTENT } from '../../../../utils/post';
+import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+import { responsiveFontSize } from '../../../../utils/responsive-utils';
+describe( 'Global Typography settings in the customizer', () => {
+	it( 'h4 typography heading font size should be applied correctly', async () => {
+		const headingFontSize = {
+			'font-size-h4': {
+				desktop: '50',
+				tablet: '50',
+				mobile: '50',
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+
+		};
+		await setCustomize( headingFontSize );
+		await createNewPost( {
+			postType: 'post',
+			title: 'heading-test',
+		} );
+		await setPostContent( TPOGRAPHY_TEST_POST_CONTENT );
+		await publishPost();
+
+		await page.goto( createURL( 'heading-test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.entry-content h4' );
+		await expect( {
+			selector: '.entry-content h4',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ headingFontSize[ 'font-size-h4' ].desktop }${ headingFontSize[ 'font-size-h4' ][ 'desktop-unit' ] }`,
+		);
+		await setBrowserViewport( 'medium' );
+
+		await expect( {
+			selector: '.entry-content h4',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h4' ].tablet,
+			) }${
+				headingFontSize[ 'font-size-h4' ][ 'tablet-unit' ]
+			}`,
+		);
+		await setBrowserViewport( 'small' );
+
+		await expect( {
+			selector: '.entry-content h4',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h4' ].mobile,
+			) }${
+				headingFontSize[ 'font-size-h4' ][ 'mobile-unit' ]
+			}`,
+		);
+	} );
+	it( 'h5 typography heading font size should be applied correctly', async () => {
+		const headingFontSize = {
+			'font-size-h5': {
+				desktop: '40',
+				tablet: '35',
+				mobile: '25',
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+
+		};
+		await setCustomize( headingFontSize );
+		await createNewPost( {
+			postType: 'post',
+			title: 'heading-test',
+		} );
+		await setPostContent( TPOGRAPHY_TEST_POST_CONTENT );
+		await publishPost();
+
+		await page.goto( createURL( 'heading-test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( 'h5, .entry-content h5' );
+		await expect( {
+			selector: 'h5, .entry-content h5',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ headingFontSize[ 'font-size-h5' ].desktop }${ headingFontSize[ 'font-size-h5' ][ 'desktop-unit' ] }`,
+		);
+		await setBrowserViewport( 'medium' );
+
+		await expect( {
+			selector: 'h5, .entry-content h5',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h5' ].tablet,
+			) }${
+				headingFontSize[ 'font-size-h5' ][ 'tablet-unit' ]
+			}`,
+		);
+		await setBrowserViewport( 'small' );
+
+		await expect( {
+			selector: 'h5, .entry-content h5',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h5' ].mobile,
+			) }${
+				headingFontSize[ 'font-size-h5' ][ 'mobile-unit' ]
+			}`,
+		);
+	} );
+	it( 'h6 typography heading font size should be applied correctly', async () => {
+		const headingFontSize = {
+			'font-size-h6': {
+				desktop: '40',
+				tablet: '30',
+				mobile: '20',
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+
+		};
+		await setCustomize( headingFontSize );
+		await createNewPost( {
+			postType: 'post',
+			title: 'heading-test',
+		} );
+		await setPostContent( TPOGRAPHY_TEST_POST_CONTENT );
+		await publishPost();
+
+		await page.goto( createURL( 'heading-test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( 'h6, .entry-content h6' );
+		await expect( {
+			selector: 'h6, .entry-content h6',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ headingFontSize[ 'font-size-h6' ].desktop }${ headingFontSize[ 'font-size-h6' ][ 'desktop-unit' ] }`,
+		);
+		await setBrowserViewport( 'medium' );
+
+		await expect( {
+			selector: 'h6, .entry-content h6',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h6' ].tablet,
+			) }${
+				headingFontSize[ 'font-size-h6' ][ 'tablet-unit' ]
+			}`,
+		);
+		await setBrowserViewport( 'small' );
+
+		await expect( {
+			selector: 'h6, .entry-content h6',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				headingFontSize[ 'font-size-h6' ].mobile,
+			) }${
+				headingFontSize[ 'font-size-h6' ][ 'mobile-unit' ]
+			}`,
+		);
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added test case for typography heading h4 h5 and h6 font size

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive tests/e2e/specs/customizer/global/typography/heading-font-size.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
