### PR TITLE
e2e test case for global typography preset 2 style in the customizer

### DIFF
--- a/tests/e2e/specs/customizer/global/typography/preset2.test.js
+++ b/tests/e2e/specs/customizer/global/typography/preset2.test.js
@@ -1,0 +1,79 @@
+import {
+	createURL,
+	createNewPost,
+	setPostContent,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { TPOGRAPHY_TEST_POST_CONTENT } from '../../../../utils/post';
+
+describe( 'Global typography preset-2 style in the customizer', () => {
+	it( 'body and heading styling should be applied correctly', async () => {
+		const globaltypographyPreset2 = {
+			'typography-presets': 'Preset2',
+			'body-font-family': "'Lora,serif'",
+			'body-font-weight': '400',
+			'body-text-transform': 'capitalize',
+			'body-line-height': '25px',
+			'headings-font-family': "'Lato,sans-serif'",
+			'headings-font-weight': '700',
+			'headings-text-transform': 'capitalize',
+			'headings-line-height': '20px',
+		};
+
+		await setCustomize( globaltypographyPreset2 );
+
+		await createNewPost( { postType: 'post', title: 'preset1' } );
+		await setPostContent( TPOGRAPHY_TEST_POST_CONTENT );
+		await publishPost();
+		await page.goto( createURL( 'preset1' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( 'body' );
+
+		await expect( {
+			selector: 'body',
+			property: 'font-family',
+		} ).cssValueToBe(
+			`${ globaltypographyPreset2[ 'body-font-family' ] }`,
+		);
+		await expect( {
+			selector: 'body',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'body-font-weight' ] }`,
+		);
+
+		await expect( {
+			selector: 'body',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'body-text-transform' ] }`,
+		);
+
+		await expect( {
+			selector: 'body, button, input, select, textarea, .ast-button, .ast-custom-button',
+			property: 'line-height',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'body-line-height' ] }`,
+		);
+
+		await expect( {
+			selector: 'h1, .entry-content h1',
+			property: 'font-family',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'headings-font-family' ] }`,
+		);
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'headings-font-weight' ] }`,
+		);
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'headings-text-transform' ] }`,
+		);
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'line-height',
+		} ).cssValueToBe( `${ globaltypographyPreset2[ 'headings-line-height' ] }`,
+		);
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
e2e test case for global typography preset 2 style in the customizer
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
