### PR TITLE
AST-1333 - E2E test case for typography preset 5

### DIFF
--- a/tests/e2e/specs/customizer/global/typography/preset6.test.js
+++ b/tests/e2e/specs/customizer/global/typography/preset6.test.js
@@ -1,0 +1,104 @@
+import {
+	createURL,
+	createNewPost,
+	setPostContent,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { TPOGRAPHY_TEST_POST_CONTENT } from '../../../../utils/post';
+import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+describe( 'Global typography settings in the customizer', () => {
+	it( 'preset 6 settings should be applied correctly', async () => {
+		const presetFont = {
+			'body-font-family': "'Work Sans', sans-serif",
+			'font-size-body': {
+				desktop: '16',
+				tablet: '16',
+				mobile: '16',
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+			'body-font-weight': '400',
+			'body-text-transform': 'uppercase',
+			'body-line-height': '25px',
+			'headings-font-family': "'DM Serif Display', serif",
+			'headings-font-weight': '700',
+			'headings-text-transform': 'lowercase',
+			'headings-line-height': '40px',
+		};
+
+		await setCustomize( presetFont );
+		await createNewPost( { postType: 'post', title: 'Preset Test' } );
+		await setPostContent( TPOGRAPHY_TEST_POST_CONTENT );
+		await publishPost();
+		await page.goto( createURL( '/preset-test/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( 'body' );
+
+		await expect( {
+			selector: 'body',
+			property: 'font-family',
+		} ).cssValueToBe( `${ presetFont[ 'body-font-family' ] }`,
+		);
+
+		await expect( {
+			selector: 'body',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ presetFont[ 'font-size-body' ].desktop }${ presetFont[ 'font-size-body' ][ 'desktop-unit' ] }`,
+		);
+
+		await setBrowserViewport( 'medium' );
+		await expect( {
+			selector: 'body',
+			property: 'font-size',
+		} ).cssValueToBe( `${ presetFont[ 'font-size-body' ].tablet }${ presetFont[ 'font-size-body' ][ 'tablet-unit' ] }`,
+		);
+
+		await setBrowserViewport( 'small' );
+		await expect( {
+			selector: 'body',
+			property: 'font-size',
+		} ).cssValueToBe( `${ presetFont[ 'font-size-body' ].mobile }${ presetFont[ 'font-size-body' ][ 'mobile-unit' ] }`,
+		);
+
+		await expect( {
+			selector: 'body',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ presetFont[ 'body-font-weight' ] }` );
+
+		await expect( {
+			selector: 'body',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ presetFont[ 'body-text-transform' ] }` );
+
+		await expect( {
+			selector: 'body',
+			property: 'line-height',
+		} ).cssValueToBe( `${ presetFont[ 'body-line-height' ] }` );
+
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'font-family',
+		} ).cssValueToBe( `${ presetFont[ 'headings-font-family' ] }`,
+		);
+
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ presetFont[ 'headings-font-weight' ] }`,
+		);
+
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ presetFont[ 'headings-text-transform' ] }` );
+
+		await expect( {
+			selector: '.entry-content h1',
+			property: 'line-height',
+		} ).cssValueToBe( `${ presetFont[ 'headings-line-height' ] }` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added E2E Test case for typography preset 5

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/YEuPr5mO

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test : npm run test:e2e:interactive tests/e2e/specs/customizer/global/typography/preset6.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
