### PR TITLE
AST-1237 - Util for creating footer menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,14 +2992,6 @@
         "globals": "^12.0.0",
         "prettier": "npm:wp-prettier@2.2.1-beta-1",
         "requireindex": "^1.2.0"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
-        }
       }
     },
     "@wordpress/hooks": {
@@ -13041,6 +13033,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/tests/e2e/specs/menu.test.js
+++ b/tests/e2e/specs/menu.test.js
@@ -7,19 +7,7 @@ import { setCustomize } from '../utils/customize';
 
 describe( 'Hello World', () => {
 	it( 'elementor Hello, World!', async () => {
-		// await createNewElementorPost( 'page' );
-		// await insertSection();
-		// await insertWidget( {
-		// 	widgetName: 'Retina Image',
-		// 	section: 1,
-		// 	column: 1,
-		// } );
-
-		// await publishPage();
-		// await viewPage();
-
 		await createNewMenu();
-
 		//center alignment for desktop, tablet and mobile
 		const headerMenuAlignment = {
 			'header-desktop-items': {
@@ -34,9 +22,7 @@ describe( 'Hello World', () => {
 		await page.goto( createURL( '/' ), {
 			waitUntil: 'networkidle0',
 		} );
-
 		await page.waitForSelector( '#primary-site-navigation' );
-
 		await expect( true ).toBe( true );
 	} );
 } );

--- a/tests/e2e/specs/menu.test.js
+++ b/tests/e2e/specs/menu.test.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { createURL } from '@wordpress/e2e-test-utils';
+import { createNewMenu } from '../utils/create-menu';
+import { setCustomize } from '../utils/customize';
+
+describe( 'Hello World', () => {
+	it( 'elementor Hello, World!', async () => {
+		// await createNewElementorPost( 'page' );
+		// await insertSection();
+		// await insertWidget( {
+		// 	widgetName: 'Retina Image',
+		// 	section: 1,
+		// 	column: 1,
+		// } );
+
+		// await publishPage();
+		// await viewPage();
+
+		await createNewMenu();
+
+		//center alignment for desktop, tablet and mobile
+		const headerMenuAlignment = {
+			'header-desktop-items': {
+				primary: {
+					primary_right: {
+						0: 'menu-1',
+					},
+				},
+			},
+		};
+		await setCustomize( headerMenuAlignment );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+
+		await page.waitForSelector( '#primary-site-navigation' );
+
+		await expect( true ).toBe( true );
+	} );
+} );

--- a/tests/e2e/utils/create-menu.js
+++ b/tests/e2e/utils/create-menu.js
@@ -35,12 +35,12 @@ export const createNewMenu = async () => {
 
 	await page.waitForSelector( '.menu-item-depth-0:nth-child(2) .menu-item-handle' );
 
-	const example = await page.$('.menu-item-depth-0:nth-child(2) .menu-item-handle');
-	const bounding_box = await example.boundingBox();
+	const menuToSubMenu = await page.$( '.menu-item-depth-0:nth-child(2) .menu-item-handle' );
+	const boundingBox = await menuToSubMenu.boundingBox();
 
-	await page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
+	await page.mouse.move( boundingBox.x + boundingBox.width / 2, boundingBox.y + boundingBox.height / 2 );
 	await page.mouse.down();
-	await page.mouse.move(126, 19);
+	await page.mouse.move( 126, 19 );
 	await page.mouse.up();
 
 	await page.waitForSelector( '#save_menu_footer' );

--- a/tests/e2e/utils/create-menu.js
+++ b/tests/e2e/utils/create-menu.js
@@ -1,22 +1,49 @@
-import { createURL } from '@wordpress/e2e-test-utils';
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { scrollToElement } from './scroll-to-element';
+import { setBrowserViewport } from '../../e2e/utils/set-browser-viewport';
+
 export const createNewMenu = async () => {
+	await createNewPost( {
+		postType: 'page',
+		title: 'Test Page',
+		content: 'This is simple test page',
+	} );
+	await publishPost();
+	await createNewPost( {
+		postType: 'page',
+		title: 'Sub Test Page',
+		content: 'This is simple sub test page',
+	} );
+	await publishPost();
 	await page.goto( createURL( '/wp-admin/nav-menus.php' ), {
 		waitUntil: 'networkidle0',
 	} );
-	//await page.waitForSelector( '#nav-menu-footer' );
+	await setBrowserViewport( 'large' );
+	await scrollToElement( '#nav-menu-footer' );
 	if ( await page.$( '.menu-delete' ) ) {
 		await page.click( '.menu-delete' );
 	}
 	await page.focus( '#menu-name' );
 	await page.type( '#menu-name', 'Menu' );
+	await page.focus( '#locations-primary' );
+	await page.click( '#locations-primary' );
 	await page.click( '#save_menu_footer' );
-	await page.waitForSelector( '.accordion-section-content ' );
+	await page.waitForSelector( '.accordion-section-content' );
 	await page.focus( '#page-tab' );
 	await page.click( '#page-tab' );
 	await page.click( '#submit-posttype-page' );
-	await page.focus( '#locations-footer_menu' );
-	await page.click( '#locations-footer_menu' );
+
+	await page.waitForSelector( '.menu-item-depth-0:nth-child(2) .menu-item-handle' );
+
+	const example = await page.$('.menu-item-depth-0:nth-child(2) .menu-item-handle');
+	const bounding_box = await example.boundingBox();
+
+	await page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(126, 19);
+	await page.mouse.up();
+
+	await page.waitForSelector( '#save_menu_footer' );
 	await page.focus( '#save_menu_footer' );
 	await page.click( '#save_menu_footer' );
-	await page.setDragInterception( true );
 };

--- a/tests/e2e/utils/create-menu.js
+++ b/tests/e2e/utils/create-menu.js
@@ -1,0 +1,22 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+export const createNewMenu = async () => {
+	await page.goto( createURL( '/wp-admin/nav-menus.php' ), {
+		waitUntil: 'networkidle0',
+	} );
+	//await page.waitForSelector( '#nav-menu-footer' );
+	if ( await page.$( '.menu-delete' ) ) {
+		await page.click( '.menu-delete' );
+	}
+	await page.focus( '#menu-name' );
+	await page.type( '#menu-name', 'Menu' );
+	await page.click( '#save_menu_footer' );
+	await page.waitForSelector( '.accordion-section-content ' );
+	await page.focus( '#page-tab' );
+	await page.click( '#page-tab' );
+	await page.click( '#submit-posttype-page' );
+	await page.focus( '#locations-footer_menu' );
+	await page.click( '#locations-footer_menu' );
+	await page.focus( '#save_menu_footer' );
+	await page.click( '#save_menu_footer' );
+	await page.setDragInterception( true );
+};


### PR DESCRIPTION
Description
Created util to add menu

Prerequisites:
Atleast 2 pages should be created and published using createNewPost() and publishPost()

How has this been tested?
Click on Appearance on Admin Panel
Click on Menu
Delete existing menu
Add menu

Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
