### PR TITLE
AST-1437 - added e2e test case for off canvas full screen header popup padding

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
+++ b/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
@@ -1,0 +1,64 @@
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+describe( 'off canvas full-screen header type popup padding setting in the customizer', () => {
+	it( 'padding should apply correctly', async () => {
+		const fullscreenPopupPadding = {
+			'mobile-header-type': 'full-width',
+			'off-canvas-padding': {
+				tablet: {
+					top: '65',
+					right: '40',
+					bottom: '65',
+					left: '40',
+				},
+				'tablet-unit': 'px',
+
+			},
+		};
+		await setCustomize( fullscreenPopupPadding );
+		await createNewPost( {
+			postType: 'page',
+			title: 'sample-page',
+		} );
+		await publishPost();
+		await createNewPost( {
+			postType: 'page',
+			title: 'test-page',
+		} );
+		await publishPost();
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-mobile-popup-drawer.active .ast-mobile-popup-content' );
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-top',
+		} ).cssValueToBe(
+			`${ fullscreenPopupPadding[ 'off-canvas-padding' ].tablet.top }${ fullscreenPopupPadding[ 'off-canvas-padding' ][ 'tablet-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-right',
+		} ).cssValueToBe(
+			`${ fullscreenPopupPadding[ 'off-canvas-padding' ].tablet.right }${ fullscreenPopupPadding[ 'off-canvas-padding' ][ 'tablet-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-bottom',
+		} ).cssValueToBe(
+			`${ fullscreenPopupPadding[ 'off-canvas-padding' ].tablet.bottom }${ fullscreenPopupPadding[ 'off-canvas-padding' ][ 'tablet-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-left',
+		} ).cssValueToBe(
+			`${ fullscreenPopupPadding[ 'off-canvas-padding' ].tablet.left }${ fullscreenPopupPadding[ 'off-canvas-padding' ][ 'tablet-unit' ] }`,
+		);
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
e2e test case for off canvas full screen header popup padding

Steps:-
1. Go to the Customizer and select tablet mode
2. Click on header section and select Off-canvas
3.  Select header type as full-screen and go to the design setting
4. set padding and check on front-end
### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/kpu6zoYg
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive — tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
