### PR TITLE
e2e test case for page meta option disabling primary header on page

### DIFF
--- a/tests/e2e/specs/customizer/astra-meta-settings/disable-primary-header.test.js
+++ b/tests/e2e/specs/customizer/astra-meta-settings/disable-primary-header.test.js
@@ -1,0 +1,34 @@
+import {createURL,
+	createNewPost,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../utils/customize';
+
+describe( 'site layout meta setting', () => {
+	it( 'site layout meta setting', async () => {
+		const astraMetaSetting = {
+			'inspector-select-control-19': 'left-sidebar',
+		};
+		await setCustomize( astraMetaSetting );
+		await createNewPost( {
+			postType: 'page',
+			title: 'QA',
+		} );
+		await page.waitForSelector( '.interface-pinned-items .components-button:not(:first-child)' );
+		await page.click( '.interface-pinned-items .components-button:not(:first-child)' );
+		await page.waitForSelector( '#astra_settings_meta_box > div:nth-child(2)' );
+		await page.click( '#astra_settings_meta_box > div:nth-child(2) > div > div > div > div.components-input-control__container.css-ygaqem-Container.e1cr7zh11' );
+		await page.click('#astra_settings_meta_box > div:nth-child(5) > div.components-base-control.components-toggle-control.ast-main-header-display.css-wdf2ti-Wrapper.e1puf3u0');
+        await publishPost();
+		await page.goto( createURL( '/QA' ), {
+			waitUntil: 'networkidle0',
+		} );
+
+		// await page.waitForSelector( '.entry-content' );
+		// await expect( {
+		// 	selector: '.ast-above-header-bar',
+		// 	property: 'border-bottom-color',
+		// } ).cssValueToBe( `${ bottomBorder[ 'hba-header-bottom-border-color' ] }`,
+		// );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
1. go to the Dashboard>> pages & create new page
2. disable primary header for page from Astra Meta setting option and set sidebar position
### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/GGu4bkn1
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive — tests/e2e/specs/customizer/astra-meta-settings/disable-primary-header.test.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
