### PR TITLE
AST-1441 - test case for mobile off canvas header general setting

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/offcanvas-general.test.js
+++ b/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/offcanvas-general.test.js
@@ -1,8 +1,8 @@
 import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
 import { setCustomize } from '../../../../../utils/customize';
 import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
-describe( 'off canvas full-screen header type and content alignment settings in the customizer', () => {
-	it( 'off canvas header setting should apply correctly', async () => {
+describe( 'off canvas full-screen header type and content alignment settings for mobile mode in the customizer', () => {
+	it( 'off canvas header setting should apply correctly for mobile mode', async () => {
 		const offCanvasHeader = {
 			'mobile-header-type': 'full-width',
 			'header-offcanvas-content-alignment': 'center',

--- a/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/offcanvas-general.test.js
+++ b/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/offcanvas-general.test.js
@@ -1,0 +1,35 @@
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+describe( 'off canvas full-screen header type and content alignment settings in the customizer', () => {
+	it( 'off canvas header setting should apply correctly', async () => {
+		const offCanvasHeader = {
+			'mobile-header-type': 'full-width',
+			'header-offcanvas-content-alignment': 'center',
+		};
+		await setCustomize( offCanvasHeader );
+
+		await createNewPost( {
+			postType: 'page',
+			title: 'sample-page',
+		} );
+		await publishPost();
+		await createNewPost( {
+			postType: 'page',
+			title: 'QA',
+		} );
+		await publishPost();
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+
+		await page.waitForSelector( '.ast-builder-menu .main-navigation > ul' );
+		await expect( {
+			selector: '.ast-builder-menu .main-navigation > ul',
+			property: 'align-self',
+		} ).cssValueToBe( `${ offCanvasHeader[ 'header-offcanvas-content-alignment' ] }` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added e2e test case for off canvas header type and content alignment in header section for mobile mode.

Steps:-

1. Go to the customizer and select mobile mode
2. Click on header section and select off-canvas option.
3. Select header type as full screen from general setting
4. Select content alignment as center from general setting
5. Check on front end

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive — tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/offcanvas-general.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
