### PR TITLE
AST-1451 - e2e test case for popup padding for mobile mode

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
+++ b/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
@@ -1,0 +1,67 @@
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+describe( 'off canvas header type popup padding for mobile mode in the customizer', () => {
+	it( 'padding should apply correctly', async () => {
+		const mobileModePopupPadding = {
+			'mobile-header-type': 'full-width',
+			'off-canvas-padding': {
+				mobile: {
+					top: '65',
+					right: '40',
+					bottom: '65',
+					left: '40',
+				},
+				'mobile-unit': 'px',
+
+			},
+		};
+		await setCustomize( mobileModePopupPadding );
+		await createNewPost( {
+			postType: 'page',
+			title: 'sample-page',
+		} );
+		await publishPost();
+		await createNewPost( {
+			postType: 'page',
+			title: 'test-page',
+		} );
+		await publishPost();
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+
+		await setBrowserViewport( 'small' );
+
+		await page.click( '.main-header-menu-toggle' );
+
+		await page.waitForSelector( '.ast-mobile-popup-drawer.active .ast-mobile-popup-content' );
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-top',
+		} ).cssValueToBe(
+			`${ mobileModePopupPadding[ 'off-canvas-padding' ].mobile.top }${ mobileModePopupPadding[ 'off-canvas-padding' ][ 'mobile-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-right',
+		} ).cssValueToBe(
+			`${ mobileModePopupPadding[ 'off-canvas-padding' ].mobile.right }${ mobileModePopupPadding[ 'off-canvas-padding' ][ 'mobile-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-bottom',
+		} ).cssValueToBe(
+			`${ mobileModePopupPadding[ 'off-canvas-padding' ].mobile.bottom }${ mobileModePopupPadding[ 'off-canvas-padding' ][ 'mobile-unit' ] }`,
+		);
+
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.active .ast-mobile-popup-content',
+			property: 'padding-left',
+		} ).cssValueToBe(
+			`${ mobileModePopupPadding[ 'off-canvas-padding' ].mobile.left }${ mobileModePopupPadding[ 'off-canvas-padding' ][ 'mobile-unit' ] }`,
+		);
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Steps:-

1. Go to the customizer and select mobile mode
2. Click on header section and select off-canvas option.
3. Select header type as full screen from general setting
4. Select popup padding from design setting
5. Check on front end

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
 npm run test:e2e:interactive — tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/popup-padding.test.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
