### PR TITLE
AST-1424 - Linked default builder element's colors to color palette colors to make them sync with switcher mode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define Constants
  */
-define( 'ASTRA_THEME_VERSION', '3.7.5' );
+define( 'ASTRA_THEME_VERSION', '3.8.0' );
 define( 'ASTRA_THEME_SETTINGS', 'astra-settings' );
 define( 'ASTRA_THEME_DIR', trailingslashit( get_template_directory() ) );
 define( 'ASTRA_THEME_URI', trailingslashit( esc_url( get_template_directory_uri() ) ) );

--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -20,7 +20,8 @@ add_filter( 'astra_theme_defaults', 'astra_hf_builder_customizer_defaults' );
  */
 function astra_hf_builder_customizer_defaults( $defaults ) {
 
-	$palette_css_var_prefix = Astra_Global_Palette::get_css_variable_prefix();
+	$palette_css_var_prefix      = Astra_Global_Palette::get_css_variable_prefix();
+	$astra_update_color_defaults = astra_check_update_defaults_colors();
 
 	/**
 	 * Header Builder - Desktop Defaults.
@@ -94,11 +95,11 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 
 	$defaults['hb-header-main-sep']          = 1;
-	$defaults['hb-header-main-sep-color']    = '#eaeaea';
+	$defaults['hb-header-main-sep-color']    = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '6)' : '#eaeaea';
 	$defaults['hb-header-main-menu-align']   = 'inline';
 	$defaults['hb-header-bg-obj-responsive'] = array(
 		'desktop' => array(
-			'background-color'      => '#ffffff',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '5)' : '#ffffff',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -162,10 +163,10 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 		'mobile'  => 'stack',
 	);
 	$defaults['hba-header-separator']               = 1;
-	$defaults['hba-header-bottom-border-color']     = '#eaeaea';
+	$defaults['hba-header-bottom-border-color']     = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '6)' : '#eaeaea';
 	$defaults['hba-header-bg-obj-responsive']       = array(
 		'desktop' => array(
-			'background-color'      => '#ffffff',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '5)' : '#ffffff',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -253,10 +254,10 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 
 	$defaults['hbb-header-separator']           = 1;
-	$defaults['hbb-header-bottom-border-color'] = '#eaeaea';
+	$defaults['hbb-header-bottom-border-color'] = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '4)' : '#eaeaea';
 	$defaults['hbb-header-bg-obj-responsive']   = array(
 		'desktop' => array(
-			'background-color'      => '#eeeeee',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '6)' : '#eeeeee',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -401,7 +402,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 */
 	$defaults['hba-footer-bg-obj-responsive'] = array(
 		'desktop' => array(
-			'background-color'      => '#eeeeee',
+			'background-color'      => 'var(' . $palette_css_var_prefix . '6)',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -427,7 +428,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 	$defaults['hbb-footer-bg-obj-responsive'] = array(
 		'desktop' => array(
-			'background-color'      => '#eeeeee',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '4)' : '#eeeeee',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -453,7 +454,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 	$defaults['hb-footer-bg-obj-responsive']  = array(
 		'desktop' => array(
-			'background-color'      => '#f9f9f9',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '5)' : '#eeeeee',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -556,7 +557,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 */
 	$defaults['hb-footer-column']              = '3';
 	$defaults['hb-footer-separator']           = 1;
-	$defaults['hb-footer-bottom-border-color'] = '#e6e6e6';
+	$defaults['hb-footer-bottom-border-color'] = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '4)' : '#e6e6e6';
 	$defaults['hb-footer-layout']              = array(
 		'desktop' => '3-equal',
 		'tablet'  => '3-equal',
@@ -564,13 +565,13 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 
 	$defaults['hb-footer-main-sep']       = 1;
-	$defaults['hb-footer-main-sep-color'] = '#e6e6e6';
+	$defaults['hb-footer-main-sep-color'] = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '4)' : '#e6e6e6';
 
 	/**
 	 * Footer Copyright.
 	 */
 	$defaults['footer-copyright-editor']                 = 'Copyright [copyright] [current_year] [site_title] | Powered by [theme_author]';
-	$defaults['footer-copyright-color']                  = '';
+	$defaults['footer-copyright-color']                  = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '3)' : '';
 	$defaults['line-height-section-footer-copyright']    = 2;
 	$defaults['footer-copyright-alignment']              = array(
 		'desktop' => 'center',
@@ -1006,7 +1007,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 		'mobile'  => 18,
 	);
 
-	$defaults['header-account-icon-color'] = '';
+	$defaults['header-account-icon-color'] = $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '';
 
 	$defaults['header-account-login-link'] = array(
 		'url'      => '',
@@ -1340,16 +1341,18 @@ function astra_prepare_button_defaults( $defaults, $index ) {
  */
 function astra_prepare_html_defaults( $defaults, $index ) {
 
-	$_section = 'section-hb-html-' . $index;
+	$palette_css_var_prefix      = Astra_Global_Palette::get_css_variable_prefix();
+	$astra_update_color_defaults = astra_check_update_defaults_colors();
+	$_section                    = 'section-hb-html-' . $index;
 
 	$defaults[ 'header-html-' . $index ]                  = __( 'Insert HTML text here.', 'astra' );
 	$defaults[ 'header-html-' . $index . 'color' ]        = array(
-		'desktop' => '',
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '3)' : '',
 		'tablet'  => '',
 		'mobile'  => '',
 	);
 	$defaults[ 'header-html-' . $index . 'link-color' ]   = array(
-		'desktop' => '',
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '0)' : '',
 		'tablet'  => '',
 		'mobile'  => '',
 	);
@@ -1373,18 +1376,17 @@ function astra_prepare_html_defaults( $defaults, $index ) {
 
 	$defaults[ 'section-hb-html-' . $index . '-margin' ] = Astra_Builder_Helper::$default_responsive_spacing;
 
-
-
+	// Footer HTML.
 	$_section = 'section-fb-html-' . $index;
 
 	$defaults[ 'footer-html-' . $index ]                  = __( 'Insert HTML text here.', 'astra' );
 	$defaults[ 'footer-html-' . $index . 'color' ]        = array(
-		'desktop' => '',
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '3)' : '',
 		'tablet'  => '',
 		'mobile'  => '',
 	);
 	$defaults[ 'footer-html-' . $index . 'link-color' ]   = array(
-		'desktop' => '',
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '0)' : '',
 		'tablet'  => '',
 		'mobile'  => '',
 	);
@@ -1432,6 +1434,9 @@ function astra_prepare_html_defaults( $defaults, $index ) {
  */
 function astra_prepare_social_icon_defaults( $defaults, $index ) {
 
+	$palette_css_var_prefix      = Astra_Global_Palette::get_css_variable_prefix();
+	$astra_update_color_defaults = astra_check_update_defaults_colors();
+
 	$defaults[ 'header-social-' . $index . '-space' ]          = array(
 		'desktop' => '',
 		'tablet'  => '',
@@ -1444,7 +1449,16 @@ function astra_prepare_social_icon_defaults( $defaults, $index ) {
 		'mobile'  => '',
 	);
 	$defaults[ 'header-social-' . $index . '-radius' ]         = '';
-	$defaults[ 'header-social-' . $index . '-color' ]          = '';
+	$defaults[ 'header-social-' . $index . '-color' ]          = array(
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+		'tablet'  => '',
+		'mobile'  => '',
+	);
+	$defaults[ 'header-social-' . $index . '-label-color' ]    = array(
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+		'tablet'  => '',
+		'mobile'  => '',
+	);
 	$defaults[ 'header-social-' . $index . '-h-color' ]        = '';
 	$defaults[ 'header-social-' . $index . '-bg-color' ]       = '';
 	$defaults[ 'header-social-' . $index . '-bg-h-color' ]     = '';
@@ -1508,8 +1522,17 @@ function astra_prepare_social_icon_defaults( $defaults, $index ) {
 		'tablet'  => '',
 		'mobile'  => '',
 	);
+	$defaults[ 'footer-social-' . $index . '-color' ]          = array(
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+		'tablet'  => '',
+		'mobile'  => '',
+	);
+	$defaults[ 'footer-social-' . $index . '-label-color' ]    = array(
+		'desktop' => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+		'tablet'  => '',
+		'mobile'  => '',
+	);
 	$defaults[ 'footer-social-' . $index . '-radius' ]         = '';
-	$defaults[ 'footer-social-' . $index . '-color' ]          = '';
 	$defaults[ 'footer-social-' . $index . '-h-color' ]        = '';
 	$defaults[ 'footer-social-' . $index . '-bg-color' ]       = '';
 	$defaults[ 'footer-social-' . $index . '-bg-h-color' ]     = '';

--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -402,7 +402,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 */
 	$defaults['hba-footer-bg-obj-responsive'] = array(
 		'desktop' => array(
-			'background-color'      => 'var(' . $palette_css_var_prefix . '6)',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '6)' : '#eeeeee',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',
@@ -454,7 +454,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	);
 	$defaults['hb-footer-bg-obj-responsive']  = array(
 		'desktop' => array(
-			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '5)' : '#eeeeee',
+			'background-color'      => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '5)' : '#f9f9f9',
 			'background-image'      => '',
 			'background-repeat'     => 'repeat',
 			'background-position'   => 'center center',

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -96,7 +96,8 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 				return self::$defaults;
 			}
 
-			$palette_css_var_prefix = Astra_Global_Palette::get_css_variable_prefix();
+			$palette_css_var_prefix      = Astra_Global_Palette::get_css_variable_prefix();
+			$astra_update_color_defaults = astra_check_update_defaults_colors();
 			/**
 			 * Update Astra customizer default values. To not update directly on existing users site, added backwards.
 			 *
@@ -225,9 +226,9 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 						'tablet'  => '',
 						'mobile'  => '',
 					),
-					'header-color-site-title'              => '',
-					'header-color-h-site-title'            => '',
-					'header-color-site-tagline'            => '',
+					'header-color-site-title'              => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+					'header-color-h-site-title'            => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
+					'header-color-site-tagline'            => $astra_update_color_defaults ? 'var(' . $palette_css_var_prefix . '8)' : '',
 					'display-site-title-responsive'        => array(
 						'desktop' => 1,
 						'tablet'  => 1,

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -800,3 +800,15 @@ function astra_check_elementor_pro_3_5_version() {
 	}
 	return false;
 }
+
+/**
+ * Check if backward flag is set before updating default colors to sync colors with palette.
+ *
+ * @since x.x.x
+ * @return bool $astra_backward_flag
+ */
+function astra_check_update_defaults_colors() {
+	$astra_settings      = get_option( ASTRA_THEME_SETTINGS );
+	$astra_backward_flag = ( isset( $astra_settings['link-default-colors-with-palette'] ) && false === $astra_settings['link-default-colors-with-palette'] ) ? false : true;
+	return $astra_backward_flag;
+}

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -3274,3 +3274,20 @@ function astra_improve_gutenberg_editor_ui() {
 		update_option( 'astra-settings', $theme_options );
 	}
 }
+
+/**
+ * Set flag to avoid direct reflections on live site & to maintain backward compatibility for existing users.
+ *
+ * @todo Updating builder & their element's default colors or static colors to make them link with color palette colors.
+ * To work in sync with Dark mode switch.
+ * @since x.x.x
+ * @return void
+ */
+function astra_update_builders_default_colors() {
+	$theme_options = get_option( 'astra-settings', array() );
+
+	if ( ! isset( $theme_options['link-default-colors-with-palette'] ) ) {
+		$theme_options['link-default-colors-with-palette'] = false;
+		update_option( 'astra-settings', $theme_options );
+	}
+}

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -117,6 +117,9 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 			'3.7.4' => array(
 				'astra_improve_gutenberg_editor_ui',
 			),
+			'3.8.0' => array(
+				'astra_update_builders_default_colors',
+			),
 		);
 
 		/**

--- a/tests/php/static-analysis-stubs/astra-stubs.php
+++ b/tests/php/static-analysis-stubs/astra-stubs.php
@@ -5051,7 +5051,7 @@ namespace {
         public function content_layout($layout)
         {
         }
-        /**
+        /** 
          * LearnDash Static CSS.
          *
          * @since 3.3.0
@@ -6921,7 +6921,7 @@ namespace {
         public function __construct()
         {
         }
-        /**
+        /** 
          * Comment count wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -6931,7 +6931,7 @@ namespace {
         public function comment_count_wrapper_open($args)
         {
         }
-        /**
+        /** 
          * Comment count wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -6941,7 +6941,7 @@ namespace {
         public function comment_count_wrapper_close($args)
         {
         }
-        /**
+        /** 
          * Comment data wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -6951,7 +6951,7 @@ namespace {
         public function ast_comment_data_wrap_open($args)
         {
         }
-        /**
+        /** 
          * Comment data wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -6961,7 +6961,7 @@ namespace {
         public function ast_comment_data_wrap_close($args)
         {
         }
-        /**
+        /** 
          * Comment meta wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -6971,7 +6971,7 @@ namespace {
         public function ast_comment_meta_wrap_open($args)
         {
         }
-        /**
+        /** 
          * Comment meta wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -6981,7 +6981,7 @@ namespace {
         public function ast_comment_meta_wrap_close($args)
         {
         }
-        /**
+        /** 
          * Comment time div attributes.
          *
          * @since 3.3.0
@@ -6990,7 +6990,7 @@ namespace {
         public function ast_comment_time_attr()
         {
         }
-        /**
+        /** 
          * Comment cite wrapper div attributes.
          *
          * @since 3.3.0
@@ -7035,16 +7035,16 @@ namespace {
         public function ast_grid_col_6()
         {
         }
-        /**
+        /** 
          * Comment form grid classes.
          *
-         * @since 3.3.0
+         * @since 3.3.0 
          * @return string.
          */
         public function comment_form_grid_class()
         {
         }
-        /**
+        /** 
          * Removed grid layout classes and make common class for same style
          *
          * @since 3.3.0
@@ -7053,7 +7053,7 @@ namespace {
         public function ast_grid_lg_12()
         {
         }
-        /**
+        /** 
          * Layout-4 grid css backward comaptibility.
          *
          * @return string.
@@ -7061,7 +7061,7 @@ namespace {
         public function ast_layout_4_grid()
         {
         }
-        /**
+        /** 
          * Layout-2 grid css backward comaptibility.
          *
          * @return string.
@@ -7069,7 +7069,7 @@ namespace {
         public function ast_layout_2_grid()
         {
         }
-        /**
+        /** 
          * Layout-1 grid css backward comaptibility.
          *
          * @return string.
@@ -7077,7 +7077,7 @@ namespace {
         public function ast_layout_1_grid()
         {
         }
-        /**
+        /** 
          * Layout-3 grid css backward comaptibility.
          *
          * @return string.
@@ -7085,7 +7085,7 @@ namespace {
         public function ast_layout_3_grid()
         {
         }
-        /**
+        /** 
          * Layout-5 grid css backward comaptibility.
          *
          * @return string.
@@ -7093,7 +7093,7 @@ namespace {
         public function ast_layout_5_grid()
         {
         }
-        /**
+        /** 
          * Layout-6 grid css backward comaptibility.
          *
          * @return string.
@@ -7103,7 +7103,7 @@ namespace {
         }
         /**
          * Footer widget opening div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -7113,7 +7113,7 @@ namespace {
         }
         /**
          * Footer widget closing div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -7143,7 +7143,7 @@ namespace {
         }
         /**
          * Footer widget opening div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -10884,7 +10884,7 @@ namespace {
     }
     /*!
      * ISC License
-     *
+     * 
      * Copyright (c) 2018-2021, Andrea Giammarchi, @WebReflection
      *
      * Permission to use, copy, modify, and/or distribute this software for any
@@ -11758,7 +11758,7 @@ namespace {
          *
          * @var array
          */
-        private static $db_updates = array('2.1.3' => array('astra_submenu_below_header'), '2.2.0' => array('astra_page_builder_button_color_compatibility', 'astra_vertical_horizontal_padding_migration'), '2.3.0' => array('astra_header_button_new_options'), '2.3.3' => array('astra_elementor_default_color_typo_comp'), '2.3.4' => array('astra_breadcrumb_separator_fix'), '2.4.0' => array('astra_responsive_base_background_option', 'astra_update_theme_tablet_breakpoint'), '2.4.4' => array('astra_gtn_full_wide_image_group_css'), '2.5.0' => array('astra_global_button_woo_css', 'astra_gtn_full_wide_group_cover_css'), '2.5.2' => array('astra_footer_widget_bg'), '2.6.0' => array('astra_bg_control_migration', 'astra_bg_responsive_control_migration', 'astra_gutenberg_core_blocks_design_compatibility'), '2.6.1' => array('astra_gutenberg_media_text_block_css_compatibility'), '3.0.0' => array('astra_header_builder_compatibility'), '3.0.1' => array('astra_clear_assets_cache'), '3.3.0' => array('astra_gutenberg_pattern_compatibility', 'astra_icons_svg_compatibility', 'astra_check_flex_based_css'), '3.4.0' => array('astra_update_cart_style'), '3.5.0' => array('astra_update_related_posts_grid_layout', 'astra_site_title_tagline_responsive_control_migration'), '3.6.0' => array('astra_headings_font_support', 'astra_remove_logo_max_width', 'astra_transparent_header_default_value'), '3.6.3' => array('astra_button_default_values_updated'), '3.6.4' => array('astra_update_underline_link_setting'), '3.6.5' => array('astra_support_block_editor'), '3.6.7' => array('astra_fix_footer_widget_right_margin_case', 'astra_remove_elementor_toc_margin'), '3.6.8' => array('astra_set_removal_widget_design_options_flag'), '3.6.9' => array('astra_zero_font_size_comp', 'astra_unset_builder_elements_underline', 'astra_remove_responsive_account_menu_colors_support'), '3.7.0' => array('astra_global_color_compatibility'), '3.7.4' => array('astra_improve_gutenberg_editor_ui'));
+        private static $db_updates = array('2.1.3' => array('astra_submenu_below_header'), '2.2.0' => array('astra_page_builder_button_color_compatibility', 'astra_vertical_horizontal_padding_migration'), '2.3.0' => array('astra_header_button_new_options'), '2.3.3' => array('astra_elementor_default_color_typo_comp'), '2.3.4' => array('astra_breadcrumb_separator_fix'), '2.4.0' => array('astra_responsive_base_background_option', 'astra_update_theme_tablet_breakpoint'), '2.4.4' => array('astra_gtn_full_wide_image_group_css'), '2.5.0' => array('astra_global_button_woo_css', 'astra_gtn_full_wide_group_cover_css'), '2.5.2' => array('astra_footer_widget_bg'), '2.6.0' => array('astra_bg_control_migration', 'astra_bg_responsive_control_migration', 'astra_gutenberg_core_blocks_design_compatibility'), '2.6.1' => array('astra_gutenberg_media_text_block_css_compatibility'), '3.0.0' => array('astra_header_builder_compatibility'), '3.0.1' => array('astra_clear_assets_cache'), '3.3.0' => array('astra_gutenberg_pattern_compatibility', 'astra_icons_svg_compatibility', 'astra_check_flex_based_css'), '3.4.0' => array('astra_update_cart_style'), '3.5.0' => array('astra_update_related_posts_grid_layout', 'astra_site_title_tagline_responsive_control_migration'), '3.6.0' => array('astra_headings_font_support', 'astra_remove_logo_max_width', 'astra_transparent_header_default_value'), '3.6.3' => array('astra_button_default_values_updated'), '3.6.4' => array('astra_update_underline_link_setting'), '3.6.5' => array('astra_support_block_editor'), '3.6.7' => array('astra_fix_footer_widget_right_margin_case', 'astra_remove_elementor_toc_margin'), '3.6.8' => array('astra_set_removal_widget_design_options_flag'), '3.6.9' => array('astra_zero_font_size_comp', 'astra_unset_builder_elements_underline', 'astra_remove_responsive_account_menu_colors_support'), '3.7.0' => array('astra_global_color_compatibility'), '3.7.4' => array('astra_improve_gutenberg_editor_ui'), '3.8.0' => array('astra_update_builders_default_colors'));
         /**
          *  Constructor
          */
@@ -12748,7 +12748,7 @@ namespace {
     }
     /**
      * Load Menu hover style static CSS if any one of the menu hover style is selected.
-     *
+     * 
      * @return string
      * @since 3.5.0
      */
@@ -12847,7 +12847,7 @@ namespace {
     }
     /**
      * Search Component static CSS.
-     *
+     * 
      * @return string
      * @since 3.5.0
      */
@@ -14474,7 +14474,7 @@ namespace {
     /**
      * Old Header Menu Last Item - Dynamic CSS.
      *
-     * @param string $dynamic_css
+     * @param string $dynamic_css 
      * @since 3.5.0
      */
     function astra_old_header_custom_menu_css($dynamic_css)
@@ -14864,6 +14864,15 @@ namespace {
      * @return boolean
      */
     function astra_check_elementor_pro_3_5_version()
+    {
+    }
+    /**
+     * Check if backward flag is set before updating default colors to sync colors with palette.
+     *
+     * @since x.x.x
+     * @return bool $astra_backward_flag
+     */
+    function astra_check_update_defaults_colors()
     {
     }
     /**
@@ -15896,6 +15905,17 @@ namespace {
      * @return void
      */
     function astra_improve_gutenberg_editor_ui()
+    {
+    }
+    /**
+     * Set flag to avoid direct reflections on live site & to maintain backward compatibility for existing users.
+     *
+     * @todo Updating builder & their element's default colors or static colors to make them link with color palette colors.
+     * To work in sync with Dark mode switch.
+     * @since x.x.x
+     * @return void
+     */
+    function astra_update_builders_default_colors()
     {
     }
     /**


### PR DESCRIPTION
### Description
- Currently some elements or areas have colors assigned hard-coded in defaults or come from static CSS
- So updating those colors by linking them to color palette

### Screenshots
- Example - https://share.bsf.io/v1ujq6kO

### Types of changes
- Improvement

### How has this been tested?
- Check builder areas elements -
- 1. Above header - Border bottom, Background color
- 2. Primary header - Border bottom, Background color
- 3. Below header - Border bottom, Background color
- 4. Site Indetity - Title, Tagline colors
- 5. Social element - Header + Footer - Icon, Label color
- 6. Account element - Icon color
- 7. HTML element - Text, Link color

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've added proper labels to this pull request
