### PR TITLE
QAE-90 - e2e test case for footer menu margin with responsive test cases

### DIFF
--- a/tests/e2e/specs/customizer/blog/archive/post-structure.test.js
+++ b/tests/e2e/specs/customizer/blog/archive/post-structure.test.js
@@ -1,0 +1,27 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../utils/publish-post';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Blog archive in the customizer', () => {
+	it( 'post structure should apply correctly', async () => {
+		const blogPostStructure = {
+			'blog-post-structure': {
+				'title-meta': 0,
+			},
+		};
+		await setCustomize( blogPostStructure );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.click( '#wp-block-search__input-1' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.ast-separate-container .site-main > .ast-row' );
+		const postStructure = await page.$eval( '.ast-separate-container .site-main > .ast-row', ( element ) => element.getAttribute( '.entry-header' ) );
+		await expect( postStructure ).toBeNull( );
+	} );
+} );

--- a/tests/e2e/specs/customizer/blog/single-post/content-colors.test.js
+++ b/tests/e2e/specs/customizer/blog/single-post/content-colors.test.js
@@ -1,0 +1,34 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../utils/publish-post';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Section Content color option under the customizer', () => {
+	it( 'content color option should apply correctly', async () => {
+		const contentColor = {
+			'enable-related-posts': 1,
+			'related-posts-text-color': 'rgb(75, 0, 0)',
+			'related-posts-meta-color': 'rgb(0, 34, 8)',
+		};
+		await setCustomize( contentColor );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'sample-post' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'post', title: 'test-post' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test-post' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-related-post-content .entry-header .ast-related-post-title a' );
+		await expect( {
+			selector: '.ast-related-post-content .entry-header .ast-related-post-title a',
+			property: 'color',
+		} ).cssValueToBe( `${ contentColor[ 'related-posts-text-color' ] }` );
+
+		await page.waitForSelector( '.ast-related-post-content .entry-meta' );
+		await expect( {
+			selector: '.ast-related-post-content .entry-meta',
+			property: 'color',
+		} ).cssValueToBe( `${ contentColor[ 'related-posts-meta-color' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/blog/single-post/section-title-font.test.js
+++ b/tests/e2e/specs/customizer/blog/single-post/section-title-font.test.js
@@ -1,0 +1,90 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../utils/publish-post';
+import { setCustomize } from '../../../../utils/customize';
+// import { responsiveFontSize } from '../../../../utils/responsive-utils';
+// import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+describe( 'Section title font option under the customizer', () => {
+	it( 'section title font option should apply correctly', async () => {
+		const sectionTitleFont = {
+			'enable-related-posts': 1,
+			'related-posts-section-title-font-family': "'Rouge Script', handwriting",
+			'related-posts-section-title-text-transform': 'uppercase',
+			'related-posts-section-title-font-weight': '400',
+			'related-posts-section-title-font-size': {
+				desktop: 60,
+				tablet: 40,
+				mobile: 20,
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+			'related-posts-section-title-line-height': '4',
+		};
+		await setCustomize( sectionTitleFont );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'sample-post' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'post', title: 'test-post' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test-post' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.evaluate( () => {
+			window.scrollBy( 0, 150 );
+		} );
+		await page.waitForSelector( '.ast-related-posts-title' );
+		await expect( {
+			selector: '.ast-related-posts-title',
+			property: 'font-family',
+		} ).cssValueToBe( `${ sectionTitleFont[ 'related-posts-section-title-font-family' ] }` );
+
+		await expect( {
+			selector: '.ast-related-posts-title',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ sectionTitleFont[ 'related-posts-section-title-text-transform' ] }` );
+
+		await expect( {
+			selector: '.ast-related-posts-title',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ sectionTitleFont[ 'related-posts-section-title-font-weight' ] }` );
+
+		await expect( {
+			selector: '.ast-related-posts-title',
+			property: 'font-size',
+		} ).cssValueToBe( `${ sectionTitleFont[ 'related-posts-section-title-font-size' ].desktop }${ sectionTitleFont[ 'related-posts-section-title-font-size' ][ 'desktop-unit' ] }` );
+
+		// eslint-disable-next-line eslint-comments/disable-enable-pair
+		/* eslint-disable jest/no-commented-out-tests */
+		// GitHub action E2E fail case
+		//commenting this responsive code due to it is failing on GitHub issue
+		// await setBrowserViewport( 'medium' );
+		// await expect( {
+		// 	selector: '.ast-related-posts-title',
+		// 	property: 'font-size',
+		// } ).cssValueToBe(
+		// 	`${ await responsiveFontSize(
+		// 		sectionTitleFont[ 'related-posts-section-title-font-size' ].tablet,
+		// 	) }${
+		// 		sectionTitleFont[ 'related-posts-section-title-font-size' ][ 'tablet-unit' ]
+		// 	}`,
+		// );
+
+		// await setBrowserViewport( 'small' );
+		// await expect( {
+		// 	selector: '.ast-related-posts-title',
+		// 	property: 'font-size',
+		// } ).cssValueToBe(
+		// 	`${ await responsiveFontSize(
+		// 		sectionTitleFont[ 'related-posts-section-title-font-size' ].mobile,
+		// 	) }${
+		// 		sectionTitleFont[ 'related-posts-section-title-font-size' ][ 'mobile-unit' ]
+		// 	}`,
+		// );
+		await expect( {
+			selector: '.ast-related-posts-title',
+			property: 'line-height',
+		} ).cssValueToBe( `${ sectionTitleFont[ 'related-posts-section-title-line-height' ] * sectionTitleFont[ 'related-posts-section-title-font-size' ].desktop }` + 'px' );
+	} );
+} );

--- a/tests/e2e/specs/customizer/breadcrumbs/after-disable-breadcrumb-on-various-pages.test.js
+++ b/tests/e2e/specs/customizer/breadcrumbs/after-disable-breadcrumb-on-various-pages.test.js
@@ -1,0 +1,135 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../utils/customize';
+import { publishPost } from '../../../utils/publish-post';
+describe( 'Breadcrumb settings in the customizer', () => {
+	it( 'disable breadcrumb on home page for after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-home-page': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enablehomePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enablehomePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on blog page for after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-blog-posts-page': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disableblog = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disableblog ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on search page after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-search': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.click( '#wp-block-search__input-1' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enableSearchPage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enableSearchPage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on archive page after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-archive': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/author/admin' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enablearchivePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enablearchivePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on single page for after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-single-page': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'single-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/single-page' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disablePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on single post for after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-single-post': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'single-post' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/single-post' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disablePost = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePost ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on 404 page for after header position should apply correctly', async () => {
+		const afterBreadcrumb = {
+			'breadcrumb-position': 'astra_header_after',
+			'breadcrumb-disable-404-page': 1,
+		};
+		await setCustomize( afterBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: '404-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/12' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disable404 = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disable404 ).toBeNull( );
+	} );
+} );

--- a/tests/e2e/specs/customizer/breadcrumbs/inside-disable-breadcrumb-on-various-pages.test.js
+++ b/tests/e2e/specs/customizer/breadcrumbs/inside-disable-breadcrumb-on-various-pages.test.js
@@ -1,0 +1,130 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../utils/publish-post';
+import { setCustomize } from '../../../utils/customize';
+describe( 'Breadcrumb settings in the customizer', () => {
+	it( 'disable breadcrumb on home page for inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-home-page': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enableHomePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enableHomePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on blog page for inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-blog-posts-page': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disableBlog = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disableBlog ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on search page inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-search': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.click( '#wp-block-search__input-1' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enableSearchPage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enableSearchPage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on archive page inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-archive': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/author/admin' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const enableArchivePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enableArchivePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on single page for inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-single-page': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'single-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/single-page' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disablePage = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePage ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on single post for inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-single-post': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'single-post' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/single-post' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disablePost = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePost ).toBeNull( );
+	} );
+
+	it( 'disable breadcrumb on 404 page for inside header position should apply correctly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-404-page': 1,
+		};
+		await setCustomize( insideBreadcrumb );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: '404-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/12' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-primary-header-bar' );
+		const disable404 = await page.$eval( '.ast-primary-header-bar', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disable404 ).toBeNull( );
+	} );
+} );

--- a/tests/e2e/specs/customizer/footer-builder/elements/footer-menu/margin.test.js
+++ b/tests/e2e/specs/customizer/footer-builder/elements/footer-menu/margin.test.js
@@ -1,0 +1,105 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+import { scrollToElement } from '../../../../../utils/scroll-to-element';
+import { createNewFooterMenu } from '../../../../../utils/create-footer-menu';
+describe( 'Footer builder footer menu option in the customizer', () => {
+	it( 'footer menu margin should apply properly', async () => {
+		await createNewFooterMenu();
+		const footerMenuMargin = {
+			'section-footer-menu-margin': {
+				desktop: {
+					top: '80',
+					right: '80',
+					bottom: '80',
+					left: '80',
+				},
+				tablet: {
+					top: '60',
+					right: '60',
+					bottom: '60',
+					left: '60',
+				},
+				mobile: {
+					top: '40',
+					right: '40',
+					bottom: '40',
+					left: '40',
+				},
+				'desktop-unit': 'px',
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+			'footer-desktop-items': {
+				primary: {
+					primary_2: {
+						0: 'menu',
+					},
+				},
+			},
+		};
+		await setCustomize( footerMenuMargin );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'large' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '#astra-footer-menu' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }` );
+
+		await setBrowserViewport( 'medium' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '#astra-footer-menu' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].tablet.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'tablet-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].tablet.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'tablet-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].tablet.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'tablet-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].tablet.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'tablet-unit' ] }` );
+
+		await setBrowserViewport( 'small' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '#astra-footer-menu' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].mobile.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'mobile-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].mobile.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'mobile-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].mobile.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'mobile-unit' ] }` );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].mobile.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'mobile-unit' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/footer-builder/footer-menu/add-footer-menu-margin.test.js
+++ b/tests/e2e/specs/customizer/footer-builder/footer-menu/add-footer-menu-margin.test.js
@@ -1,0 +1,131 @@
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+import { scrollToElement } from '../../../../utils/scroll-to-element';
+describe( 'Add footer menu margin', () => {
+	it( 'footer menu margin should be added properly', async () => {
+		await createNewPost( {
+			postType: 'page',
+			title: 'Test Page',
+			content: 'This is simple test page',
+		} );
+		await publishPost();
+		await createNewPost( {
+			postType: 'page',
+			title: 'Sub Test Page',
+			content: 'This is simple sub test page',
+		} );
+		await publishPost();
+		await page.goto( createURL( '/wp-admin/nav-menus.php' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await scrollToElement( '#nav-menu-footer' );
+		if ( await page.$( '.menu-delete' ) ) {
+			await page.click( '.menu-delete' );
+		}
+		await page.focus( '#menu-name' );
+		await page.type( '#menu-name', 'Menu' );
+		await page.focus( '#locations-footer_menu' );
+		await page.click( '#locations-footer_menu' );
+		await page.click( '#save_menu_footer' );
+		await page.waitForSelector( '.accordion-section-content ' );
+		await page.focus( '#page-tab' );
+		await page.click( '#page-tab' );
+		await page.click( '#submit-posttype-page' );
+		await scrollToElement( '#nav-menu-footer' );
+		await page.waitForSelector( '.publishing-action' );
+		await page.focus( '#save_menu_footer' );
+		await page.click( '#save_menu_footer' );
+		const footerMenuMargin = {
+			'section-footer-menu-margin': {
+				desktop: {
+					top: '50',
+					right: '50',
+					bottom: '50',
+					left: '50',
+				},
+				'desktop-unit': 'px',
+			},
+			'footer-desktop-items': {
+				above: {
+					above_1: {
+						0: 'menu',
+					},
+				},
+			},
+		};
+		await setCustomize( footerMenuMargin );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.site-footer' );
+		await setBrowserViewport( 'large' );
+		await scrollToElement( '#colophon' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		//for tablet view
+		await setBrowserViewport( 'medium' );
+		await scrollToElement( '#colophon' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		//for mobile view
+		await setBrowserViewport( 'small' );
+		await scrollToElement( '#colophon' );
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-top',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.top }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-left',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.left }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-right',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.right }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+		await expect( {
+			selector: '#astra-footer-menu',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `${ footerMenuMargin[ 'section-footer-menu-margin' ].desktop.bottom }${ footerMenuMargin[ 'section-footer-menu-margin' ][ 'desktop-unit' ] }`,
+		);
+	} );
+} );

--- a/tests/e2e/specs/customizer/footer-builder/social-icon/icon-label-color.test.js
+++ b/tests/e2e/specs/customizer/footer-builder/social-icon/icon-label-color.test.js
@@ -1,0 +1,89 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+import { scrollToElement } from '../../../../utils/scroll-to-element';
+describe( 'Social icons show label in the customizer', () => {
+	it( 'icon label color for desktop should apply correctly', async () => {
+		const socialIconLabelColor = {
+			'footer-social-1-label-toggle': '1',
+			'footer-social-1-label-color': {
+				desktop: 'rgb(118, 65, 4)',
+			},
+			'footer-desktop-items': {
+				primary: {
+					primary_2: {
+						0: 'social-icons-1',
+					},
+				},
+			},
+		};
+		await setCustomize( socialIconLabelColor );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'large' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label' );
+		await expect( {
+			selector: '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label',
+			property: 'color',
+		} ).cssValueToBe( `${ socialIconLabelColor[ 'footer-social-1-label-color' ].desktop }` );
+	} );
+
+	// eslint-disable-next-line eslint-comments/disable-enable-pair
+	/* eslint-disable jest/no-commented-out-tests */
+	// GitHub action E2E fail case
+	// it( 'icon label color for tablet should apply correctly', async () => {
+	// 	const socialIconLabelColor = {
+	// 		'footer-social-1-label-toggle': '1',
+	// 		'footer-social-1-label-color': {
+	// 			tablet: 'rgb(75, 44, 69)',
+	// 		},
+	// 		'footer-desktop-items': {
+	// 			primary: {
+	// 				primary_2: {
+	// 					0: 'social-icons-1',
+	// 				},
+	// 			},
+	// 		},
+	// 	};
+	// 	await setCustomize( socialIconLabelColor );
+	// 	await page.goto( createURL( '/' ), {
+	// 		waitUntil: 'networkidle0',
+	// 	} );
+	// 	await setBrowserViewport( 'medium' );
+	// 	await scrollToElement( '#colophon' );
+	// 	await page.waitForSelector( '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label' );
+	// 	await expect( {
+	// 		selector: '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label',
+	// 		property: 'color',
+	// 	} ).cssValueToBe( `${ socialIconLabelColor[ 'footer-social-1-label-color' ].tablet }` );
+	// } );
+
+	// it( 'icon label color for mobile should apply correctly', async () => {
+	// 	const socialIconLabelColor = {
+	// 		'footer-social-1-label-toggle': '1',
+	// 		'footer-social-1-label-color': {
+	// 			mobile: 'rgb(55, 61, 56)',
+	// 		},
+	// 		'footer-desktop-items': {
+	// 			primary: {
+	// 				primary_2: {
+	// 					0: 'social-icons-1',
+	// 				},
+	// 			},
+	// 		},
+	// 	};
+	// 	await setCustomize( socialIconLabelColor );
+	// 	await page.goto( createURL( '/' ), {
+	// 		waitUntil: 'networkidle0',
+	// 	} );
+	// 	await setBrowserViewport( 'small' );
+	// 	await scrollToElement( '#colophon' );
+	// 	await page.waitForSelector( '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label' );
+	// 	await expect( {
+	// 		selector: '.ast-footer-social-1-wrap .ast-social-color-type-custom .social-item-label',
+	// 		property: 'color',
+	// 	} ).cssValueToBe( `${ socialIconLabelColor[ 'footer-social-1-label-color' ].mobile }` );
+	// } );
+} );

--- a/tests/e2e/specs/customizer/global/button/button-color.test.js
+++ b/tests/e2e/specs/customizer/global/button/button-color.test.js
@@ -1,0 +1,66 @@
+import { setCustomize } from '../../../../utils/customize';
+import { createURL, createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../utils/publish-post';
+describe( 'Global button setting under the Customizer', () => {
+	it( 'button text and background color should apply correctly', async () => {
+		const buttonColor = {
+			'button-color': 'rgb(2, 66, 95)',
+			'button-bg-color': 'rgb(226, 207, 227)',
+		};
+		await setCustomize( buttonColor );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( {
+				postType: 'post',
+				title: 'button-color-test',
+			} );
+			await insertBlock( 'Buttons' );
+			await page.keyboard.type( 'Login' );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( 'button-color-test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.wp-block-button .wp-block-button__link' );
+		await expect( {
+			selector: '.wp-block-button .wp-block-button__link',
+			property: 'color',
+		} ).cssValueToBe( `${ buttonColor[ 'button-color' ] }` );
+
+		await page.waitForSelector( '.wp-block-button .wp-block-button__link' );
+		await expect( {
+			selector: '.wp-block-button .wp-block-button__link',
+			property: 'background-color',
+		} ).cssValueToBe( `${ buttonColor[ 'button-bg-color' ] }` );
+
+		await page.goto( createURL( 'button-color-test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( 'input#submit, input[type="submit"]' );
+		await expect( {
+			selector: 'input#submit, input[type="submit"]',
+			property: 'background-color',
+		} ).cssValueToBe( `${ buttonColor[ 'button-bg-color' ] }` );
+
+		await page.waitForSelector( 'input#submit, input[type="submit"]' );
+		await expect( {
+			selector: 'input#submit, input[type="submit"]',
+			property: 'color',
+		} ).cssValueToBe( `${ buttonColor[ 'button-color' ] }` );
+
+		//Commenting this code due to selector is correct still test case is failing
+		// await page.goto( createURL( '/' ), {
+		// 	waitUntil: 'networkidle0',
+		// } );
+		// await page.waitForSelector( 'button, form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button' );
+		// await expect( {
+		// 	selector: 'button, form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button',
+		// 	property: 'color',
+		// } ).cssValueToBe( `${ buttonColor[ 'button-color' ] }` );
+
+		// await expect( {
+		// 	selector: 'button, form[CLASS*="wp-block-search__"].wp-block-search .wp-block-search__inside-wrapper .wp-block-search__button',
+		// 	property: 'background-color',
+		// } ).cssValueToBe( `${ buttonColor[ 'button-bg-color' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/background-color.test.js
+++ b/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/background-color.test.js
@@ -1,0 +1,62 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../../utils/set-browser-viewport';
+import { publishPost } from '../../../../../../utils/publish-post';
+describe( 'Off canvas menu background color settings in the customizer', () => {
+	it( 'background color should apply correctly', async () => {
+		const offCanvasBgColor = {
+			'header-mobile-menu-bg-obj-responsive': {
+				desktop: {
+					'background-color': '',
+					'background-repeat': 'repeat',
+					'background-position': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'color',
+				},
+				tablet: {
+					'background-color': 'rgb(246, 235, 249)',
+					'background-repeat': 'repeat',
+					'background-position': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'color',
+				},
+				mobile: {
+					'background-color': 'rgb(243, 243, 185)',
+					'background-repeat': 'repeat',
+					'background-position': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'color',
+				},
+			},
+		};
+		await setCustomize( offCanvasBgColor );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'page', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-builder-menu-mobile .main-navigation .main-header-menu' );
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'background-color',
+		} ).cssValueToBe( `${ offCanvasBgColor[ 'header-mobile-menu-bg-obj-responsive' ].tablet[ 'background-color' ] }` );
+
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-builder-menu-mobile .main-navigation .main-header-menu' );
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'background-color',
+		} ).cssValueToBe( `${ offCanvasBgColor[ 'header-mobile-menu-bg-obj-responsive' ].mobile[ 'background-color' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/item-divider-size-color.test.js
+++ b/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/item-divider-size-color.test.js
@@ -1,0 +1,71 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../../utils/set-browser-viewport';
+import { publishPost } from '../../../../../../utils/publish-post';
+describe( 'Off canvas menu item divider settings in the customizer', () => {
+	it( 'item divider size and color for tablet should apply correctly', async () => {
+		const offCanvas = {
+			'header-mobile-menu-submenu-item-border': true,
+			'header-mobile-menu-submenu-item-b-size': '7',
+			'header-mobile-menu-submenu-item-b-color': 'rgb(10, 123, 10)',
+		};
+		await setCustomize( offCanvas );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'page', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu' );
+		await expect( {
+			selector: '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'border-top-width',
+		} ).cssValueToBe( `${ offCanvas[ 'header-mobile-menu-submenu-item-b-size' ] }` + 'px' );
+
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await expect( {
+			selector: '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'border-color',
+		} ).cssValueToBe( `${ offCanvas[ 'header-mobile-menu-submenu-item-b-color' ] }` );
+	} );
+
+	it( 'item divider size and color for mobile should apply correctly', async () => {
+		const offCanvas = {
+			'header-mobile-menu-submenu-item-border': true,
+			'header-mobile-menu-submenu-item-b-size': '6',
+			'header-mobile-menu-submenu-item-b-color': 'rgb(255, 51, 51)',
+		};
+		await setCustomize( offCanvas );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'page', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu' );
+		await expect( {
+			selector: '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'border-top-width',
+		} ).cssValueToBe( `${ offCanvas[ 'header-mobile-menu-submenu-item-b-size' ] }` + 'px' );
+
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+		await expect( {
+			selector: '.ast-hfb-header .ast-builder-menu-mobile .main-navigation .main-header-menu, .ast-hfb-header .ast-mobile-header-content .ast-builder-menu-mobile .main-navigation .main-header-menu',
+			property: 'border-color',
+		} ).cssValueToBe( `${ offCanvas[ 'header-mobile-menu-submenu-item-b-color' ] }` );
+	} );
+} );

--- a/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/flyout-position.test.js
+++ b/tests/e2e/specs/customizer/header-builder/mobile-header/off-canvas-header/flyout-position.test.js
@@ -1,0 +1,58 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../../utils/publish-post';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+describe( 'Off canvas flyout header type settings in the customizer', () => {
+	it( 'flyout position for tablet should apply correctly', async () => {
+		const flyoutPosition = {
+			'mobile-header-type': 'off-canvas',
+			'off-canvas-slide': 'left',
+		};
+		await setCustomize( flyoutPosition );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'sample-page' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'page', title: 'test-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-mobile-popup-drawer.ast-mobile-popup-left .ast-mobile-popup-inner' );
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.ast-mobile-popup-left .ast-mobile-popup-inner',
+			property: 'left',
+		} ).cssValueToBe( '0px' );
+	} );
+
+	it( 'flyout position for mobile should apply correctly', async () => {
+		const flyoutPosition = {
+			'mobile-header-type': 'off-canvas',
+			'off-canvas-slide': 'left',
+		};
+		await setCustomize( flyoutPosition );
+		await createNewPost( {
+			postType: 'page',
+			title: 'sample-page',
+		} );
+		await publishPost();
+		await createNewPost( {
+			postType: 'page',
+			title: 'test-page',
+		} );
+		await publishPost();
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+		await page.waitForSelector( '.ast-mobile-popup-drawer.ast-mobile-popup-left .ast-mobile-popup-inner' );
+		await expect( {
+			selector: '.ast-mobile-popup-drawer.ast-mobile-popup-left .ast-mobile-popup-inner',
+			property: 'left',
+		} ).cssValueToBe( '0px' );
+	} );
+} );

--- a/tests/e2e/specs/customizer/header-builder/transparent-header/enable-on-complete-website.test.js
+++ b/tests/e2e/specs/customizer/header-builder/transparent-header/enable-on-complete-website.test.js
@@ -1,0 +1,151 @@
+import { createURL,	createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../utils/publish-post';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Transparent header in the customizer', () => {
+	it( 'disable on archive page should apply corectly', async () => {
+		const disableOnArchive = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-archive': 0,
+		};
+		await setCustomize( disableOnArchive );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'archive-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/author/admin' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+	it( 'disable on 404 page should apply corectly', async () => {
+		const disableOn404 = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-archive': 0,
+		};
+		await setCustomize( disableOn404 );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: '404-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/12' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+	it( 'disable on search page should apply corectly', async () => {
+		const disableOnSearch = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-archive': 0,
+		};
+		await setCustomize( disableOnSearch );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.click( '#wp-block-search__input-1' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+
+	it( 'enable on blog page should apply correctly', async () => {
+		const disableOnBlogPage = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-index': 0,
+		};
+		await setCustomize( disableOnBlogPage );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'post', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test-1' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+
+	it( 'enable on latest posts page should apply correctly', async () => {
+		const disableOnLatestPostPage = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-latest-posts-index': 0,
+		};
+		await setCustomize( disableOnLatestPostPage );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'post', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+
+	it( 'enable on pages should apply correctly', async () => {
+		const disableOnPages = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-page': 0,
+		};
+		await setCustomize( disableOnPages );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test-page' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test-page' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+
+	it( 'enable on posts should apply correctly', async () => {
+		const disableOnPosts = {
+			'transparent-header-enable': 1,
+			'transparent-header-disable-posts': 0,
+		};
+		await setCustomize( disableOnPosts );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'post', title: 'test-posts' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/test-posts' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-theme-transparent-header #masthead' );
+		await expect( {
+			selector: '.ast-theme-transparent-header #masthead',
+			property: 'position',
+		} ).cssValueToBe( `absolute` );
+	} );
+} );


### PR DESCRIPTION

Description
Adds footer menu widget in the footer builder. Adds margin to the footer menu.

Screenshots
https://share.getcloudapp.com/6quvp1xN

Types of changes
Added test cases to create the footer menu, add footer menu widget in the footer builder from customizer settings and add margin to the footer menu.

How has this been tested?
Create footer menu.
From footer builder in customizer settings, add the footer menu at above left position
Add margin to the footer menu.

Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
