### PR TITLE
QAE-309 - E2E test case for gutenberg list block

### DIFF
--- a/tests/e2e/specs/block-editor/list-block/list-block-width.test.js
+++ b/tests/e2e/specs/block-editor/list-block/list-block-width.test.js
@@ -6,6 +6,9 @@ describe( 'List in gutenberg editor', () => {
 			title: 'test List',
 		} );
 		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
 		await page.waitForSelector( '.editor-styles-wrapper > .block-editor-block-list__layout' );
 		await expect( {
 			selector: '.editor-styles-wrapper > .block-editor-block-list__layout',

--- a/tests/e2e/specs/block-editor/list-block/list-block-width.test.js
+++ b/tests/e2e/specs/block-editor/list-block/list-block-width.test.js
@@ -1,0 +1,15 @@
+import { insertBlock, createNewPost } from '@wordpress/e2e-test-utils';
+describe( 'List in gutenberg editor', () => {
+	it( 'assert wide width of the list in the block editor', async () => {
+		await createNewPost( {
+			postType: 'post',
+			title: 'test List',
+		} );
+		await insertBlock( 'List' );
+		await page.waitForSelector( '.editor-styles-wrapper > .block-editor-block-list__layout' );
+		await expect( {
+			selector: '.editor-styles-wrapper > .block-editor-block-list__layout',
+			property: 'width',
+		} ).cssValueToBe( `1119px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Create a new post
- Insert gutenberg List block and add some content
- Check width

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/Qwu4YNRe

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test: npm run test:e2e:interactive tests/e2e/specs/block-editor/list-block/list-block-width.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
