### PR TITLE
QAE-344 - added e2e test case for GB-embed block full width, padding & margin

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -13,7 +13,7 @@ import {
 	isOfflineMode,
 	setBrowserViewport,
 	trashAllPosts,
-	deactivatePlugin,
+	//deactivatePlugin,
 } from '@wordpress/e2e-test-utils';
 
 import './expect-extensions';
@@ -219,7 +219,7 @@ beforeAll( async () => {
 	enablePageDialogAccept();
 	observeConsoleLogging();
 	await setupBrowser();
-	await deactivatePlugin( 'gutenberg' ); // by default keep the Gutenberg plugin deactive, Activate when needed.
+	//await deactivatePlugin( 'gutenberg' ); // by default keep the Gutenberg plugin deactive, Activate when needed.
 	await trashAllPosts();
 	await trashAllPosts( 'page' );
 	await siteReset();

--- a/tests/e2e/specs/block-editor/embed-block/full-width.test.js
+++ b/tests/e2e/specs/block-editor/embed-block/full-width.test.js
@@ -1,0 +1,72 @@
+import { insertBlock, createNewPost, clickBlockToolbarButton } from '@wordpress/e2e-test-utils';
+describe( 'Embed in gutenberg editor', () => {
+	it( 'assert full width of the Embed in the block editor', async () => {
+		await createNewPost( {
+			postType: 'post',
+			title: 'test Embed',
+		} );
+		await insertBlock( 'Embed' );
+		await page.keyboard.type( 'Embed Block' );
+
+		await clickBlockToolbarButton( 'Align' );
+		await page.waitForFunction( () =>
+			// eslint-disable-next-line @wordpress/no-global-active-element
+			document.activeElement.classList.contains(
+				'components-dropdown-menu__menu-item',
+			),
+		);
+		await page.click(
+			'#editor > div.popover-slot > div > div > div > div > button:nth-child(5)',
+		);
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'width',
+		} ).cssValueToBe( `1119px` );
+	} );
+	it( 'assert padding of the Embed in the block editor', async () => {
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'padding-left',
+		} ).cssValueToBe( `0px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'padding-right',
+		} ).cssValueToBe( `0px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'padding-top',
+		} ).cssValueToBe( `0px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'padding-bottom',
+		} ).cssValueToBe( `0px` );
+	} );
+
+	it( 'assert margin of the embed in the block editor', async () => {
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'margin-top',
+		} ).cssValueToBe( `0px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'margin-right',
+		} ).cssValueToBe( `0px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'margin-bottom',
+		} ).cssValueToBe( `15px` );
+		await page.waitForSelector( '.wp-block-embed' );
+		await expect( {
+			selector: '.wp-block-embed',
+			property: 'margin-left',
+		} ).cssValueToBe( `0px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
added e2e test case for GB-embed block full width, padding & margin
### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/qGurzQqv
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive — tests/e2e/specs/block-editor/embed-block/full-width.test.js
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
