### PR TITLE
QAE-18 - E2E test case for enable breadcrumb on various page for inside header position

### DIFF
--- a/tests/e2e/specs/customizer/breadcrumbs/inside-enable-breadcrumbs-on-various-pages.test.js
+++ b/tests/e2e/specs/customizer/breadcrumbs/inside-enable-breadcrumbs-on-various-pages.test.js
@@ -1,0 +1,115 @@
+import { createURL, createNewPost, publishPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../utils/customize';
+describe( 'breadcrumb settings in the customizer', () => {
+	it( 'enable breadcrumb on home page for inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-home-page': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const enablehomePage = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enablehomePage ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on blog page for inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-blog-posts-page': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await createNewPost( { postType: 'post', title: 'test' } );
+		await publishPost();
+		await page.goto( createURL( '/test' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const disableblog = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disableblog ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on search page inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-archive': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await createNewPost( { postType: 'post', title: 'test' } );
+		await publishPost();
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.click( '.widget_search .search-form' );
+		await page.keyboard.type( 'test' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const enableSearchPage = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enableSearchPage ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on archive page inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-archive': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await page.goto( createURL( '/author/admin' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const enablearchivePage = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( enablearchivePage ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on single page for inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-single-page': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await createNewPost( { postType: 'page', title: 'single-page' } );
+		await publishPost();
+		await page.goto( createURL( '/single-page' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const disablePage = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePage ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on single ppost for inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-single-post': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await createNewPost( { postType: 'page', title: 'single-post' } );
+		await publishPost();
+		await page.goto( createURL( '/single-post' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const disablePost = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disablePost ).toBeNull( );
+	} );
+
+	it( 'enable breadcrumb on 404 page for inside header position should apply corectly for inside position', async () => {
+		const insideBreadcrumb = {
+			'breadcrumb-position': 'astra_header_primary_container_after',
+			'breadcrumb-disable-404-page': 0,
+		};
+		await setCustomize( insideBreadcrumb );
+		await createNewPost( { postType: 'page', title: '404-page' } );
+		await publishPost();
+		await page.goto( createURL( '/12' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-breadcrumbs-wrapper' );
+		const disable404 = await page.$eval( '.ast-breadcrumbs-wrapper', ( element ) => element.getAttribute( '.site-header-focus-item + .ast-breadcrumbs-wrapper' ) );
+		await expect( disable404 ).toBeNull( );
+	} );
+} );
+


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added test case for enable breadcrumb on various page for inside header position

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/d5uNeB8n

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test: npm run test:e2e:interactive tests/e2e/specs/customizer/breadcrumbs/inside-enable-breadcrumbs-on-various-pages.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
