### PR TITLE
AST-1516 - Removing unwanted padding which causes Gutenberg blocks jerks when clicked.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ v3.8.0(Unreleased)
 - Fix: Off-canvas - Dropdown menu displayed when flyout/fullscreen header type is selected in mobile/tablet customizer.
 - Fix: W3 validation - Builder - Account - Duplicate IDs for account icons.
 - Fix: Elementor Pro - WooCommerce Grid layout support in WooCommerce Products Archive widget.
+- Fix: Gutenberg editor - Gutenberg Blocks jerks when users edit any of the blocks.
 
 v3.7.7(Unreleased)
 

--- a/inc/assets/css/block-editor-styles-rtl.css
+++ b/inc/assets/css/block-editor-styles-rtl.css
@@ -761,10 +761,6 @@ h6 {
   margin-bottom: 20px;
 }
 
-.block-editor-rich-text__editable.is-selected {
-  padding: 5px;
-}
-
 .block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle.components-button.has-icon {
   margin: 6px 0 0 -2px;
   border-radius: 0;

--- a/inc/assets/css/block-editor-styles.css
+++ b/inc/assets/css/block-editor-styles.css
@@ -761,10 +761,6 @@ h6 {
   margin-bottom: 20px;
 }
 
-.block-editor-rich-text__editable.is-selected {
-  padding: 5px;
-}
-
 .block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle.components-button.has-icon {
   margin: 6px -2px 0 0;
   border-radius: 0;

--- a/sass/admin/block-editor-styles.scss
+++ b/sass/admin/block-editor-styles.scss
@@ -383,9 +383,6 @@ h6{
 .block-editor-block-list__layout .wp-block-heading {
 	margin-bottom: 20px;
 }
-.block-editor-rich-text__editable.is-selected {
-	padding: 5px;
-}
 .block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle.components-button.has-icon {
 	margin: 6px -2px 0 0;
 	border-radius: 0;


### PR DESCRIPTION
### Description
Removing unwanted Gutenberg block padding which causes Gutenberg blocks to jerk when clicked.

CSS which adds padding to blocks is not needed.
Even in 5.8, this CSS was causing the same issue.
There is no need to handle backward capability.
As padding should not be added to block on select, so we have eliminated it.

### Screenshots
Before Fix - https://share.getcloudapp.com/P8u6YpYD
After Fix - https://share.getcloudapp.com/6quELWPq

### Types of changes
Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
1. Add Some text or any other Gutenberg blocks in the editor.
2. Now Click on any block to edit the content.
3. You will find, when clicked it's jerking. 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
