### PR TITLE
QAE-317 - E2E test case for add another gutenberg block in group block and assert width

### DIFF
--- a/tests/e2e/specs/block-editor/group-block/add-another-block-in-group-block.test.js
+++ b/tests/e2e/specs/block-editor/group-block/add-another-block-in-group-block.test.js
@@ -1,0 +1,16 @@
+import { searchForBlock, createNewPost } from '@wordpress/e2e-test-utils';
+describe( 'group in gutenberg editor', () => {
+	it( 'add other blocks in group block and assert width', async () => {
+		await createNewPost( { postType: 'post', title: 'test group' } );
+		await searchForBlock( 'Group' );
+		await page.click( '.editor-block-list-item-group' );
+		await page.click( '.block-editor-button-block-appender' );
+		await page.click( '.editor-block-list-item-paragraph' );
+		await page.keyboard.type( 'Group Block with a Paragraph' );
+		await page.waitForSelector( '.editor-styles-wrapper > .block-editor-block-list__layout' );
+		await expect( {
+			selector: '.editor-styles-wrapper > .block-editor-block-list__layout',
+			property: 'width',
+		} ).cssValueToBe( `1119px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added test case for add another gutenberg block in group block and assert width

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/p9uX7XXw

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test: npm run test:e2e:interactive tests/e2e/specs/block-editor/group-block/add-another-block-in-group-block.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
