### PR TITLE
QAE-356 - E2E test case for add another block in gutenberg columns block and assert width

### DIFF
--- a/tests/e2e/specs/block-editor/columns-block/add-another-block-in-column-block.test.js
+++ b/tests/e2e/specs/block-editor/columns-block/add-another-block-in-column-block.test.js
@@ -1,0 +1,16 @@
+import { createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
+describe( 'columns in gutenberg editor', () => {
+	it( 'add other blocks in column block and assert width', async () => {
+		await createNewPost( { postType: 'post', title: 'test columns' } );
+		await insertBlock( 'Columns' );
+		await page.click( '[aria-label="One column"]' );
+		await page.click( '.block-editor-button-block-appender' );
+		await page.click( '.editor-block-list-item-paragraph' );
+		await page.keyboard.type( 'Columns Block with a Paragraph' );
+		await page.waitForSelector( '.editor-styles-wrapper > .block-editor-block-list__layout' );
+		await expect( {
+			selector: '.editor-styles-wrapper > .block-editor-block-list__layout',
+			property: 'width',
+		} ).cssValueToBe( `1119px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added test case for add another block in gutenberg columns block and assert width

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/12u0yRpo

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive tests/e2e/specs/block-editor/columns-block/add-another-block-in-column-block.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
