### PR TITLE
QAE-324 - E2E test case for gutenberg audio block width

### DIFF
--- a/tests/e2e/specs/block-editor/audio-block/audio-block-width.test.js
+++ b/tests/e2e/specs/block-editor/audio-block/audio-block-width.test.js
@@ -1,0 +1,12 @@
+import { insertBlock, createNewPost } from '@wordpress/e2e-test-utils';
+describe( 'List in gutenberg editor', () => {
+	it( 'assert wide width of the list in the block editor', async () => {
+		await createNewPost( { postType: 'post', title: 'test audio block' } );
+		await insertBlock( 'Audio' );
+		await page.waitForSelector( '.components-placeholder.components-placeholder' );
+		await expect( {
+			selector: '.components-placeholder.components-placeholder',
+			property: 'width',
+		} ).cssValueToBe( `1119px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added test case for gutenberg audio block width

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/yAuk2AJ4

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
npm run test:e2e:interactive tests/e2e/specs/block-editor/audio-block/audio-block-width.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
