### PR TITLE
AST-1528 - Block Editor Layout Issue with Astra Parent Theme Editor layout issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ v3.8.0(Unreleased)
 - Fix: JS Error - Uncaught ReferenceError: bodyElement is not defined.
 - Fix: WooCommerce - Blank Flyout shopping cart appearing on checkout & cart page for mobile/tablet devices.
 - Fix: Gutenberg editor - Gutenberg Blocks jerks when users edit any of the blocks.
+- Fix: Gutenberg editor - Block Editor layout showing issue with heading block on page or post.
 
 v3.7.7(Unreleased)
 

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -915,9 +915,6 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					'.ast-page-builder-template .block-editor-block-list__layout.is-root-container > .wp-block:not(.wp-block-cover):not(.wp-block-group):not(.wp-block-columns):not(.wp-block-media-text):not([data-align=wide]):not([data-align=full]):not([data-align=left]):not([data-align=right]), .editor-styles-wrapper .wp-block.editor-post-title__block' => array(
 						'max-width' => '100%',
 					),
-					'.block-editor-block-list__layout.is-root-container > .wp-block:not([data-align=full]):not([data-align=wide]):not([data-align=left]):not([data-align=right]):not(p.wp-block-paragraph):not(.wp-block-cover):not(.wp-block-group):not(.wp-block-columns):not(.wp-block-media-text)' => array(
-						'max-width' => astra_get_css_value( $site_content_width, 'px' ),
-					),
 					'.edit-post-visual-editor .editor-post-title__input, p.wp-block-paragraph, .wp-block[data-align="wide"]' => array(
 						'max-width' => astra_get_css_value( $site_content_width - 56, 'px' ),
 					),


### PR DESCRIPTION
### Description
The blocks editor displays the headings and paragraphs differently than the front end when the Astra Parent theme is activated.

Switching to the child theme reduces the padding but there is still some padding left as compared to other themes.

Refer to the screencast for a detailed view:

### Screenshots
Video:- https://d.pr/v/qzjIV6

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Breaking editor layout change 

### How has this been tested?
Added in the card.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
