### PR TITLE
AST-1531 - Some of the Astra Meta Settings does not work with Classic Editor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ v3.7.6
 - Fix: JS console error when Custom Layout is added for header.
 - Fix: Accessibility - Tab navigation does not highlight menu with submenus.
 - Fix: Filter to disable all Meta Settings of Page/Post by default is not working in Gutenberg based metabox. ( https://wpastra.com/docs/disable-all-meta-settings-of-page-post-by-default/ )
+- Fix: Fixed Astra meta settings are not getting saved for the Classic editor.
 
 v3.7.5
 - Improvement: Added compatibility for Elementor Pro v3.5.0 WooCommerce widgets.

--- a/inc/metabox/class-astra-meta-boxes.php
+++ b/inc/metabox/class-astra-meta-boxes.php
@@ -835,8 +835,6 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 	}
 }
 
-
-
 /**
  * Kicking this off by calling 'get_instance()' method
  */

--- a/inc/metabox/class-astra-meta-boxes.php
+++ b/inc/metabox/class-astra-meta-boxes.php
@@ -60,47 +60,8 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 			 *
 			 * @see https://php.net/manual/en/filter.filters.sanitize.php
 			 */
-			self::$meta_option = apply_filters(
-				'astra_meta_box_options',
-				array(
-					'ast-hfb-above-header-display'  => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'ast-main-header-display'       => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'ast-hfb-below-header-display'  => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'ast-hfb-mobile-header-display' => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'footer-sml-layout'             => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'footer-adv-display'            => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'site-post-title'               => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'site-sidebar-layout'           => array(
-						'default'  => 'default',
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'site-content-layout'           => array(
-						'default'  => 'default',
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'ast-featured-img'              => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-					'ast-breadcrumbs-content'       => array(
-						'sanitize' => 'FILTER_DEFAULT',
-					),
-				)
-			);
-
+			
+			self::post_meta_options();
 			add_action( 'load-post.php', array( $this, 'init_metabox' ) );
 			add_action( 'load-post-new.php', array( $this, 'init_metabox' ) );
 			add_action( 'do_meta_boxes', array( $this, 'remove_metabox' ) );
@@ -170,7 +131,8 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 		 *  Init Metabox
 		 */
 		public function init_metabox() {
-
+			
+			self::post_meta_options();
 			add_action( 'add_meta_boxes', array( $this, 'setup_meta_box' ) );
 			add_action( 'save_post', array( $this, 'save_meta_box' ) );
 		}
@@ -822,8 +784,58 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 				)
 			);
 		}
+
+		/**
+		 * Setup meta options for Astra meta settings.
+		 * 
+		 * @since x.x.x
+		 */
+		public static function post_meta_options() {
+			self::$meta_option = apply_filters(
+				'astra_meta_box_options',
+				array(
+					'ast-hfb-above-header-display'  => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'ast-main-header-display'       => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'ast-hfb-below-header-display'  => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'ast-hfb-mobile-header-display' => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'footer-sml-layout'             => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'footer-adv-display'            => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'site-post-title'               => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'site-sidebar-layout'           => array(
+						'default'  => 'default',
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'site-content-layout'           => array(
+						'default'  => 'default',
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'ast-featured-img'              => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+					'ast-breadcrumbs-content'       => array(
+						'sanitize' => 'FILTER_DEFAULT',
+					),
+				)
+			);
+		}
 	}
 }
+
+
 
 /**
  * Kicking this off by calling 'get_instance()' method


### PR DESCRIPTION
### Description
Some of the Astra Meta settings do not work when Classic editor is enabled. 
I have tested this mainly for Sticky Header and Transparent Header. Some settings such as Title, Layout, Sidebar, etc. works fine.

### Screenshots
<!-- if applicable -->
https://d.pr/v/NHy5B0

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
 Install and activate the Classic editor
2. Try changing the Transparent header or sticky header meta settings for any page/post
3. When we click on update, nothing changes.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
