### PR TITLE
AST-1613 - Header and Footer Icon spacing in not working for Social Icons

### DIFF
--- a/inc/builder/type/base/dynamic-css/social/class-astra-social-component-dynamic-css.php
+++ b/inc/builder/type/base/dynamic-css/social/class-astra-social-component-dynamic-css.php
@@ -371,18 +371,7 @@ class Astra_Social_Component_Dynamic_CSS {
 				padding-right: 6px;
 			}';
 		} else {
-			$social_static_css .= '.ast-footer-social-wrap .ast-builder-social-element:first-child {
-				margin-left: 0;
-			}  
-			.ast-footer-social-wrap .ast-builder-social-element:last-child {
-				margin-right: 0;
-			}
-			.ast-header-social-wrap .ast-builder-social-element:first-child {
-				margin-left: 0;
-			}  
-			.ast-header-social-wrap .ast-builder-social-element:last-child {
-				margin-right: 0;
-			}
+			$social_static_css .= '
 			.ast-builder-social-element {
 				line-height: 1;
 				color: #3a3a3a;


### PR DESCRIPTION
### Description
If we have applied Icon spacing form header and footer for Icon element. because default static CSS is loading margin-left:-0  for the first icon and last icon margin-right:0, it will not allow to update this spacing from option.

- Add a social icon component in the header and footer.
- Click on Social element on header and footer, it will set -> Design section → Add Icon spacing.
- It will not add for first social and last social icon properly.

### Screenshots
https://share.bsf.io/NQuNLNpN

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Added in the card.
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
