### PR TITLE
AST-1635 - Not able select the color Round Shape Appear on Color Pallete in the Block Widgets

### DIFF
--- a/inc/customizer/custom-controls/assets/css/unminified/custom-controls.css
+++ b/inc/customizer/custom-controls/assets/css/unminified/custom-controls.css
@@ -1003,7 +1003,7 @@
 .astra-color-picker-wrap .astra-popover-color .components-color-picker,
 .astra-color-picker-wrap .astra-popover-color .react-colorful {
     width: 100%;
-} 
+}
 
 .astra-color-picker-wrap.picker-open{
 	display: block;
@@ -1124,7 +1124,7 @@
 
 .astra-color-picker-wrap .ast-gradient-ui .components-custom-gradient-picker__remove-control-point {
     padding: 0 16px 16px 16px;
-    border: 0; 
+    border: 0;
 }
 
 .astra-color-picker-wrap .ast-gradient-ui .components-custom-gradient-picker__remove-control-point:focus {
@@ -1271,10 +1271,7 @@
 .ast-color-palette.components-circular-option-picker .components-circular-option-picker__swatches{
     width: 100%;
 }
-.components-circular-option-picker__option-wrapper:hover,
-.components-circular-option-picker__option-wrapper{
-    transform: none;
-}
+
 .customize-control-ast-customizer-link .customizer-link {
   font-style: italic;
   text-decoration: none;
@@ -2524,7 +2521,7 @@ input[type="text"].select2-search__field {
     margin-bottom: 0;
     display: none;
 }
-  
+
 .ast-responsive-toggle-btns > li.active {
     display: inline-block;
 }


### PR DESCRIPTION
### Description
A weird round shape appears on top of the Global Color palette. It is happening on the Block Widgets.

### Screenshots
- https://d.pr/v/QVzfmS

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
**How to reproduce: **
1. Add Heading or Paragraph block widget to the Widget area
2. Change the color from the Block 
3. The round shape will appear on the color palette and would not allow changing the color


### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
