### PR TITLE
Verify shop page display option for WooCommerce

### DIFF
--- a/tests/e2e/specs/customizer/woo-commerce/shop-page-display/show-products.test.js
+++ b/tests/e2e/specs/customizer/woo-commerce/shop-page-display/show-products.test.js
@@ -1,0 +1,46 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Shop page display etting under the customizer', () => {
+	it( 'should set the shop pages display', async () => {
+		const shopPageDisplay = {
+			'_customize-input-woocommerce_shop_page_display': 'Show categories',
+		};
+		await setCustomize( shopPageDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.product-category>a' );
+		await expect( {
+			selector: '.product-category>a',
+			property: 'display',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should set the shop pages display as show products', async () => {
+		const shopPageDisplay = {
+			'_customize-input-woocommerce_shop_page_display': 'Show products',
+		};
+		await setCustomize( shopPageDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'display',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should set the shop pages display as show categories & products', async () => {
+		const shopPageDisplay = {
+			'_customize-input-woocommerce_shop_page_display': 'Show categories & products',
+		};
+		await setCustomize( shopPageDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'list-style',
+		} ).cssValueToBe( `inline-block` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Steps-
1. Go to the Customizer
2. Select WC option
3. Go to the product catlog
4. Select shop page category
5. Set the option and validate on front-end 
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
