### PR TITLE
Validate Product sorting

### DIFF
--- a/tests/e2e/specs/customizer/woo-commerce/product-category/sort-product.test.js
+++ b/tests/e2e/specs/customizer/woo-commerce/product-category/sort-product.test.js
@@ -1,11 +1,11 @@
 import { createURL } from '@wordpress/e2e-test-utils';
 import { setCustomize } from '../../../../utils/customize';
 describe( 'Sort the products by multiple options from customizer', () => {
-	it( 'should sort the products', async () => {
-		const categoryDisplay = {
-			'_customize-input-woocommerce_default_catalog_orderby': 'Show products',
+	it( 'should sort the product by default', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Default sorting (custom ordering + name)',
 		};
-		await setCustomize( categoryDisplay );
+		await setCustomize( sortProduct );
 		await page.goto( createURL( 'Shop' ), {
 			waitUntil: 'networkidle0',
 		} );
@@ -15,11 +15,11 @@ describe( 'Sort the products by multiple options from customizer', () => {
 			property: 'display',
 		} ).cssValueToBe( `inline-block` );
 	} );
-	it( 'should set the category display as Show subcategories', async () => {
-		const categoryDisplay = {
-			'_customize-input-woocommerce_default_catalog_orderby': 'Show subcategories',
+	it( 'should sort the product by popularity', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Popularity (sales)',
 		};
-		await setCustomize( categoryDisplay );
+		await setCustomize( sortProduct );
 		await page.goto( createURL( 'Shop' ), {
 			waitUntil: 'networkidle0',
 		} );
@@ -29,11 +29,53 @@ describe( 'Sort the products by multiple options from customizer', () => {
 			property: 'display',
 		} ).cssValueToBe( `inline-block` );
 	} );
-	it( 'should set the category display as Show subcategories & products', async () => {
-		const categoryDisplay = {
-			'_customize-input-woocommerce_default_catalog_orderby': 'Show subcategories & products',
+	it( 'should sort the product by average rating', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Average rating',
 		};
-		await setCustomize( categoryDisplay );
+		await setCustomize( sortProduct );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'list-style',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should sort the product by most recent', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Sort by most recent',
+		};
+		await setCustomize( sortProduct );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'list-style',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should sort the product by ascending order', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Sort by price (asc)',
+		};
+		await setCustomize( sortProduct );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'list-style',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should sort the product by descending order', async () => {
+		const sortProduct = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Sort by price (desc)',
+		};
+		await setCustomize( sortProduct );
 		await page.goto( createURL( 'Shop' ), {
 			waitUntil: 'networkidle0',
 		} );

--- a/tests/e2e/specs/customizer/woo-commerce/product-category/sort-product.test.js
+++ b/tests/e2e/specs/customizer/woo-commerce/product-category/sort-product.test.js
@@ -1,0 +1,46 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Sort the products by multiple options from customizer', () => {
+	it( 'should sort the products', async () => {
+		const categoryDisplay = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Show products',
+		};
+		await setCustomize( categoryDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.product-category>a' );
+		await expect( {
+			selector: '.product-category>a',
+			property: 'display',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should set the category display as Show subcategories', async () => {
+		const categoryDisplay = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Show subcategories',
+		};
+		await setCustomize( categoryDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'display',
+		} ).cssValueToBe( `inline-block` );
+	} );
+	it( 'should set the category display as Show subcategories & products', async () => {
+		const categoryDisplay = {
+			'_customize-input-woocommerce_default_catalog_orderby': 'Show subcategories & products',
+		};
+		await setCustomize( categoryDisplay );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products' );
+		await expect( {
+			selector: '.woocommerce ul.products',
+			property: 'list-style',
+		} ).cssValueToBe( `inline-block` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Steps-
1. Go to the customizer
2. Select WooCommerce
3. Click on pRoduct catlog
4. Click on default product sorting option 
5. Set option and validate on front-end
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
