### PR TITLE
Verify Product per page

### DIFF
--- a/tests/e2e/specs/customizer/woo-commerce/product-catlog/product-per-page.test.js
+++ b/tests/e2e/specs/customizer/woo-commerce/product-catlog/product-per-page.test.js
@@ -1,0 +1,19 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Product per page display setting from customizer', () => {
+	it( 'should set number of product to be displayed on pages', async () => {
+		const productPerPage = {
+			'customize-control-default-input-73': 3,
+		};
+		await setCustomize( productPerPage );
+		await page.goto( createURL( 'Shop' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.woocommerce ul.products:not(.elementor-grid).columns-3' );
+		await expect( {
+			selector: '.woocommerce ul.products:not(.elementor-grid).columns-3',
+			property: 'grid-template-columns',
+		} ).cssValueToBe( `repeat(3,minmax(0,1fr))` );
+	} );
+} );
+//responsive test case


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Steps-
1. Go to the Customizer
2. Select WooCommerce
3. Click on product category
4. Set count to display No. of products on page
5. Validate on front-end
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
