### PR TITLE
QAE-290 - E2E test case for off canvas menu font option

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/font.test.js
+++ b/tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/font.test.js
@@ -1,0 +1,82 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../../utils/set-browser-viewport';
+import { publishPost } from '../../../../../../utils/publish-post';
+import { responsiveFontSize } from '../../../../../../utils/responsive-utils';
+describe( 'Off canvas menu font settings in the customizer', () => {
+	it( 'font should apply corectly for after header', async () => {
+		const offCanvasFont = {
+			'header-mobile-menu-font-family': 'Alice, serif',
+			'header-mobile-menu-text-transform': 'uppercase',
+			'header-mobile-menu-font-weight': '400',
+			'header-mobile-menu-font-size': {
+				tablet: 40,
+				mobile: 20,
+				'tablet-unit': 'px',
+				'mobile-unit': 'px',
+			},
+			'header-mobile-menu-line-height': 0.99,
+		};
+		await setCustomize( offCanvasFont );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'test-1' } );
+			ppStatus = await publishPost();
+			await createNewPost( { postType: 'page', title: 'test-2' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+
+		await page.waitForSelector( '.ast-builder-menu-mobile .main-navigation .menu-item > .menu-link' );
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .menu-item > .menu-link',
+			property: 'font-family',
+		} ).cssValueToBe( `${ offCanvasFont[ 'header-mobile-menu-font-family' ] }` );
+
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .menu-item > .menu-link',
+			property: 'text-transform',
+		} ).cssValueToBe( `${ offCanvasFont[ 'header-mobile-menu-text-transform' ] }` );
+
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .menu-item > .menu-link',
+			property: 'font-weight',
+		} ).cssValueToBe( `${ offCanvasFont[ 'header-mobile-menu-font-weight' ] }` );
+
+		await page.waitForSelector( '.ast-builder-menu-mobile .main-navigation' );
+		await setBrowserViewport( 'medium' );
+		await page.click( '.main-header-menu-toggle' );
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				offCanvasFont[ 'header-mobile-menu-font-size' ].tablet,
+			) }${
+				offCanvasFont[ 'header-mobile-menu-font-size' ][ 'tablet-unit' ]
+			}`,
+		);
+
+		await setBrowserViewport( 'small' );
+		await page.click( '.main-header-menu-toggle' );
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation',
+			property: 'font-size',
+		} ).cssValueToBe(
+			`${ await responsiveFontSize(
+				offCanvasFont[ 'header-mobile-menu-font-size' ].mobile,
+			) }${
+				offCanvasFont[ 'header-mobile-menu-font-size' ][ 'mobile-unit' ]
+			}`,
+		);
+
+		await expect( {
+			selector: '.ast-builder-menu-mobile .main-navigation .menu-item > .menu-link',
+			property: 'line-height',
+		} ).cssValueToBe( `${ offCanvasFont[ 'header-mobile-menu-line-height' ] }` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Header builder → Off canvas → off canvas menu → Design → Font option

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/9Zum0GDx

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run test: npm run test:e2e:interactive -- tests/e2e/specs/customizer/header-builder/header-types/mobile-header/off-canvas-menu/font.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
