### PR TITLE
AST-1030 - Old Header Footer Builder Fatal error

### DIFF
--- a/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
@@ -329,7 +329,9 @@ class Astra_Customizer_Woo_Cart_Configs extends Astra_Customizer_Config_Base {
 		 * Adding the Margin and Padding option.
 		 * $_section: section-header-woo-cart.
 		 */
-		$_configs = array_merge( $_configs, Astra_Builder_Base_Configuration::prepare_advanced_tab( $_section ) );
+        if ( true === Astra_Builder_Helper::$is_header_footer_builder_active ) {
+            $_configs = array_merge( $_configs, Astra_Builder_Base_Configuration::prepare_advanced_tab( $_section ) );
+        }
 
 		$configurations                    = array_merge( $configurations, $_configs );
 		$header_woo_cart_background_colors = 'header-woo-cart-background-colors';


### PR DESCRIPTION
### Description
Fatal error showing when switched to Old HFB
Reference PR: https://github.com/brainstormforce/astra/pull/3496/files

### Screenshots
https://share.bsf.io/Bluodp9A

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
