### PR TITLE
QAE-876 - E2E test case for primary footer width

### DIFF
--- a/tests/e2e/specs/customizer/footer-builder/primary-footer/width.test.js
+++ b/tests/e2e/specs/customizer/footer-builder/primary-footer/width.test.js
@@ -1,0 +1,53 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+import { setBrowserViewport } from '../../../../utils/set-browser-viewport';
+import { scrollToElement } from '../../../../utils/scroll-to-element';
+describe( 'Primary footer width setting in customizer', () => {
+	it( 'full width should apply correctly', async () => {
+		const primaryFooterWidth = {
+			'hb-footer-layout-width': 'full',
+			'footer-desktop-items': {
+				primary: {
+					primary_2: {
+						0: 'social-icons-1',
+					},
+				},
+			},
+		};
+		await setCustomize( primaryFooterWidth );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'large' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '.site-primary-footer-wrap[data-section="section-primary-footer-builder"] .ast-builder-grid-row' );
+		await expect( {
+			selector: '.site-primary-footer-wrap[data-section="section-primary-footer-builder"] .ast-builder-grid-row',
+			property: 'max-width',
+		} ).cssValueToBe( `100%` );
+	} );
+
+	it( 'content width should apply correctly', async () => {
+		const primaryFooterWidth = {
+			'hb-footer-layout-width': 'content',
+			'footer-desktop-items': {
+				primary: {
+					primary_2: {
+						0: 'social-icons-1',
+					},
+				},
+			},
+		};
+		await setCustomize( primaryFooterWidth );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await setBrowserViewport( 'large' );
+		await scrollToElement( '#colophon' );
+		await page.waitForSelector( '.site-primary-footer-wrap[data-section="section-primary-footer-builder"] .ast-builder-grid-row' );
+		await expect( {
+			selector: '.site-primary-footer-wrap[data-section="section-primary-footer-builder"] .ast-builder-grid-row',
+			property: 'max-width',
+		} ).cssValueToBe( `1200px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Footer builder -> primary footer -> width option

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run single test - npm run test:e2e:interactive tests/e2e/specs/customizer/footer-builder/primary-footer/widthtest.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
