### PR TITLE
QAE-220 - E2E test case for header builder width option

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/overall-header-settings/width.test.js
+++ b/tests/e2e/specs/customizer/header-builder/overall-header-settings/width.test.js
@@ -1,0 +1,33 @@
+import { createURL } from '@wordpress/e2e-test-utils';
+import { setCustomize } from '../../../../utils/customize';
+describe( 'Header builder settings in the customizer', () => {
+	it( 'full width settings should be applied correctly', async () => {
+		const headerWidth = {
+			'hb-header-main-layout-width': 'full',
+		};
+		await setCustomize( headerWidth );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '#masthead .ast-container' );
+		await expect( {
+			selector: '#masthead .ast-container',
+			property: 'max-width',
+		} ).cssValueToBe( `100%` );
+	} );
+
+	it( 'content width settings should be applied correctly', async () => {
+		const headerWidth = {
+			'hb-header-main-layout-width': 'content',
+		};
+		await setCustomize( headerWidth );
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-container' );
+		await expect( {
+			selector: '.ast-container',
+			property: 'max-width',
+		} ).cssValueToBe( `1240px` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run test: npm run test:e2e:interactive tests/e2e/specs/customizer/header-builder/overall-header-settings/width.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
