### PR TITLE
QAE-887 - E2E test case for secondary menu background image option

### DIFF
--- a/tests/e2e/specs/customizer/header-builder/elements/secondary-menu/background-image.test.js
+++ b/tests/e2e/specs/customizer/header-builder/elements/secondary-menu/background-image.test.js
@@ -1,0 +1,76 @@
+import { createURL, createNewPost } from '@wordpress/e2e-test-utils';
+import { publishPost } from '../../../../../utils/publish-post';
+import { setCustomize } from '../../../../../utils/customize';
+import { setBrowserViewport } from '../../../../../utils/set-browser-viewport';
+describe( 'Secondary menu settings in the customizer', () => {
+	it( 'background image should apply correctly', async () => {
+		const secondaryMenuBgImage = {
+			'header-menu2-bg-obj-responsive': {
+				desktop: {
+					'background-image': 'https://pd.w.org/2022/04/2626264f36443b827.24646863-220x300.jpg',
+					'background-repeat': 'repeat',
+					'background-position]': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'image',
+				},
+				tablet: {
+					'background-image': 'https://pd.w.org/2022/04/2966264f298b6e007.81903590-300x200.jpg',
+					'background-repeat': 'repeat',
+					'background-position]': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'image',
+				},
+				mobile: {
+					'background-image': 'https://pd.w.org/2022/04/276262a8d1470467.39785232-300x200.jpeg',
+					'background-repeat': 'repeat',
+					'background-position]': 'center center',
+					'background-size': 'auto',
+					'background-attachment': 'scroll',
+					'background-type': 'image',
+				},
+			},
+			'header-desktop-items': {
+				primary: {
+					primary_center: {
+						0: 'menu-2',
+					},
+				},
+			},
+			'header-mobile-items': {
+				primary: {
+					primary_center: {
+						0: 'menu-2',
+					},
+				},
+			},
+		};
+		await setCustomize( secondaryMenuBgImage );
+		let ppStatus = false;
+		while ( false === ppStatus ) {
+			await createNewPost( { postType: 'page', title: 'menu-background-image' } );
+			ppStatus = await publishPost();
+		}
+		await page.goto( createURL( '/' ), {
+			waitUntil: 'networkidle0',
+		} );
+		await page.waitForSelector( '.ast-builder-menu-2 .main-header-menu' );
+		await expect( {
+			selector: '.ast-builder-menu-2 .main-header-menu',
+			property: 'background-image',
+		} ).cssValueToBe( `url("${ secondaryMenuBgImage[ 'header-menu2-bg-obj-responsive' ].desktop[ 'background-image' ] + '")' }` );
+
+		await setBrowserViewport( 'medium' );
+		await expect( {
+			selector: '.ast-builder-menu-2 .main-header-menu',
+			property: 'background-image',
+		} ).cssValueToBe( `url("${ secondaryMenuBgImage[ 'header-menu2-bg-obj-responsive' ].tablet[ 'background-image' ] + '")' }` );
+
+		await setBrowserViewport( 'small' );
+		await expect( {
+			selector: '.ast-builder-menu-2 .main-header-menu',
+			property: 'background-image',
+		} ).cssValueToBe( `url("${ secondaryMenuBgImage[ 'header-menu2-bg-obj-responsive' ].mobile[ 'background-image' ] + '")' }` );
+	} );
+} );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Header builder → Secondary menu → Design → Background image

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Run tests: npm run test:e2e:interactive tests/e2e/specs/customizer/header-builder/elements/secondary-menu/background-image.test.js

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
