### PR TITLE
AST-1898 - fix: Escaped all the add_query_arg & remove_query_arg functions outputs.

### DIFF
--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1159,7 +1159,7 @@ if ( ! function_exists( 'astra_get_pro_url' ) ) :
 		}
 
 		$astra_pro_url = esc_url( apply_filters( 'astra_get_pro_url', $astra_pro_url, $url ) );
-		$astra_pro_url = remove_query_arg( 'bsf', $astra_pro_url );
+		$astra_pro_url = esc_url_raw( remove_query_arg( 'bsf', $astra_pro_url ) );
 
 		$ref = get_option( 'astra_partner_url_param', '' );
 		if ( ! empty( $ref ) ) {


### PR DESCRIPTION
### Description
Escaped all the add_query_arg & remove_query_arg functions outputs.
Reference PR: https://github.com/brainstormforce/gutenberg-templates/pull/47/files

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
