### PR TITLE
AST-1914 - Offcanvas menu content left arrow not aligned

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v3.8.3 (Unreleased)
 - Fix: Primary submenus not expandable on mobile when toggle button element is not added.
 - Fix: PHP Notice - Array to string conversion on widget.php page.
 - Fix: Logo markup loading on the frontend without added logo in Site Identity.
+- Fix: Offcanvas menu content left arrow not aligned.
 
 v3.8.2
 - Fix: Improvements as per WordPress coding standards.

--- a/inc/builder/type/header/off-canvas/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/off-canvas/dynamic-css/dynamic.css.php
@@ -364,7 +364,7 @@ function astra_off_canvas_static_css() {
 		.ast-hfb-header.ast-default-menu-enable.ast-header-break-point .ast-mobile-popup-drawer .main-header-bar-navigation .sub-menu .menu-item .menu-item .menu-link {
 			padding-left: 40px;
 		}
-		.ast-mobile-popup-drawer .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle {
+		.ast-mobile-popup-drawer:not(.content-align-flex-end) .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle {
 			right: calc( 20px - 0.907em);
 		}
 		.ast-mobile-popup-drawer.content-align-flex-end .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle {
@@ -542,6 +542,7 @@ function astra_dropdown_type_static_css() {
 		.ast-mobile-header-content.content-align-flex-end .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle,
 		.ast-desktop-header-content.content-align-flex-end .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle {
 		  	left: calc( 20px - 0.907em);
+			right: unset;
 		}
 		.ast-mobile-header-content .ast-search-menu-icon,
 		.ast-mobile-header-content .ast-search-menu-icon.slide-search,


### PR DESCRIPTION
### Description
The off-canvas dropdown menu arrow is misplaced(in the middle) rather than left and the arrow is taking some weird space.

### Screenshots
https://d.pr/v/rfmnGr

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Go to the Customizer>Switch to mobile view>Off-canvas setting>Content Alignment>Right. After that visit the front-end mobile view.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
