### PR TITLE
AST-1924 - Divider hide on desktop option not working

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ v3.8.3 (Unreleased)
 - Fix: Primary submenus not expandable on mobile when toggle button element is not added.
 - Fix: PHP Notice - Array to string conversion on widget.php page.
 - Fix: Logo markup loading on the frontend without added logo in Site Identity.
+- Fix: Hide on Desktop is not working for desktop in all footer divider element.
 
 v3.8.2
 - Fix: Improvements as per WordPress coding standards.

--- a/inc/builder/type/class-astra-builder-base-dynamic-css.php
+++ b/inc/builder/type/class-astra-builder-base-dynamic-css.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'Astra_Builder_Base_Dynamic_CSS' ) ) {
 			$hide_mobile  = ( ! astra_get_option( $section_id . '-hide-mobile' ) ) ? $mobile_tablet_default : 'none';
 
 			$css_output_desktop = array(
-				$selector => array(
+				'ast-builder-grid-row-container-inner' . $selector => array(
 					'display' => $hide_desktop,
 				),
 			);


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Add divider element and check to hide on desktop option, it will not be hiding divider on the frontend.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
