### PR TITLE
AST-1926 - Reverted default updation for single container as this managed by basic CSS

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -1025,20 +1025,37 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			}
 
 			/**
-			 * Remove margin top when Primary Header is not set and No Sidebar is added in Full-Width / Contained Layout.
+			 * Re-add margin top when FullWidth Contained layout is set.
 			 *
-			 * @since 2.5.0
+			 * @since x.x.x
 			 */
-			if ( self::gtn_group_cover_css_comp() && is_singular() ) {
-				$display_header = get_post_meta( get_the_ID(), 'ast-main-header-display', true );
-				if ( 'disabled' === $display_header && apply_filters( 'astra_content_margin_full_width_contained', true ) || ( Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) || ( self::gutenberg_core_blocks_css_comp() ) ) {
+			if ( true === $update_customizer_strctural_defaults ) {
+				if ( ! Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 					$gtn_margin_top = array(
 						'.ast-plain-container.ast-no-sidebar #primary' => array(
-							'margin-top'    => '0',
-							'margin-bottom' => '0',
+							'margin-top'    => '60px',
+							'margin-bottom' => '60px',
 						),
 					);
 					$parse_css     .= astra_parse_css( $gtn_margin_top );
+				}
+			} else {
+				/**
+				 * Remove margin top when Primary Header is not set and No Sidebar is added in Full-Width / Contained Layout.
+				 *
+				 * @since 2.5.0
+				 */
+				if ( self::gtn_group_cover_css_comp() && is_singular() ) {
+					$display_header = get_post_meta( get_the_ID(), 'ast-main-header-display', true );
+					if ( 'disabled' === $display_header && apply_filters( 'astra_content_margin_full_width_contained', true ) || ( Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) || ( self::gutenberg_core_blocks_css_comp() ) ) {
+						$gtn_margin_top = array(
+							'.ast-plain-container.ast-no-sidebar #primary' => array(
+								'margin-top'    => '0',
+								'margin-bottom' => '0',
+							),
+						);
+						$parse_css     .= astra_parse_css( $gtn_margin_top );
+					}
 				}
 			}
 

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -1073,6 +1073,12 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 				}
 			}
 
+			if ( true === astra_get_option( 'customizer-default-layout-update', true ) ) {
+				$css_output['.ast-separate-container .ast-woocommerce-container'] = array(
+					'padding' => '3em',
+				);
+			}
+
 			/* Parse WooCommerce General CSS from array() */
 			$css_output = astra_parse_css( $css_output );
 

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -463,9 +463,9 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					),
 					'single-post-outside-spacing'          => array(
 						'desktop'      => array(
-							'top'    => $is_new_strctural_defaults ? 60 : '',
+							'top'    => '',
 							'right'  => '',
-							'bottom' => $is_new_strctural_defaults ? 60 : '',
+							'bottom' => '',
 							'left'   => '',
 						),
 						'tablet'       => array(


### PR DESCRIPTION
### Description
- WooCommerce container 3em padding updated as like other in boxed layout
- Reverted 60px from customizer option as managed by static CSS

### Screenshots
<!-- if applicable -->

### Types of changes
- non-breaking change 

### How has this been tested?
- Check with transparent header
- Check full-width contained layout cases as discussed
- Check WooCOmmerce boxed layout

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] I've included any necessary tests 
- [x] I've added proper labels to this pull request 
