### PR TITLE
AST-1897 - fix: Defaults updated directly after the update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.8.4
+- Fix: Page layout & Sidebar option directly updating after the last update.
+
 v3.8.3
 - New: Block editor - Padding presets for container blocks. ( https://wpastra.com/docs/improved-block-editor-experience/ )
 - Improvement: Default sidebar layout is improved.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			$is_widget_title_support_font_weight = self::support_font_css_to_widget_and_in_editor();
 			$font_weight_prop                    = ( $is_widget_title_support_font_weight ) ? 'inherit' : 'normal';
 
-			$update_customizer_strctural_defaults = astra_get_option( 'customizer-default-layout-update', true );
+			$update_customizer_strctural_defaults = astra_check_is_structural_setup();
 
 			// Fallback for H1 - headings typography.
 			if ( 'inherit' == $h1_font_family ) {
@@ -3997,7 +3997,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 		 */
 		public static function load_sidebar_static_css() {
 
-			$update_customizer_strctural_defaults = astra_get_option( 'customizer-default-layout-update', true );
+			$update_customizer_strctural_defaults = astra_check_is_structural_setup();
 			$secondary_li_bottom_spacing          = ( true === $update_customizer_strctural_defaults ) ? '0.75em' : '0.25em';
 			$is_site_rtl                          = is_rtl() ? true : false;
 			$ltr_left                             = $is_site_rtl ? esc_attr( 'right' ) : esc_attr( 'left' );

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -1073,7 +1073,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 				}
 			}
 
-			if ( true === astra_get_option( 'customizer-default-layout-update', true ) ) {
+			if ( true === astra_check_is_structural_setup() ) {
 				$css_output['.ast-separate-container .ast-woocommerce-container'] = array(
 					'padding' => '3em',
 				);

--- a/inc/core/builder/class-astra-builder-options.php
+++ b/inc/core/builder/class-astra-builder-options.php
@@ -83,7 +83,7 @@ function astra_hf_builder_customizer_defaults( $defaults ) {
 	 */
 	$defaults['hb-header-main-layout-width'] = 'content';
 	$defaults['hb-header-height']            = array(
-		'desktop' => ( false === astra_get_option( 'customizer-default-layout-update', true ) ) ? 70 : 80,
+		'desktop' => ( false === astra_check_is_structural_setup() ) ? 70 : 80,
 		'tablet'  => '',
 		'mobile'  => '',
 	);

--- a/inc/core/class-astra-theme-options.php
+++ b/inc/core/class-astra-theme-options.php
@@ -103,7 +103,6 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 			 * @since 3.6.3
 			 */
 			$apply_new_default_values  = astra_button_default_padding_updated();
-			$is_new_strctural_defaults = astra_get_option( 'customizer-default-layout-update', true );
 
 			// Defaults list of options.
 			self::$defaults = apply_filters(
@@ -387,7 +386,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 						),
 					),
 					// Entry Content.
-					'wp-blocks-ui'                         => false === $is_new_strctural_defaults ? 'custom' : 'comfort',
+					'wp-blocks-ui'                         => false === astra_check_is_structural_setup() ? 'custom' : 'comfort',
 					'wp-blocks-global-padding'             => array(
 						'desktop'      => array(
 							'top'    => '',
@@ -413,7 +412,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					),
 					// Container.
 					'site-content-layout'                  => 'content-boxed-container',
-					'single-page-content-layout'           => false === $is_new_strctural_defaults ? 'default' : 'plain-container',
+					'single-page-content-layout'           => false === astra_check_is_structural_setup() ? 'default' : 'plain-container',
 					'single-post-content-layout'           => 'default',
 					'archive-post-content-layout'          => 'default',
 					// Typography.
@@ -552,7 +551,7 @@ if ( ! class_exists( 'Astra_Theme_Options' ) ) {
 					// Sidebar.
 					'site-sidebar-layout'                  => 'right-sidebar',
 					'site-sidebar-width'                   => 30,
-					'single-page-sidebar-layout'           => false === $is_new_strctural_defaults ? 'default' : 'no-sidebar',
+					'single-page-sidebar-layout'           => false === astra_check_is_structural_setup() ? 'default' : 'no-sidebar',
 					'single-post-sidebar-layout'           => 'default',
 					'archive-post-sidebar-layout'          => 'default',
 

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -927,7 +927,7 @@ if ( ! function_exists( 'astra_archive_page_info' ) ) {
 			// Author.
 			if ( is_author() ) {
 				$author_name      = get_the_author() ? get_the_author() : '';
-				$author_name_html = ( true === astra_get_option( 'customizer-default-layout-update', true ) && $author_name ) ? __( 'Author name: ', 'astra' ) . $author_name : $author_name;
+				$author_name_html = ( true === astra_check_is_structural_setup() && $author_name ) ? __( 'Author name: ', 'astra' ) . $author_name : $author_name;
 				?>
 
 				<section class="ast-author-box ast-archive-description">
@@ -1575,4 +1575,14 @@ function astra_block_based_legacy_setup() {
 	$astra_settings = get_option( ASTRA_THEME_SETTINGS );
 	$legacy_setup   = ( isset( $astra_settings['blocks-legacy-setup'] ) && isset( $astra_settings['wp-blocks-ui'] ) && 'legacy' === $astra_settings['wp-blocks-ui'] ) ? true : false;
 	return $legacy_setup;
+}
+
+/**
+ * Check is new strctural things are updated.
+ *
+ * @return bool true|false.
+ */
+function astra_check_is_structural_setup() {
+	$astra_settings = get_option( ASTRA_THEME_SETTINGS );
+	return isset( $astra_settings['customizer-default-layout-update'] ) ? false : true;
 }

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -342,7 +342,7 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	if ( $astra_block_editor_v2_ui ) {
 		$single_post_continer_spacing = astra_get_option( 'single-post-inside-spacing' );
 
-		$container_lg_spacing = ( true === astra_get_option( 'customizer-default-layout-update', true ) ) ? '3' : '6.67';
+		$container_lg_spacing = ( true === astra_check_is_structural_setup() ) ? '3' : '6.67';
 
 		$astra_continer_left_spacing  = defined( 'ASTRA_EXT_VER' ) && astra_responsive_spacing( $single_post_continer_spacing, 'left', 'desktop' ) ? astra_responsive_spacing( $single_post_continer_spacing, 'left', 'desktop', $container_lg_spacing ) : 'var(--ast-container-default-xlg-padding)';
 		$astra_continer_right_spacing = defined( 'ASTRA_EXT_VER' ) && astra_responsive_spacing( $single_post_continer_spacing, 'right', 'desktop' ) ? astra_responsive_spacing( $single_post_continer_spacing, 'right', 'desktop', $container_lg_spacing ) : 'var(--ast-container-default-xlg-padding)';

--- a/inc/dynamic-css/comments-flex.php
+++ b/inc/dynamic-css/comments-flex.php
@@ -51,7 +51,7 @@ function astra_comments_css( $dynamic_css ) {
 		);
 		$dynamic_css .= astra_parse_css( $desktop_comment_global );
 
-		$update_customizer_strctural_defaults = ( true === astra_get_option( 'customizer-default-layout-update', true ) );
+		$update_customizer_strctural_defaults = ( true === astra_check_is_structural_setup() );
 		$padding_comment_title                = $update_customizer_strctural_defaults ? '1em 0 0' : '2em 0';
 		$padding_ast_comment                  = $update_customizer_strctural_defaults ? '0' : '1em 0';
 		$padding_ast_comment_list             = $update_customizer_strctural_defaults ? '0' : '0.5em';

--- a/inc/dynamic-css/comments.php
+++ b/inc/dynamic-css/comments.php
@@ -51,7 +51,7 @@ function astra_comments_css( $dynamic_css ) {
 		);
 		$dynamic_css .= astra_parse_css( $desktop_comment_global );
 
-		$update_customizer_defaults = ( true === astra_get_option( 'customizer-default-layout-update', true ) );
+		$update_customizer_defaults = ( true === astra_check_is_structural_setup() );
 		$padding_comment_title      = $update_customizer_defaults ? '1em 0 0' : '2em 0';
 		$padding_ast_comment        = $update_customizer_defaults ? '2em 0' : '1em 0';
 		$padding_ast_comment_list   = $update_customizer_defaults ? '0' : '0.5em';

--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -59,7 +59,7 @@ function astra_container_layout_css() {
 	$container_layout = astra_get_content_layout();
 
 	$page_container_css        = '';
-	$customizer_default_update = astra_get_option( 'customizer-default-layout-update', true );
+	$customizer_default_update = astra_check_is_structural_setup();
 	$page_title_header_padding = ( true === $customizer_default_update ) ? '2em' : '4em';
 
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort

--- a/inc/dynamic-css/content-background.php
+++ b/inc/dynamic-css/content-background.php
@@ -30,7 +30,7 @@ function astra_content_background_css( $dynamic_css ) {
 	$blog_layout    = astra_get_option( 'blog-layout' );
 	$blog_grid      = astra_get_option( 'blog-grid' );
 
-	$author_box_extra_selector = ( true === astra_get_option( 'customizer-default-layout-update', true ) ) ? '.site-main' : '';
+	$author_box_extra_selector = ( true === astra_check_is_structural_setup() ) ? '.site-main' : '';
 
 	// Container Layout Colors.
 	$separate_container_css = array(

--- a/inc/modules/related-posts/css/static-css.php
+++ b/inc/modules/related-posts/css/static-css.php
@@ -59,7 +59,7 @@ function astra_related_posts_static_css( $dynamic_css ) {
 		}
 		';
 
-		if ( true === astra_get_option( 'customizer-default-layout-update', true ) ) {
+		if ( true === astra_check_is_structural_setup() ) {
 			/** @psalm-suppress InvalidOperand */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$astra_mobile_breakpoint = astra_get_mobile_breakpoint();
 			/** @psalm-suppress InvalidOperand */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort

--- a/template-parts/404/404-layout.php
+++ b/template-parts/404/404-layout.php
@@ -9,7 +9,7 @@
  * @since       Astra 1.0.0
  */
 
-$astra_404_subtitle_tag = ( true === astra_get_option( 'customizer-default-layout-update', true ) ) ? 'h3' : 'div';
+$astra_404_subtitle_tag = ( true === astra_check_is_structural_setup() ) ? 'h3' : 'div';
 
 ?>
 <div <?php echo astra_attr( '404_page', array( 'class' => 'ast-404-layout-1' ) ); ?> >


### PR DESCRIPTION
### Description
- fix: Defaults updated directly after the update
- Directly updating customizer defaults

### Screenshots

### Types of changes
- Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
