### PR TITLE
AST-1934 - RC-1 version improvements for WooCommerce improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ v3.9.0-beta.1 (woocommerce-improvements)
 - New: WooCommerce - Added Product Variation Orientation option in the Single product.
 - New: WooCommerce - Added show/hide cart total badge option.
 - Improvement: WooCommerce - Modify the Cart label section via Shortcodes. (Needs Doc)
+- Improvement: Introduced filter 'astra_stretched_layout_with_spacing' to exclude Stretched layout around spacing CSS. ( https://wpastra.com/docs/improved-block-editor-experience/ )
 - Fix: WooCommerce - Margin issue for single shop page with the Full width & Contained Layout.
 
 v3.8.5 (Unreleased)

--- a/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-single-layout-configs.php
+++ b/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-single-layout-configs.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'Astra_Woo_Shop_Single_Layout_Configs' ) ) {
 					'type'        => 'control',
 					'section'     => 'section-woo-shop-single',
 					'title'       => __( 'Product Variation Layout', 'astra' ),
-					'description' => __( 'Changes single product variation layout to be displayed inline or stacked' ),
+					'description' => __( 'Changes single product variation layout to be displayed inline or stacked.', 'astra' ),
 					'context'     => array(
 						Astra_Builder_Helper::$general_tab_config,
 					),

--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -115,7 +115,7 @@ function astra_container_layout_css() {
 				}
 			';
 			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			if ( false === astra_check_any_page_builder_is_active( astra_get_post_id() ) ) {
+			if ( false === astra_check_any_page_builder_is_active( astra_get_post_id() ) && true === apply_filters( 'astra_stretched_layout_with_spacing', true ) ) {
 				/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$page_container_css .= '
 					.ast-single-post.ast-page-builder-template .site-main > article {


### PR DESCRIPTION
### Description
- 1. Added filter provision to restrict the CSS of full-width stretched 
```
add_filter( 'astra_stretched_layout_with_spacing', '__return_false' );
```
- 2. Missing textdomain added for a case.

### Types of changes
- New feature (non-breaking change )

### How has this been tested?
- Check with filters
- At full-width stretched the previous compatibility CSS needs to load/unload

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
