### PR TITLE
AST-1956 - Added dependency for woocommerce general layouts to its archive and single product

### DIFF
--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -868,22 +868,24 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			if ( is_shop() || is_product_taxonomy() || is_checkout() || is_cart() || is_account_page() || is_product() ) {
 
 				$woo_sidebar = astra_get_option( 'woocommerce-sidebar-layout' );
+				$astra_with_modern_ecommerce = astra_get_option( 'astra-ecommerce-modern-setup', true );
 
 				if ( 'default' !== $woo_sidebar ) {
-
 					$sidebar_layout = $woo_sidebar;
 				}
 
 				$global_page_specific_layout = 'default';
 
 				if ( is_shop() || is_product_taxonomy() ) {
-					$global_page_specific_layout = astra_get_option( 'archive-product-sidebar-layout', 'default' );
+					$archive_product_fallback_sidebar = ( false === $astra_with_modern_ecommerce ) ? astra_get_option( 'site-sidebar-layout' ) : astra_get_option( 'woocommerce-sidebar-layout' );
+					$archive_product_sidebar = astra_get_option( 'archive-product-sidebar-layout', 'default' );
+					$global_page_specific_layout     = 'default' === $archive_product_sidebar ? $archive_product_fallback_sidebar : $archive_product_sidebar;
 				}
 
 				if ( is_product() ) {
-					$single_product_fallback_sidebar_layout = ( true === astra_get_option( 'woocommerce-single-product-fallback-default', false ) ) ? astra_get_option( 'site-sidebar-layout' ) : astra_get_option( 'woocommerce-sidebar-layout' );
-					$single_product_sidebar                 = astra_get_option( 'single-product-sidebar-layout', 'default' );
-					$global_page_specific_layout            = 'default' === $single_product_sidebar ? $single_product_fallback_sidebar_layout : $single_product_sidebar;
+					$single_product_fallback_sidebar = ( false === $astra_with_modern_ecommerce ) ? astra_get_option( 'site-sidebar-layout' ) : astra_get_option( 'woocommerce-sidebar-layout' );
+					$single_product_sidebar          = astra_get_option( 'single-product-sidebar-layout', 'default' );
+					$global_page_specific_layout     = 'default' === $single_product_sidebar ? $single_product_fallback_sidebar : $single_product_sidebar;
 				}
 
 				if ( 'default' !== $global_page_specific_layout ) {

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -983,22 +983,6 @@ function astra_legacy_customizer_maintenance() {
 }
 
 /**
- * Set flag to new customizer UI maintainer flag, to avoid direct reflections on live site & to maintain backward compatibility for existing users.
- *
- * Case: In older versions of Astra WooCommerce > Single Product sidebar layout synced with Default sidebar layout (not with WooCommerce sidebar option).
- *
- * @since x.x.x
- * @return void
- */
-function astra_update_single_product_sidebar_layout() {
-	$theme_options = get_option( 'astra-settings', array() );
-	if ( ! isset( $theme_options['woocommerce-single-product-fallback-default'] ) ) {
-		$theme_options['woocommerce-single-product-fallback-default'] = true;
-		update_option( 'astra-settings', $theme_options );
-	}
-}
-
-/**
  * Enable single product breadcrumb to maintain backward compatibility for existing users.
  *
  * @since x.x.x
@@ -1012,4 +996,18 @@ function astra_update_single_product_breadcrumb() {
 		$theme_options['single-product-breadcrumb-disable'] = true;
 	}
 	update_option( 'astra-settings', $theme_options );
+}
+
+/**
+ * Restrict direct changes on users end so make it filterable.
+ *
+ * @since x.x.x
+ * @return void
+ */
+function astra_apply_modern_ecommerce_setup() {
+	$theme_options = get_option( 'astra-settings', array() );
+	if ( ! isset( $theme_options['astra-ecommerce-modern-setup'] ) ) {
+		$theme_options['astra-ecommerce-modern-setup'] = false;
+		update_option( 'astra-settings', $theme_options );
+	}
 }

--- a/inc/theme-update/class-astra-theme-background-updater.php
+++ b/inc/theme-update/class-astra-theme-background-updater.php
@@ -133,7 +133,7 @@ if ( ! class_exists( 'Astra_Theme_Background_Updater' ) ) {
 				'astra_display_cart_total_title_compatibility',
 				'astra_update_woocommerce_cart_icons',
 				'astra_legacy_customizer_maintenance',
-				'astra_update_single_product_sidebar_layout',
+				'astra_apply_modern_ecommerce_setup',
 			),
 		);
 


### PR DESCRIPTION
### Description
- Content Layout & Sidebar Layout priorities will be -
- 1. Individual setting
- 2. WooCommerce General settings
- 3. Global default

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- 1. Check backward for old users - filter dependent
```
add_filter( 'astra_get_option_astra-ecommerce-modern-setup', '__return_true' );
```
- 2. Check as fresh user
- 3. Check dependencies

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
