### PR TITLE
AST-1958 - Fixed WooCommerce Full Width stretched layout with around spacing & filter position updated in condition

### DIFF
--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -115,10 +115,10 @@ function astra_container_layout_css() {
 				}
 			';
 			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			if ( false === astra_check_any_page_builder_is_active( astra_get_post_id() ) && true === apply_filters( 'astra_stretched_layout_with_spacing', true ) ) {
+			if ( true === apply_filters( 'astra_stretched_layout_with_spacing', true ) && false === astra_check_any_page_builder_is_active( astra_get_post_id() ) ) {
 				/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$page_container_css .= '
-					.ast-single-post.ast-page-builder-template .site-main > article {
+					.ast-single-post.ast-page-builder-template .site-main > article, .woocommerce.ast-page-builder-template .site-main {
 						padding-top: 2em;
 						padding-left: 20px;
 						padding-right: 20px;


### PR DESCRIPTION
### Description
- Full Width / Stretched Layout || No Sidebar => If we are not using page builder then there should be 20px spacing 
- Full Width / Stretched Layout || Left Sidebar => We should consider the spacing around sidebar separator line 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Check archive-single product page with Full Width stretched layout. 
- There should be padding as per the block editor we done. Changes will start reflecting directly but if in case user don’t want this we have added following filter. 
- __return_true = Load spacing CSS
- __return_false = Won’t load spacing CSS
```
add_filter( 'astra_stretched_layout_with_spacing', '__return_true' );
```
- Before - [Image 2022-07-08 at 3.45.15 PM](https://share.bsf.io/bLuB5GZm)  
- After - [Image 2022-07-08 at 3.44.38 PM](https://share.bsf.io/eDuX79rd)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
