### PR TITLE
AST-1973 - Fix Cart icon color when transparent header is enabled

### DIFF
--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -31,7 +31,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	}
 
 	$selector              = '.ast-site-header-cart';
-	$trans_header_selector = '.ast-theme-transparent-header .ast-site-header-cart';
+	$trans_header_selector = 'body.ast-theme-transparent-header .ast-site-header-cart';
 	$theme_color           = astra_get_option( 'theme-color' );
 	$icon_color            = esc_attr( astra_get_option( 'header-woo-cart-icon-color', $theme_color ) );
 	$icon_hover_color      = esc_attr( astra_get_option( 'header-woo-cart-icon-hover-color' ) ); // icon cart hover color.
@@ -152,6 +152,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 			'color'        => $icon_color,
 			'border-color' => $icon_color,
 		),
+		
 		$selector . ' .ast-addon-cart-wrap .ast-icon-shopping-cart:after' => array(
 			'color'            => esc_attr( $theme_h_color ),
 			'background-color' => esc_attr( $icon_color ),
@@ -173,32 +174,8 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 		$selector . ' a.cart-container *'             => array(
 			'transition' => 'none',
 		),
-		$selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap i.astra-icon:after' => array(
-			'color'            => esc_attr( $theme_h_color ),
-			'background-color' => $icon_hover_color,
-		),
 
-		/**
-		* Transparent Header - Woo Cart icon color.
-		*/
-		$trans_header_selector . ' .ast-cart-menu-wrap, ' . $trans_header_selector . ' .ast-addon-cart-wrap' => array(
-			'color' => $transparent_header_icon_color,
-		),
-		$trans_header_selector . ' .ast-cart-menu-wrap .count, ' . $trans_header_selector . ' .ast-cart-menu-wrap .count:after, ' . $trans_header_selector . ' .ast-addon-cart-wrap .count, ' . $trans_header_selector . ' .ast-addon-cart-wrap .ast-icon-shopping-cart:after' => array(
-			'color'        => $transparent_header_icon_color,
-			'border-color' => $transparent_header_icon_color,
-		),
-		$trans_header_selector . ' .ast-addon-cart-wrap .ast-icon-shopping-cart:after' => array(
-			'color'            => esc_attr( $theme_h_color ),
-			'background-color' => esc_attr( $transparent_header_icon_color ),
-		),
-		$trans_header_selector . ' .ast-woo-header-cart-info-wrap' => array(
-			'color' => esc_attr( $transparent_header_icon_color ),
-		),
-		$trans_header_selector . ' .ast-addon-cart-wrap i.astra-icon:after' => array(
-			'color'            => esc_attr( $theme_h_color ),
-			'background-color' => esc_attr( $transparent_header_icon_color ),
-		),
+	
 		/**
 		 * General Woo Cart tray color for widget
 		 */
@@ -440,31 +417,14 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 
 	if ( 'none' !== $header_cart_icon_style ) {
 
+		$cart_icon_list = astra_get_option( 'woo-header-cart-icon' );
+
+		$current_selected_color = 'default' === $cart_icon_list ? $icon_hover_color : 'transparent';
+
 		$header_cart_icon = array(
 
 			$selector . ' .ast-cart-menu-wrap, ' . $selector . ' .ast-addon-cart-wrap'       => array(
 				'color' => $icon_color,
-			),
-			// Outline icon hover colors.
-			'.ast-site-header-cart .ast-cart-menu-wrap:hover .count, .ast-site-header-cart .ast-addon-cart-wrap:hover .count' => array(
-				'color'            => esc_attr( $cart_h_color ),
-				'background-color' => esc_attr( $icon_color ),
-			),
-
-			// Label/Fill icon hover Color.
-			'.ast-site-header-cart-li:hover .ast-woo-header-cart-info-wrap,' . $selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap, .ast-menu-cart-outline .ast-site-header-cart-li:hover .ast-addon-cart-wrap .astra-icon' => array(
-				'color' => $icon_hover_color,
-			),
-
-			// Outline icon hover Color.
-			$selector . ' .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count, .ast-menu-cart-outline .ast-site-header-cart-li:hover .ast-addon-cart-wrap' => array(
-				'border-color' => $icon_hover_color,
-			),
-
-
-			$selector . ' .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count:after, ' . $selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap .count' => array(
-				'color'        => $icon_hover_color,
-				'border-color' => $icon_hover_color,
 			),
 
 			// Outline icon colors.
@@ -477,46 +437,22 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 				'color' => esc_attr( $icon_color ),
 			),
 
-			// Fill icon Color.
-			'.ast-menu-cart-fill .ast-cart-menu-wrap .count, .ast-menu-cart-fill .ast-cart-menu-wrap, .ast-menu-cart-fill .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-menu-cart-fill .ast-addon-cart-wrap' => array(
-				'background-color' => esc_attr( $icon_color ),
-				'color'            => esc_attr( $cart_h_color ),
-			),
-
-			// Fill icon hover Color.
-			'.ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-cart-menu-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap i.astra-icon:after' => array(
-				'background-color' => $icon_hover_color,
-				'color'            => esc_attr( $cart_h_color ),
-			),
-
-			// Transparent Header - Cart Icon color.
-			$trans_header_selector . ' .ast-cart-menu-wrap, ' . $trans_header_selector . ' .ast-addon-cart-wrap'       => array(
-				'color' => $transparent_header_icon_color,
-			),
 			// Outline icon hover colors.
 			'.ast-theme-transparent-header .ast-site-header-cart .ast-cart-menu-wrap:hover .count, .ast-theme-transparent-header .ast-site-header-cart .ast-addon-cart-wrap:hover .count' => array(
 				'color'            => esc_attr( $transparent_header_cart_h_color ),
 				'background-color' => esc_attr( $transparent_header_icon_color ),
 			),
-			// Outline icon colors.
-			'.ast-theme-transparent-header .ast-menu-cart-outline .ast-cart-menu-wrap .count, .ast-theme-transparent-header .ast-menu-cart-outline .ast-addon-cart-wrap' => array(
-				'color' => esc_attr( $transparent_header_icon_color ),
-			),
+			
 			// Outline Info colors.
 			$trans_header_selector . ' .ast-menu-cart-outline .ast-woo-header-cart-info-wrap' => array(
 				'color' => esc_attr( $transparent_header_icon_color ),
-			),
-
-			// Fill icon Color.
-			'.ast-theme-transparent-header .ast-menu-cart-fill .ast-cart-menu-wrap .count, .ast-theme-transparent-header .ast-menu-cart-fill .ast-cart-menu-wrap, .ast-theme-transparent-header .ast-menu-cart-fill .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-theme-transparent-header .ast-menu-cart-fill .ast-addon-cart-wrap' => array(
-				'background-color' => esc_attr( $transparent_header_icon_color ),
-				'color'            => esc_attr( $transparent_header_cart_h_color ),
 			),
 
 			// Border radius.
 			'.ast-site-header-cart.ast-menu-cart-outline .ast-cart-menu-wrap, .ast-site-header-cart.ast-menu-cart-fill .ast-cart-menu-wrap, .ast-site-header-cart.ast-menu-cart-outline .ast-cart-menu-wrap .count, .ast-site-header-cart.ast-menu-cart-fill .ast-cart-menu-wrap .count, .ast-site-header-cart.ast-menu-cart-outline .ast-addon-cart-wrap, .ast-site-header-cart.ast-menu-cart-fill .ast-addon-cart-wrap, .ast-site-header-cart.ast-menu-cart-outline .ast-woo-header-cart-info-wrap, .ast-site-header-cart.ast-menu-cart-fill .ast-woo-header-cart-info-wrap' => array(
 				'border-radius' => astra_get_css_value( $header_cart_icon_radius, 'px' ),
 			),
+
 		);
 
 		// We adding this conditional CSS only to maintain backwards. Remove this condition after 2-3 updates of add-on.
@@ -534,6 +470,107 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 		}
 
 		$css_output .= astra_parse_css( $header_cart_icon );
+	}
+
+	$remove_when_transparent_header = array(
+
+		// Fill icon Color.
+		'.ast-menu-cart-fill .ast-cart-menu-wrap .count, .ast-menu-cart-fill .ast-cart-menu-wrap, .ast-menu-cart-fill .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-menu-cart-fill .ast-addon-cart-wrap' => array(
+			'background-color' => esc_attr( $icon_color ),
+			'color'            => esc_attr( $cart_h_color ),
+		),
+
+		// Fill icon hover Color.
+		'.ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-cart-menu-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-menu-cart-fill .ast-site-header-cart-li:hover .ast-addon-cart-wrap i.astra-icon:after' => array(
+			'background-color' => $icon_hover_color,
+			'color'            => esc_attr( $cart_h_color ),
+		),
+
+		// Outline icon hover Color.
+		$selector . ' .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count, .ast-menu-cart-outline .ast-site-header-cart-li:hover .ast-addon-cart-wrap' => array(
+			'border-color' => $icon_hover_color,
+		),
+
+		$selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap i.astra-icon:after' => array(
+			'color'            => esc_attr( $theme_h_color ),
+			'background-color' => $icon_hover_color,
+		),
+
+		// Label/Fill icon hover Color.
+		'.ast-site-header-cart-li:hover .ast-woo-header-cart-info-wrap,' . $selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap, .ast-menu-cart-outline .ast-site-header-cart-li:hover .ast-addon-cart-wrap .astra-icon' => array(
+			'color' => $icon_hover_color,
+		),
+
+		// Outline icon hover colors.
+		'.ast-site-header-cart .cart-container:hover .count, .ast-site-header-cart .cart-container:hover .count' => array(
+			'color' => esc_attr( $cart_h_color ),
+		),
+
+		$selector . ' .ast-site-header-cart-li:hover .ast-cart-menu-wrap .count:after, ' . $selector . ' .ast-site-header-cart-li:hover .ast-addon-cart-wrap .count' => array(
+			'color'        => $icon_hover_color,
+			'border-color' => $icon_hover_color,
+		),
+
+		'.ast-site-header-cart.ast-menu-cart-fill .ast-site-header-cart-li:hover .astra-icon' => array(
+			'color' => $cart_h_color,
+		),
+
+	);
+
+	$add_when_transparent_header = array(
+
+		$trans_header_selector . ' .ast-cart-menu-wrap .count, ' . $trans_header_selector . ' .ast-cart-menu-wrap .count:after, ' . $trans_header_selector . ' .ast-addon-cart-wrap .count, ' . $trans_header_selector . ' .ast-addon-cart-wrap .ast-icon-shopping-cart:after' => array(
+			'border-color' => $transparent_header_icon_color,
+		),
+		$trans_header_selector . ' .ast-addon-cart-wrap .ast-icon-shopping-cart:after' => array(
+			'color'            => esc_attr( $theme_h_color ),
+			'background-color' => esc_attr( $transparent_header_icon_color ),
+		),
+		$trans_header_selector . ' .ast-woo-header-cart-info-wrap' => array(
+			'color' => esc_attr( $transparent_header_icon_color ),
+		),
+		$trans_header_selector . ' .ast-addon-cart-wrap i.astra-icon:after' => array(
+			'color'            => esc_attr( $theme_h_color ),
+			'background-color' => esc_attr( $transparent_header_icon_color ),
+		),
+
+		// Outline icon colors.
+		'.ast-theme-transparent-header .ast-menu-cart-outline .ast-cart-menu-wrap .count, .ast-theme-transparent-header .ast-menu-cart-outline .ast-addon-cart-wrap' => array(
+			'color'        => esc_attr( $transparent_header_icon_color ),
+			'border-color' => esc_attr( $transparent_header_icon_color ),
+		),
+
+		// Fill icon Color.
+		'.ast-theme-transparent-header .ast-menu-cart-fill .ast-cart-menu-wrap .count, .ast-theme-transparent-header .ast-menu-cart-fill .ast-cart-menu-wrap, .ast-theme-transparent-header .ast-menu-cart-fill .ast-addon-cart-wrap .ast-woo-header-cart-info-wrap, .ast-theme-transparent-header .ast-menu-cart-fill .ast-addon-cart-wrap' => array(
+			'background-color' => esc_attr( $transparent_header_icon_color ),
+			'color'            => esc_attr( $transparent_header_cart_h_color ),
+		),
+	);
+	
+
+	$check_sticky_is_enabled_on = astra_get_option( 'transparent-header-on-devices' );
+
+	if ( false === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
+		$css_output .= astra_parse_css( $remove_when_transparent_header );
+	}
+	
+	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
+
+		if ( $check_sticky_is_enabled_on && 'desktop' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
+			$css_output .= astra_parse_css( $remove_when_transparent_header, 922, '' );
+		}
+
+		if ( $check_sticky_is_enabled_on && 'mobile' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
+			$css_output .= astra_parse_css( $remove_when_transparent_header, '', astra_get_tablet_breakpoint() );
+		}
+
+		if ( $check_sticky_is_enabled_on && 'desktop' === $check_sticky_is_enabled_on ) {
+			$css_output .= astra_parse_css( $add_when_transparent_header, 922, '' );
+		} elseif ( $check_sticky_is_enabled_on && 'mobile' === $check_sticky_is_enabled_on ) {
+			$css_output .= astra_parse_css( $add_when_transparent_header, '', astra_get_tablet_breakpoint() );
+		} else {
+			$css_output .= astra_parse_css( $add_when_transparent_header );
+		}
 	}
 
 	/**

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -419,8 +419,6 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 
 		$cart_icon_list = astra_get_option( 'woo-header-cart-icon' );
 
-		$current_selected_color = 'default' === $cart_icon_list ? $icon_hover_color : 'transparent';
-
 		$header_cart_icon = array(
 
 			$selector . ' .ast-cart-menu-wrap, ' . $selector . ' .ast-addon-cart-wrap'       => array(
@@ -435,17 +433,6 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 			// Outline Info colors.
 			$selector . ' .ast-menu-cart-outline .ast-woo-header-cart-info-wrap' => array(
 				'color' => esc_attr( $icon_color ),
-			),
-
-			// Outline icon hover colors.
-			'.ast-theme-transparent-header .ast-site-header-cart .ast-cart-menu-wrap:hover .count, .ast-theme-transparent-header .ast-site-header-cart .ast-addon-cart-wrap:hover .count' => array(
-				'color'            => esc_attr( $transparent_header_cart_h_color ),
-				'background-color' => esc_attr( $transparent_header_icon_color ),
-			),
-			
-			// Outline Info colors.
-			$trans_header_selector . ' .ast-menu-cart-outline .ast-woo-header-cart-info-wrap' => array(
-				'color' => esc_attr( $transparent_header_icon_color ),
 			),
 
 			// Border radius.
@@ -545,16 +532,28 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 			'background-color' => esc_attr( $transparent_header_icon_color ),
 			'color'            => esc_attr( $transparent_header_cart_h_color ),
 		),
+
+		// Outline icon hover colors.
+		'.ast-theme-transparent-header .ast-site-header-cart .ast-cart-menu-wrap:hover .count, .ast-theme-transparent-header .ast-site-header-cart .ast-addon-cart-wrap:hover .count' => array(
+			'color'            => esc_attr( $transparent_header_cart_h_color ),
+			'background-color' => esc_attr( $transparent_header_icon_color ),
+		),
+		
+		// Outline Info colors.
+		$trans_header_selector . ' .ast-menu-cart-outline .ast-woo-header-cart-info-wrap' => array(
+			'color' => esc_attr( $transparent_header_icon_color ),
+		),
 	);
 	
 
 	$check_sticky_is_enabled_on = astra_get_option( 'transparent-header-on-devices' );
 
-	if ( false === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
+
+	if ( ! Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 		$css_output .= astra_parse_css( $remove_when_transparent_header );
 	}
 	
-	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
+	if ( Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 
 		/** @psalm-suppress InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		$tablet_breakpoint = astra_get_tablet_breakpoint( '', 1 );

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -557,7 +557,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 
 		if ( $check_sticky_is_enabled_on && 'desktop' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
-			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			/** @psalm-suppress InvalidArgument InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $remove_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		}
 
@@ -567,7 +567,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 		}
 
 		if ( $check_sticky_is_enabled_on && 'desktop' === $check_sticky_is_enabled_on ) {
-			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			/** @psalm-suppress InvalidArgument InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $add_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		} elseif ( $check_sticky_is_enabled_on && 'mobile' === $check_sticky_is_enabled_on ) {
 			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -557,16 +557,20 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 
 		if ( $check_sticky_is_enabled_on && 'desktop' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $remove_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		}
 
 		if ( $check_sticky_is_enabled_on && 'mobile' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $remove_when_transparent_header, '', astra_get_tablet_breakpoint() );
 		}
 
 		if ( $check_sticky_is_enabled_on && 'desktop' === $check_sticky_is_enabled_on ) {
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $add_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		} elseif ( $check_sticky_is_enabled_on && 'mobile' === $check_sticky_is_enabled_on ) {
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $add_when_transparent_header, '', astra_get_tablet_breakpoint() );
 		} else {
 			$css_output .= astra_parse_css( $add_when_transparent_header );

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -556,9 +556,12 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	
 	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 
+		/** @psalm-suppress InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		$tablet_breakpoint = astra_get_tablet_breakpoint( '', 1 );
+
 		if ( $check_sticky_is_enabled_on && 'desktop' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
-			/** @psalm-suppress InvalidArgument InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$css_output .= astra_parse_css( $remove_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			$css_output .= astra_parse_css( $remove_when_transparent_header, $tablet_breakpoint, '' );
 		}
 
 		if ( $check_sticky_is_enabled_on && 'mobile' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
@@ -567,8 +570,8 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 		}
 
 		if ( $check_sticky_is_enabled_on && 'desktop' === $check_sticky_is_enabled_on ) {
-			/** @psalm-suppress InvalidArgument InvalidScalarArgument  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$css_output .= astra_parse_css( $add_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
+			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+			$css_output .= astra_parse_css( $add_when_transparent_header, $tablet_breakpoint, '' );
 		} elseif ( $check_sticky_is_enabled_on && 'mobile' === $check_sticky_is_enabled_on ) {
 			/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$css_output .= astra_parse_css( $add_when_transparent_header, '', astra_get_tablet_breakpoint() );

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -557,7 +557,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 	if ( true === Astra_Ext_Transparent_Header_Markup::is_transparent_header() ) {
 
 		if ( $check_sticky_is_enabled_on && 'desktop' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
-			$css_output .= astra_parse_css( $remove_when_transparent_header, 922, '' );
+			$css_output .= astra_parse_css( $remove_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		}
 
 		if ( $check_sticky_is_enabled_on && 'mobile' !== $check_sticky_is_enabled_on && 'both' !== $check_sticky_is_enabled_on ) {
@@ -565,7 +565,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 		}
 
 		if ( $check_sticky_is_enabled_on && 'desktop' === $check_sticky_is_enabled_on ) {
-			$css_output .= astra_parse_css( $add_when_transparent_header, 922, '' );
+			$css_output .= astra_parse_css( $add_when_transparent_header, astra_get_tablet_breakpoint( '', 1 ), '' );
 		} elseif ( $check_sticky_is_enabled_on && 'mobile' === $check_sticky_is_enabled_on ) {
 			$css_output .= astra_parse_css( $add_when_transparent_header, '', astra_get_tablet_breakpoint() );
 		} else {

--- a/inc/class-astra-global-palette.php
+++ b/inc/class-astra-global-palette.php
@@ -252,7 +252,6 @@ class Astra_Global_Palette {
 		return $color;
 	}
 
-
 	/**
 	 * Add dynamic CSS for the global border color.
 	 *
@@ -263,11 +262,7 @@ class Astra_Global_Palette {
 	 * @return String Generated dynamic CSS for global border.
 	 */
 	public function global_border_compatibility( $dynamic_css ) {
-		$global_border_color = astra_get_option( 'border-color' );
-		
-		if ( ! $global_border_color ) {
-			$global_border_color = '#ddd';
-		}
+		$global_border_color = astra_get_option( 'border-color', '#dddddd' );
 
 		$global_border = '
 			:root {

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -977,7 +977,7 @@ function astra_update_woocommerce_cart_icons() {
 function astra_legacy_customizer_maintenance() {
 	$theme_options = get_option( 'astra-settings', array() );
 	if ( ! isset( $theme_options['border-color'] ) ) {
-		$theme_options['border-color'] = '';
+		$theme_options['border-color'] = '#dddddd';
 		update_option( 'astra-settings', $theme_options );
 	}
 }


### PR DESCRIPTION
### Description
Cart icon color fix when transparent header is enabled 


### Screenshots


### Types of changes
Bug fix (non-breaking change which fixes an issue) 


### How has this been tested?
Checked when transparent header is enabled 
Checked when transparent header is disabled 
Checked when transparent color is not set
Checked icon with outline and fill properties 
Checked custom with color and hover


### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
