### PR TITLE
AST-2021 - Fix row changing automatically to block issue

### DIFF
--- a/inc/assets/js/column-block-compatibility.js
+++ b/inc/assets/js/column-block-compatibility.js
@@ -31,6 +31,7 @@ wp.hooks.addFilter(
 	20
 );
 
+/*
 wp.hooks.addFilter(
 	'blocks.getBlockAttributes',
 	'astra/groupBlockSetting/checkInheritOption',

--- a/inc/assets/js/column-block-compatibility.js
+++ b/inc/assets/js/column-block-compatibility.js
@@ -40,7 +40,7 @@ wp.hooks.addFilter(
 			return attributes;
 		}
 
-		if (blockType.name == 'core/group' && undefined != attributes.layout && false == attributes.layout.inherit ) {
+		if (blockType.name == 'core/group' && undefined != attributes.layout && 'flex' === attributes.layout.type) {
 			return attributes;
 		}
 

--- a/inc/assets/js/column-block-compatibility.js
+++ b/inc/assets/js/column-block-compatibility.js
@@ -31,7 +31,6 @@ wp.hooks.addFilter(
 	20
 );
 
-/*
 wp.hooks.addFilter(
 	'blocks.getBlockAttributes',
 	'astra/groupBlockSetting/checkInheritOption',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
The row block in the block editor keeps changing to the group block and causing the layout issue in the editor itself.

This issue does not occur on the frontend but editor only.

### Video
<!-- if applicable -->
https://d.pr/v/iwZBOT

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

- Create a page and add the row block

- Add some images to the row block and publish the page

- Check the front; it looks good.

- Now come back to the editor and refresh the page, previously the row block is changed to the group block, and the layout is different. You will notice horizontal images as vertical.

- Now it's working fine.

Try changing to the default theme, and the issue is gone.
### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
