### PR TITLE
AST-2042 -  Fix step count for range slider when em is selected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.9.2
+- Fix: Customizer - Customizer range slider module not accepting decimal values then em unit is selected.
+
 v3.9.1
 - Fix: WooCommerce - Child theme's WooCommerce custom templates gets overridden by parent theme.
 - Fix: Block editor - Row block's layout stack in editor.

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-typo-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-typo-configs.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Typo_Configs' ) ) {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),

--- a/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
+++ b/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
@@ -367,7 +367,7 @@ class Astra_Button_Component_Configs {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),

--- a/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
+++ b/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
@@ -169,7 +169,7 @@ final class Astra_Builder_Base_Configuration {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),
@@ -204,7 +204,7 @@ final class Astra_Builder_Base_Configuration {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-menu-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-menu-configs.php
@@ -346,7 +346,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -378,7 +378,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),

--- a/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
@@ -607,7 +607,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),

--- a/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
@@ -397,7 +397,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),

--- a/inc/customizer/configurations/typography/class-astra-archive-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-archive-typo-configs.php
@@ -113,7 +113,7 @@ if ( ! class_exists( 'Astra_Archive_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Astra_Archive_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -190,7 +190,7 @@ if ( ! class_exists( 'Astra_Archive_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -222,7 +222,7 @@ if ( ! class_exists( 'Astra_Archive_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),

--- a/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -88,7 +88,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -196,7 +196,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),

--- a/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
@@ -78,7 +78,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -188,7 +188,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -300,7 +300,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -411,7 +411,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -521,7 +521,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -631,7 +631,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),

--- a/inc/customizer/configurations/typography/class-astra-single-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-single-typo-configs.php
@@ -111,7 +111,7 @@ if ( ! class_exists( 'Astra_Single_Typo_Configs' ) ) {
 							),
 							'em' => array(
 								'min'  => 0,
-								'step' => 1,
+								'step' => 0.01,
 								'max'  => 20,
 							),
 						),
@@ -144,7 +144,7 @@ if ( ! class_exists( 'Astra_Single_Typo_Configs' ) ) {
 						),
 						'em' => array(
 							'min'  => 0,
-							'step' => 1,
+							'step' => 0.01,
 							'max'  => 20,
 						),
 					),

--- a/inc/modules/related-posts/customizer/class-astra-related-posts-configs.php
+++ b/inc/modules/related-posts/customizer/class-astra-related-posts-configs.php
@@ -712,7 +712,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -814,7 +814,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -916,7 +916,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),
@@ -1018,7 +1018,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					),
 					'em' => array(
 						'min'  => 0,
-						'step' => 1,
+						'step' => 0.01,
 						'max'  => 20,
 					),
 				),


### PR DESCRIPTION
### Description
Fixed step count for range slider when em is selected

### Screenshots
https://d.pr/i/w6ZG1R

### Types of changes
 Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
- Checked if the change is effected in customizer on various range sliders

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
