### PR TITLE
AST-2134 - Spectra plugin admin redirection url corrected & added highlight label for plugin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ v3.9.2 (Unreleased)
 - Fix: WooCommerce - Checkout - Misalignment for order products quality in order summary box.
 - Fix: The Menu get disappear on the Android mobile device when you select Header Type is set as Dropdown.
 - Fix: Footer - Footer global background color and padding is not working in the frontend.
-
+- Fix: Spectra plugin settings page link redirect to old 'uag' admin page.
 
 v3.9.1
 - Fix: WooCommerce - Child theme's WooCommerce custom templates gets overridden by parent theme.

--- a/inc/assets/css/astra-admin-menu-settings-rtl.css
+++ b/inc/assets/css/astra-admin-menu-settings-rtl.css
@@ -299,3 +299,18 @@ a.astra-starter-sites-detail-link {
 .ast-other-links-list .dashicons {
     margin-left: 6px;
 }
+.astra-recommended-plugin > a[highlight-label]:after {
+	color: #fff;
+	font-size: 0.65em;
+	font-weight: 600;
+	position: relative;
+	content: attr(highlight-label);
+	padding: 0.3em 0.6em 0.3em;
+	top: -1px;
+	right: 12px;
+	letter-spacing: 0.5px;
+	line-height: 1em;
+	background-color: rgb(97 4 255);
+	text-transform: uppercase;
+	border-radius: 2px;
+}

--- a/inc/assets/css/astra-admin-menu-settings.css
+++ b/inc/assets/css/astra-admin-menu-settings.css
@@ -299,3 +299,18 @@ a.astra-starter-sites-detail-link {
 .ast-other-links-list .dashicons {
     margin-right: 6px;
 }
+.astra-recommended-plugin > a[highlight-label]:after {
+	color: #fff;
+	font-size: 0.65em;
+	font-weight: 600;
+	position: relative;
+	content: attr(highlight-label);
+	padding: 0.3em 0.6em 0.3em;
+	top: -1px;
+	left: 12px;
+	letter-spacing: 0.5px;
+	line-height: 1em;
+	background-color: rgb(97 4 255);
+	text-transform: uppercase;
+	border-radius: 2px;
+}

--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -1103,6 +1103,23 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 		}
 
 		/**
+		 * Check if Spectra is installed.
+		 *
+		 * @since x.x.x
+		 *
+		 * @access public
+		 * @return array
+		 */
+		public static function astra_get_spectra_plugin_data() {
+			$path    = 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php';
+			$plugins = get_plugins();
+			return array(
+				'is_exist' => isset( $plugins[ $path ] ),
+				'version'  => isset( $plugins[ $path ] ) ? $plugins[ $path ]['Version'] : '2.0.0',
+			);
+		}
+
+		/**
 		 * Include Welcome page content
 		 *
 		 * @since 1.2.4
@@ -1122,6 +1139,10 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 					astra_get_theme_name()
 				)
 			);
+
+			$spectra_plugin_data = self::astra_get_spectra_plugin_data();
+
+			$spectra_plugin_slug = ( ! $spectra_plugin_data['is_exist'] ) || version_compare( $spectra_plugin_data['version'], '2.0.0', '>=' ) ? 'spectra' : 'uag';
 
 			$recommended_plugins = apply_filters(
 				'astra_recommended_plugins',
@@ -1193,8 +1214,9 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 						array(
 							'plugin-name'        => __( 'Spectra – WordPress Gutenberg Blocks', 'astra' ),
 							'plugin-init'        => 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php',
-							'settings-link'      => admin_url( 'options-general.php?page=uag' ),
+							'settings-link'      => admin_url( 'options-general.php?page=' . esc_attr( $spectra_plugin_slug ) ),
 							'settings-link-text' => 'Settings',
+							'highlight-label'    => __( 'Popular', 'astra' ),
 							'display'            => function_exists( 'register_block_type' ),
 						),
 				)
@@ -1214,6 +1236,7 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 									<ul class="ast-addon-list">
 										<?php
 										foreach ( $recommended_plugins as $slug => $plugin ) {
+											$highlight_label_attr = isset( $plugin['highlight-label'] ) ? 'highlight-label="' . esc_html( $plugin['highlight-label'] ) . '"' : '';
 
 											// If display condition for the plugin does not meet, skip the plugin from displaying.
 											if ( isset( $plugin['display'] ) && false === $plugin['display'] ) {
@@ -1234,7 +1257,7 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 												)
 											) . '>';
 
-												echo '<a href="' . esc_url( self::build_worg_plugin_link( $slug ) ) . '" target="_blank">';
+												echo '<a href="' . esc_url( self::build_worg_plugin_link( $slug ) ) . '" target="_blank"' . $highlight_label_attr . '>';
 													echo esc_html( $plugin['plugin-name'] );
 												echo '</a>';
 

--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -1113,10 +1113,12 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 		public static function astra_get_spectra_plugin_data() {
 			$path    = 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php';
 			$plugins = get_plugins();
+			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			return array(
 				'is_exist' => isset( $plugins[ $path ] ),
-				'version'  => isset( $plugins[ $path ] ) ? $plugins[ $path ]['Version'] : '2.0.0',
+				'version'  => ( isset( $plugins[ $path ] ) && $plugins[ $path ]['Version'] ) ? $plugins[ $path ]['Version'] : '2.0.0',
 			);
+			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		}
 
 		/**
@@ -1142,7 +1144,9 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 
 			$spectra_plugin_data = self::astra_get_spectra_plugin_data();
 
+			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$spectra_plugin_slug = ( ! $spectra_plugin_data['is_exist'] ) || version_compare( $spectra_plugin_data['version'], '2.0.0', '>=' ) ? 'spectra' : 'uag';
+			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			$recommended_plugins = apply_filters(
 				'astra_recommended_plugins',

--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -1147,6 +1147,16 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 			$recommended_plugins = apply_filters(
 				'astra_recommended_plugins',
 				array(
+					'ultimate-addons-for-gutenberg' =>
+						array(
+							'plugin-name'        => __( 'Spectra – WordPress Gutenberg Blocks', 'astra' ),
+							'plugin-init'        => 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php',
+							'settings-link'      => admin_url( 'options-general.php?page=' . esc_attr( $spectra_plugin_slug ) ),
+							'settings-link-text' => 'Settings',
+							'highlight-label'    => __( 'Popular', 'astra' ),
+							'display'            => function_exists( 'register_block_type' ),
+						),
+
 					'astra-import-export'           =>
 						array(
 							'plugin-name'        => __( 'Import / Export Customizer Settings', 'astra' ),
@@ -1209,16 +1219,6 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 						'settings-link'      => admin_url( 'edit.php?post_type=bsf-sidebar' ),
 						'settings-link-text' => 'Settings',
 					),
-
-					'ultimate-addons-for-gutenberg' =>
-						array(
-							'plugin-name'        => __( 'Spectra – WordPress Gutenberg Blocks', 'astra' ),
-							'plugin-init'        => 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php',
-							'settings-link'      => admin_url( 'options-general.php?page=' . esc_attr( $spectra_plugin_slug ) ),
-							'settings-link-text' => 'Settings',
-							'highlight-label'    => __( 'Popular', 'astra' ),
-							'display'            => function_exists( 'register_block_type' ),
-						),
 				)
 			);
 

--- a/tests/php/static-analysis-stubs/astra-stubs.php
+++ b/tests/php/static-analysis-stubs/astra-stubs.php
@@ -5034,7 +5034,7 @@ namespace {
         public function content_layout($layout)
         {
         }
-        /**
+        /** 
          * LearnDash Static CSS.
          *
          * @since 3.3.0
@@ -6680,6 +6680,17 @@ namespace {
         {
         }
         /**
+         * Check if Spectra is installed.
+         *
+         * @since x.x.x
+         *
+         * @access public
+         * @return array
+         */
+        public static function astra_get_spectra_plugin_data()
+        {
+        }
+        /**
          * Include Welcome page content
          *
          * @since 1.2.4
@@ -7123,7 +7134,7 @@ namespace {
         public function __construct()
         {
         }
-        /**
+        /** 
          * Comment count wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -7133,7 +7144,7 @@ namespace {
         public function comment_count_wrapper_open($args)
         {
         }
-        /**
+        /** 
          * Comment count wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -7143,7 +7154,7 @@ namespace {
         public function comment_count_wrapper_close($args)
         {
         }
-        /**
+        /** 
          * Comment data wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -7153,7 +7164,7 @@ namespace {
         public function ast_comment_data_wrap_open($args)
         {
         }
-        /**
+        /** 
          * Comment data wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -7163,7 +7174,7 @@ namespace {
         public function ast_comment_data_wrap_close($args)
         {
         }
-        /**
+        /** 
          * Comment meta wrapper opening div.
          *
          * @param array $args markup arguments.
@@ -7173,7 +7184,7 @@ namespace {
         public function ast_comment_meta_wrap_open($args)
         {
         }
-        /**
+        /** 
          * Comment meta wrapper closing div.
          *
          * @param array $args markup arguments.
@@ -7183,7 +7194,7 @@ namespace {
         public function ast_comment_meta_wrap_close($args)
         {
         }
-        /**
+        /** 
          * Comment time div attributes.
          *
          * @since 3.3.0
@@ -7192,7 +7203,7 @@ namespace {
         public function ast_comment_time_attr()
         {
         }
-        /**
+        /** 
          * Comment cite wrapper div attributes.
          *
          * @since 3.3.0
@@ -7237,16 +7248,16 @@ namespace {
         public function ast_grid_col_6()
         {
         }
-        /**
+        /** 
          * Comment form grid classes.
          *
-         * @since 3.3.0
+         * @since 3.3.0 
          * @return string.
          */
         public function comment_form_grid_class()
         {
         }
-        /**
+        /** 
          * Removed grid layout classes and make common class for same style
          *
          * @since 3.3.0
@@ -7255,7 +7266,7 @@ namespace {
         public function ast_grid_lg_12()
         {
         }
-        /**
+        /** 
          * Layout-4 grid css backward comaptibility.
          *
          * @return string.
@@ -7263,7 +7274,7 @@ namespace {
         public function ast_layout_4_grid()
         {
         }
-        /**
+        /** 
          * Layout-2 grid css backward comaptibility.
          *
          * @return string.
@@ -7271,7 +7282,7 @@ namespace {
         public function ast_layout_2_grid()
         {
         }
-        /**
+        /** 
          * Layout-1 grid css backward comaptibility.
          *
          * @return string.
@@ -7279,7 +7290,7 @@ namespace {
         public function ast_layout_1_grid()
         {
         }
-        /**
+        /** 
          * Layout-3 grid css backward comaptibility.
          *
          * @return string.
@@ -7287,7 +7298,7 @@ namespace {
         public function ast_layout_3_grid()
         {
         }
-        /**
+        /** 
          * Layout-5 grid css backward comaptibility.
          *
          * @return string.
@@ -7295,7 +7306,7 @@ namespace {
         public function ast_layout_5_grid()
         {
         }
-        /**
+        /** 
          * Layout-6 grid css backward comaptibility.
          *
          * @return string.
@@ -7305,7 +7316,7 @@ namespace {
         }
         /**
          * Footer widget opening div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -7315,7 +7326,7 @@ namespace {
         }
         /**
          * Footer widget closing div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -7345,7 +7356,7 @@ namespace {
         }
         /**
          * Footer widget opening div.
-         *
+         * 
          * @since 3.3.0
          * @param array $args div attributes.
          * @return array.
@@ -9912,7 +9923,7 @@ namespace {
          * @var array Notices.
          * @since 1.0.0
          */
-        private static $version = '1.1.11';
+        private static $version = '1.1.9';
         /**
          * Notices
          *
@@ -10999,7 +11010,7 @@ namespace {
     }
     /*!
      * ISC License
-     *
+     * 
      * Copyright (c) 2018-2021, Andrea Giammarchi, @WebReflection
      *
      * Permission to use, copy, modify, and/or distribute this software for any
@@ -12901,7 +12912,7 @@ namespace {
     }
     /**
      * Load Menu hover style static CSS if any one of the menu hover style is selected.
-     *
+     * 
      * @return string
      * @since 3.5.0
      */
@@ -13446,9 +13457,9 @@ namespace {
     /**
      * Parse CSS
      *
-     * @param  array  $css_output Array of CSS.
+     * @param  array $css_output Array of CSS.
      * @param  mixed $min_media  Min Media breakpoint.
-	 * @param  mixed $max_media  Max Media breakpoint.
+     * @param  mixed $max_media  Max Media breakpoint.
      * @return string             Generated CSS.
      */
     function astra_parse_css($css_output = array(), $min_media = '', $max_media = '')
@@ -14696,7 +14707,7 @@ namespace {
     /**
      * Old Header Menu Last Item - Dynamic CSS.
      *
-     * @param string $dynamic_css
+     * @param string $dynamic_css 
      * @since 3.5.0
      */
     function astra_old_header_custom_menu_css($dynamic_css)
@@ -14959,7 +14970,7 @@ namespace {
     /**
      * Check the Astra addon version.
      * For  major update and frequently we used version_compare, added a function for this for easy maintenance.
-     *
+     * 
      * @param string $version Astra addon version.
      * @param string $compare Compare symbols.
      * @since  x.x.x
@@ -16265,15 +16276,6 @@ namespace {
     {
     }
     /**
-     * Apply css for show password icon on woocommerce account page.
-     *
-     * @since x.x.x
-     * @return void
-     */
-    function astra_apply_woocommerce_show_password_icon_css()
-    {
-    }
-    /**
      * Migrate old user data to new responsive format layout for shop's summary box content alignment.
      *
      * @since 3.9.0
@@ -16289,6 +16291,15 @@ namespace {
      * @return void
      */
     function astra_shop_style_design_layout()
+    {
+    }
+    /**
+     * Apply css for show password icon on woocommerce account page.
+     *
+     * @since x.x.x
+     * @return void
+     */
+    function astra_apply_woocommerce_show_password_icon_css()
     {
     }
     /**


### PR DESCRIPTION
### Description
- Spectra plugin admin redirection url corrected & added highlight label
- Highlight label - https://share.bsf.io/z8uQAwed
- Redirect url - https://share.bsf.io/DOurnGOY

### Types of changes
- Bug fix (redirect url) 
- non-breaking change 

### How has this been tested?
- 1. Redirect url
- - Check by activating plugin from Astra options page
- - The link should redirect to proper spectra page
- - Check with installed plugin activation
- - Check with install then activate plugin case
- 2. Highlight label
- Check UI

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
