### PR TITLE
AST-2140 - fix: Brizy Full/Width Layout is containing extra padding which needs …

### DIFF
--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -53,16 +53,18 @@ function astra_check_any_page_builder_is_active( $post_id ) {
 		return true;
 	}
 
-	if ( class_exists( 'Brizy_Editor_Post' ) ) {
-		try {
-			$post = Brizy_Editor_Post::get( $post_id );
+	if ( class_exists( 'Brizy_Editor_Post' ) && class_exists( 'Brizy_Editor' ) ) {
 
-			if ( $post ) {
+		$brizy_post_types = Brizy_Editor::get()->supported_post_types();
+		$post             = get_post( $post_id ); 
+		$post_type        = get_post_type( $post );
+		
+		if ( in_array( $post_type, $brizy_post_types ) ) {
+
+			if ( Brizy_Editor_Post::get( $post_id )->uses_editor() ) {
 				return true;
-			}
-		} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// The post type is not supported by Brizy hence Brizy should not be used render the post.
-		}
+			}       
+		}   
 	}
 
 	return false;

--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -56,8 +56,7 @@ function astra_check_any_page_builder_is_active( $post_id ) {
 	if ( class_exists( 'Brizy_Editor_Post' ) && class_exists( 'Brizy_Editor' ) ) {
 
 		$brizy_post_types = Brizy_Editor::get()->supported_post_types();
-		$post             = get_post( $post_id ); 
-		$post_type        = get_post_type( $post );
+		$post_type        = get_post_type( $post_id );
 		
 		if ( in_array( $post_type, $brizy_post_types ) ) {
 


### PR DESCRIPTION
…to be excluded

### Description
<!-- Please describe what you have changed or added -->
- Fix: Padding being added when Brizy Layout is active and set to Full/Width Stretched. 
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Fix: Padding being added when Brizy Layout is active and set to Full/Width Stretched. 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Activate Brizy.
- Create a new page using Brizy.
- Set it to Full Width Layout.
- Check in front end, there should not be any extra padding added.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
