### PR TITLE
AST-2185 - Update: Astra Options sidebar Template widget count

### DIFF
--- a/inc/core/class-astra-admin-settings.php
+++ b/inc/core/class-astra-admin-settings.php
@@ -665,7 +665,7 @@ if ( ! class_exists( 'Astra_Admin_Settings' ) ) {
 		 */
 		public static function get_starter_templates_title() {
 
-			$astra_sites_name = __( '180+ Starter Templates', 'astra' );
+			$astra_sites_name = __( '230+ Starter Templates', 'astra' );
 
 			if ( method_exists( 'Astra_Ext_White_Label_Markup', 'get_whitelabel_string' ) ) {
 				$white_labelled_astra_sites_name = Astra_Ext_White_Label_Markup::get_whitelabel_string( 'astra-sites', 'name' );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
We need to [update this text](https://d.pr/i/OzfigH) on the Astra Options sidebar, as we have [230+ templates](https://wpastra.com/starter-templates/?page-builder=elementor) now. Reference: https://d.pr/i/OzfigH

### Screenshots
<!-- if applicable -->
https://d.pr/i/OzfigH

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
