### PR TITLE
AST-2191 - Border not showing up when astra addon is disabled

### DIFF
--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -426,6 +426,20 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 
 	if ( 'none' !== $header_cart_icon_style ) {
 
+		
+		if ( ! astra_has_pro_woocommerce_addon() && 'outline' === $header_cart_icon_style && 'default' !== $header_woo_cart_list ) {
+
+			$header_cart_icon_outline = array(
+				'.ast-menu-cart-outline .ast-cart-menu-wrap .count, .ast-menu-cart-outline .ast-addon-cart-wrap'  => array(
+					'border-width' => '2px',
+					'border-style' => 'solid',
+					'border-color' => esc_attr( $icon_color ),
+				),
+			);
+
+			$css_output .= astra_parse_css( $header_cart_icon_outline );
+		}
+
 		$header_cart_icon = array(
 
 			$selector . ' .ast-cart-menu-wrap, ' . $selector . ' .ast-addon-cart-wrap'       => array(

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -1645,7 +1645,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			);
 
 			$css_desktop_output['.ast-site-header-cart.ast-menu-cart-outline .ast-addon-cart-wrap, .ast-site-header-cart.ast-menu-cart-fill .ast-addon-cart-wrap '] = array(
-				'line-height' => '1.8',
+				'line-height' => '1',
 			);
 
 			$css_desktop_output['.ast-site-header-cart.ast-menu-cart-fill i.astra-icon'] = array(
@@ -1661,7 +1661,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			);
 
 			$css_desktop_output['.ast-hfb-header .ast-addon-cart-wrap'] = array(
-				' padding' => '0.2em 0.6em',
+				' padding' => '0.4em',
 			);
 
 			$css_desktop_output['.ast-header-break-point.ast-header-custom-item-outside .ast-woo-header-cart-info-wrap'] = array(

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -1664,10 +1664,6 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 				' padding' => '0.2em 0.6em',
 			);
 
-			$css_desktop_output['.ast-hfb-header .ast-addon-cart-wrap .astra-icon'] = array(
-				' line-height' => '1',
-			);
-
 			$css_desktop_output['.ast-header-break-point.ast-header-custom-item-outside .ast-woo-header-cart-info-wrap'] = array(
 				' display' => 'none',
 			);


### PR DESCRIPTION
### Description
Jira : https://brainstormforce.atlassian.net/browse/AST-2191

### Screenshots
https://user-images.githubusercontent.com/28552974/188547654-87cba7a3-fb10-4724-bc9b-dd1cb2640723.png

### Types of changes
Bug fix (non-breaking change which fixes an issue) 


### How has this been tested?
- Checked with transparent mode 
- Checked with svg and css mode 
- Checked responsive 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
