### PR TITLE
AST-2190 - Remove tabs in woocommerce misc section when addons is disabled

### DIFF
--- a/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-misc-layout-configs.php
+++ b/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-misc-layout-configs.php
@@ -33,20 +33,7 @@ if ( ! class_exists( 'Astra_Woo_Shop_Misc_Layout_Configs' ) ) {
 
 
 			$_configs = array(
-				
-				/**
-				 * Option: Divider.
-				 */
-				array(
-					'name'     => ASTRA_THEME_SETTINGS . '[single-product-plus-minus-button-divider]',
-					'section'  => 'section-woo-misc',
-					'title'    => __( 'Quantity Plus and Minus', 'astra' ),
-					'type'     => 'control',
-					'control'  => 'ast-heading',
-					'priority' => 59,
-					'settings' => array(),
-					'divider'  => array( 'ast_class' => 'ast-section-spacing' ),
-				),
+			
 
 				/**
 				 * Option: Enable Quantity Plus and Minus.

--- a/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-misc-layout-configs.php
+++ b/inc/compatibility/woocommerce/customizer/sections/layout/class-astra-woo-shop-misc-layout-configs.php
@@ -31,16 +31,8 @@ if ( ! class_exists( 'Astra_Woo_Shop_Misc_Layout_Configs' ) ) {
 		 */
 		public function register_configuration( $configurations, $wp_customize ) {
 
-			$_configs = array(
-				array(
-					'name'        => 'section-woo-general-tabs',
-					'section'     => 'section-woo-misc',
-					'type'        => 'control',
-					'control'     => 'ast-builder-header-control',
-					'priority'    => 0,
-					'description' => '',
-				),
 
+			$_configs = array(
 				
 				/**
 				 * Option: Divider.
@@ -73,6 +65,20 @@ if ( ! class_exists( 'Astra_Woo_Shop_Misc_Layout_Configs' ) ) {
 
 			);
 
+			/**
+			 * Option: Adds tabs only if astra addons is enabled.
+			 */
+			if ( astra_has_pro_woocommerce_addon() ) {
+				$_configs[] = array(
+					'name'        => 'section-woo-general-tabs',
+					'section'     => 'section-woo-misc',
+					'type'        => 'control',
+					'control'     => 'ast-builder-header-control',
+					'priority'    => 0,
+					'description' => '',
+				);
+			}
+
 			if ( ! defined( 'ASTRA_EXT_VER' ) ) {
 				// Learn More link if Astra Pro is not activated.
 				$_configs[] = array(
@@ -86,7 +92,7 @@ if ( ! class_exists( 'Astra_Woo_Shop_Misc_Layout_Configs' ) ) {
 					'settings' => array(),
 					'divider'  => array( 'ast_class' => 'ast-section-spacing' ),
 					'context'  => array(
-						Astra_Builder_Helper::$design_tab_config,
+						Astra_Builder_Helper::$general_tab_config,
 					),
 				);
 			}


### PR DESCRIPTION
### Description
Jira : https://brainstormforce.atlassian.net/browse/AST-2190

### Screenshots
https://d.pr/i/VF89zn

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
- Checked when astra addons is enabled and disabled

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
