### PR TITLE
AST-2211 - Class "Astra_WP_Editor_CSS" not found when updating Astra theme.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 v3.9.3
-- Fix: Fatal error when updatig astra theeme.it's showing class not found Astra_WP_Editor_CSS.
+- Fix: Fatal error: Uncaught Error: Class 'Astra_WP_Editor_CSS' not found when updating theme in some cases.
 
 v3.9.2
 - Improvement: WooCommerce - Admin bar's customize link updated on WooCommerce pages for quick landing to it's respected customizer section.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.9.3
+- Fix: Fatal error when updatig astra theeme.it's showing class not found Astra_WP_Editor_CSS.
+
 v3.9.2
 - Improvement: WooCommerce - Admin bar's customize link updated on WooCommerce pages for quick landing to it's respected customizer section.
 - Improvement: WooCommerce - Added WPML translation support for cart dynamic input, proceed to checkout input & free-shipping text input through wpml-config.xml file. (Props - OnTheGoSystems)

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -185,10 +185,7 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	$ltr_right                = is_rtl() ? 'left' : 'right';
 	$astra_block_editor_v2_ui = astra_get_option( 'wp-blocks-v2-ui', true );
 	$ast_container_width      = astra_get_option( 'site-content-width', 1200 ) . 'px';
-	if(class_exists('Astra_WP_Editor_CSS')){
-		$blocks_spacings          = Astra_WP_Editor_CSS::astra_get_block_spacings();
-	}
-
+	
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	$tablet_breakpoint = (string) astra_get_tablet_breakpoint();
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
@@ -197,49 +194,54 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	$mobile_breakpoint = (string) astra_get_mobile_breakpoint();
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
-	$desktop_top_spacing    = isset( $blocks_spacings['desktop']['top'] ) ? $blocks_spacings['desktop']['top'] : '';
-	$desktop_right_spacing  = isset( $blocks_spacings['desktop']['right'] ) ? $blocks_spacings['desktop']['right'] : '';
-	$desktop_bottom_spacing = isset( $blocks_spacings['desktop']['bottom'] ) ? $blocks_spacings['desktop']['bottom'] : '';
-	$desktop_left_spacing   = isset( $blocks_spacings['desktop']['left'] ) ? $blocks_spacings['desktop']['left'] : '';
-	$tablet_top_spacing     = isset( $blocks_spacings['tablet']['top'] ) ? $blocks_spacings['tablet']['top'] : '';
-	$tablet_right_spacing   = isset( $blocks_spacings['tablet']['right'] ) ? $blocks_spacings['tablet']['right'] : '';
-	$tablet_bottom_spacing  = isset( $blocks_spacings['tablet']['bottom'] ) ? $blocks_spacings['tablet']['bottom'] : '';
-	$tablet_left_spacing    = isset( $blocks_spacings['tablet']['left'] ) ? $blocks_spacings['tablet']['left'] : '';
-	$mobile_top_spacing     = isset( $blocks_spacings['mobile']['top'] ) ? $blocks_spacings['mobile']['top'] : '';
-	$mobile_right_spacing   = isset( $blocks_spacings['mobile']['right'] ) ? $blocks_spacings['mobile']['right'] : '';
-	$mobile_bottom_spacing  = isset( $blocks_spacings['mobile']['bottom'] ) ? $blocks_spacings['mobile']['bottom'] : '';
-	$mobile_left_spacing    = isset( $blocks_spacings['mobile']['left'] ) ? $blocks_spacings['mobile']['left'] : '';
+	if ( class_exists( 'Astra_WP_Editor_CSS' ) ) {
+		$blocks_spacings = Astra_WP_Editor_CSS::astra_get_block_spacings();
 
-	$ast_content_width = apply_filters( 'astra_block_content_width', $astra_block_editor_v2_ui ? $ast_container_width : '910px' );
-	$ast_wide_width    = apply_filters( 'astra_block_wide_width', $astra_block_editor_v2_ui ? 'calc(' . esc_attr( $ast_container_width ) . ' + var(--wp--custom--ast-default-block-left-padding) + var(--wp--custom--ast-default-block-right-padding))' : $ast_container_width );
+		$desktop_top_spacing    = isset( $blocks_spacings['desktop']['top'] ) ? $blocks_spacings['desktop']['top'] : '';
+		$desktop_right_spacing  = isset( $blocks_spacings['desktop']['right'] ) ? $blocks_spacings['desktop']['right'] : '';
+		$desktop_bottom_spacing = isset( $blocks_spacings['desktop']['bottom'] ) ? $blocks_spacings['desktop']['bottom'] : '';
+		$desktop_left_spacing   = isset( $blocks_spacings['desktop']['left'] ) ? $blocks_spacings['desktop']['left'] : '';
+		$tablet_top_spacing     = isset( $blocks_spacings['tablet']['top'] ) ? $blocks_spacings['tablet']['top'] : '';
+		$tablet_right_spacing   = isset( $blocks_spacings['tablet']['right'] ) ? $blocks_spacings['tablet']['right'] : '';
+		$tablet_bottom_spacing  = isset( $blocks_spacings['tablet']['bottom'] ) ? $blocks_spacings['tablet']['bottom'] : '';
+		$tablet_left_spacing    = isset( $blocks_spacings['tablet']['left'] ) ? $blocks_spacings['tablet']['left'] : '';
+		$mobile_top_spacing     = isset( $blocks_spacings['mobile']['top'] ) ? $blocks_spacings['mobile']['top'] : '';
+		$mobile_right_spacing   = isset( $blocks_spacings['mobile']['right'] ) ? $blocks_spacings['mobile']['right'] : '';
+		$mobile_bottom_spacing  = isset( $blocks_spacings['mobile']['bottom'] ) ? $blocks_spacings['mobile']['bottom'] : '';
+		$mobile_left_spacing    = isset( $blocks_spacings['mobile']['left'] ) ? $blocks_spacings['mobile']['left'] : '';
 
-	$dynamic_css .= '
-		html body {
-			--wp--custom--ast-default-block-top-padding: ' . $desktop_top_spacing . ';
-			--wp--custom--ast-default-block-right-padding: ' . $desktop_right_spacing . ';
-			--wp--custom--ast-default-block-bottom-padding: ' . $desktop_bottom_spacing . ';
-			--wp--custom--ast-default-block-left-padding: ' . $desktop_left_spacing . ';
-			--wp--custom--ast-container-width: ' . $ast_container_width . ';
-			--wp--custom--ast-content-width-size: ' . $ast_content_width . ';
-			--wp--custom--ast-wide-width-size: ' . $ast_wide_width . ';
-		}
-		@media(max-width: ' . $tablet_breakpoint . 'px) {
+		$ast_content_width = apply_filters( 'astra_block_content_width', $astra_block_editor_v2_ui ? $ast_container_width : '910px' );
+		$ast_wide_width    = apply_filters( 'astra_block_wide_width', $astra_block_editor_v2_ui ? 'calc(' . esc_attr( $ast_container_width ) . ' + var(--wp--custom--ast-default-block-left-padding) + var(--wp--custom--ast-default-block-right-padding))' : $ast_container_width );
+
+		$dynamic_css .= '
 			html body {
-				--wp--custom--ast-default-block-top-padding: ' . $tablet_top_spacing . ';
-				--wp--custom--ast-default-block-right-padding: ' . $tablet_right_spacing . ';
-				--wp--custom--ast-default-block-bottom-padding: ' . $tablet_bottom_spacing . ';
-				--wp--custom--ast-default-block-left-padding: ' . $tablet_left_spacing . ';
+				--wp--custom--ast-default-block-top-padding: ' . $desktop_top_spacing . ';
+				--wp--custom--ast-default-block-right-padding: ' . $desktop_right_spacing . ';
+				--wp--custom--ast-default-block-bottom-padding: ' . $desktop_bottom_spacing . ';
+				--wp--custom--ast-default-block-left-padding: ' . $desktop_left_spacing . ';
+				--wp--custom--ast-container-width: ' . $ast_container_width . ';
+				--wp--custom--ast-content-width-size: ' . $ast_content_width . ';
+				--wp--custom--ast-wide-width-size: ' . $ast_wide_width . ';
 			}
-		}
-		@media(max-width: ' . $mobile_breakpoint . 'px) {
-			html body {
-				--wp--custom--ast-default-block-top-padding: ' . $mobile_top_spacing . ';
-				--wp--custom--ast-default-block-right-padding: ' . $mobile_right_spacing . ';
-				--wp--custom--ast-default-block-bottom-padding: ' . $mobile_bottom_spacing . ';
-				--wp--custom--ast-default-block-left-padding: ' . $mobile_left_spacing . ';
+			@media(max-width: ' . $tablet_breakpoint . 'px) {
+				html body {
+					--wp--custom--ast-default-block-top-padding: ' . $tablet_top_spacing . ';
+					--wp--custom--ast-default-block-right-padding: ' . $tablet_right_spacing . ';
+					--wp--custom--ast-default-block-bottom-padding: ' . $tablet_bottom_spacing . ';
+					--wp--custom--ast-default-block-left-padding: ' . $tablet_left_spacing . ';
+				}
 			}
-		}
-	';
+			@media(max-width: ' . $mobile_breakpoint . 'px) {
+				html body {
+					--wp--custom--ast-default-block-top-padding: ' . $mobile_top_spacing . ';
+					--wp--custom--ast-default-block-right-padding: ' . $mobile_right_spacing . ';
+					--wp--custom--ast-default-block-bottom-padding: ' . $mobile_bottom_spacing . ';
+					--wp--custom--ast-default-block-left-padding: ' . $mobile_left_spacing . ';
+				}
+			}
+		';
+
+	}
 
 	$astra_wide_particular_selector = $astra_block_editor_v2_ui ? '.entry-content[ast-blocks-layout] > .alignwide' : '.entry-content[ast-blocks-layout] > .alignwide, .entry-content[ast-blocks-layout] .wp-block-cover__inner-container, .entry-content[ast-blocks-layout] > p';
 	$astra_full_stretched_selector  = $astra_block_editor_v2_ui ? '.ast-plain-container.ast-no-sidebar .entry-content > .alignfull, .ast-page-builder-template .ast-no-sidebar .entry-content > .alignfull' : '.ast-plain-container.ast-no-sidebar .entry-content .alignfull, .ast-page-builder-template .ast-no-sidebar .entry-content .alignfull';

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -185,7 +185,9 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	$ltr_right                = is_rtl() ? 'left' : 'right';
 	$astra_block_editor_v2_ui = astra_get_option( 'wp-blocks-v2-ui', true );
 	$ast_container_width      = astra_get_option( 'site-content-width', 1200 ) . 'px';
-	$blocks_spacings          = Astra_WP_Editor_CSS::astra_get_block_spacings();
+	if(class_exists('dbinfo')){
+		$blocks_spacings          = Astra_WP_Editor_CSS::astra_get_block_spacings();
+	}
 
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	$tablet_breakpoint = (string) astra_get_tablet_breakpoint();

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -185,7 +185,7 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	$ltr_right                = is_rtl() ? 'left' : 'right';
 	$astra_block_editor_v2_ui = astra_get_option( 'wp-blocks-v2-ui', true );
 	$ast_container_width      = astra_get_option( 'site-content-width', 1200 ) . 'px';
-	if(class_exists('dbinfo')){
+	if(class_exists('Astra_WP_Editor_CSS')){
 		$blocks_spacings          = Astra_WP_Editor_CSS::astra_get_block_spacings();
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
It seems after the update Fatal error: Uncaught Error: Class 'Astra_WP_Editor_CSS' is not found and the users site is down.
https://secure.helpscout.net/conversation/2007704985/237646

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
