### PR TITLE
AST-2245 - Sticky Add to Cart & Quantity Plus and Minus is not working for the Old header on the latest version(3.9.2) of the single product page.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ v3.9.3 (Unreleased)
 - Fix: WooCommerce - Content background color preview not working in customizer preview.
 - Fix: WooCommerce - Shop - Sale badge text is misaligned on the frontend.
 - Fix: Block Editor - Astra Meta settings does not save when Custom Fields option is enabled from the preferences.
+- Fix: WooCommerce - Sticky add to cart is not working on old header footer.
 
 v3.9.2
 - Improvement: WooCommerce - Admin bar's customize link updated on WooCommerce pages for quick landing to it's respected customizer section.

--- a/inc/core/class-astra-enqueue-scripts.php
+++ b/inc/core/class-astra-enqueue-scripts.php
@@ -189,16 +189,20 @@ if ( ! class_exists( 'Astra_Enqueue_Scripts' ) ) {
 					$default_assets['js']['astra-mobile-cart'] = 'mobile-cart';
 				}
 
-				if ( class_exists( 'WooCommerce' ) && is_product() && astra_get_option( 'single-product-sticky-add-to-cart' ) ) {
-					$default_assets['js']['astra-sticky-add-to-cart'] = 'sticky-add-to-cart';
-				}
-
 				/** @psalm-suppress UndefinedFunction */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 				$astra_add_to_cart_quantity_btn_enabled = apply_filters( 'astra_add_to_cart_quantity_btn_enabled', astra_get_option( 'single-product-plus-minus-button' ) );
 
 				if ( class_exists( 'WooCommerce' ) && $astra_add_to_cart_quantity_btn_enabled ) {
 					$default_assets['js']['astra-add-to-cart-quantity-btn'] = 'add-to-cart-quantity-btn';
 				}
+			}
+			$astra_add_to_cart_quantity_btn_enabled = apply_filters( 'astra_add_to_cart_quantity_btn_enabled', astra_get_option( 'single-product-plus-minus-button' ) );
+
+			if ( class_exists( 'WooCommerce' ) && $astra_add_to_cart_quantity_btn_enabled ) {
+					$default_assets['js']['astra-add-to-cart-quantity-btn'] = 'add-to-cart-quantity-btn';
+			}
+			if ( class_exists( 'WooCommerce' ) && is_product() && astra_get_option( 'single-product-sticky-add-to-cart' ) ) {
+				$default_assets['js']['astra-sticky-add-to-cart'] = 'sticky-add-to-cart';
 			}
 			return apply_filters( 'astra_theme_assets', $default_assets );
 		}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
install/activate the Astra Pro Addon with all the modules or WooCommerce module on an old header footer e-commerce site.

Try enabling the features like [Sticky Add to Cart](https://d.pr/i/r9gL3V) from a single page & [Quantity Plus and Minus](https://d.pr/i/UwNtuH) from the Misc.
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
