### PR TITLE
AST-2279 - Old HF string changes on the Astra setting page improve.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ v3.9.3 (Unreleased)
 - Fix: Two search buttons visible on the empty archive search result page.
 - Fix: Disabled Astra meta setting for Blog page which does not not work from metabox, as it acts like a archive page on the frontend.
 - Fix: Megamenu spacing conflict with primary menu top offset option on mobile devices.
+- Fix: Updated Old header footer description in the astra settings.
 
 v3.9.2
 - Improvement: WooCommerce - Admin bar's customize link updated on WooCommerce pages for quick landing to it's respected customizer section.

--- a/inc/core/builder/class-astra-builder-admin.php
+++ b/inc/core/builder/class-astra-builder-admin.php
@@ -97,13 +97,21 @@ final class Astra_Builder_Admin {
 						<?php
 							printf(
 								/* translators: %1$s: Theme name. */
-								esc_html__( 'Latest features and options of %1$s customizer will no longer support to the old Header footer,we will disable this old header footer in the future release ', 'astra' ),
+								esc_html__( 'After years of evolution and updates, the old header footer builder is at the point where it can no longer handle all of the new features. ', 'astra' ),
+								esc_html( $astra_theme_title )
+							);
+						?>
+					</p>
+					<p>
+						<?php
+							printf(
+								/* translators: %1$s: Theme name. */
+								esc_html__( 'We recommend that you upgrade to the new header footer builder which has an assortment of new features and provides a more seamless experience. ', 'astra' ),
 								esc_html( $astra_theme_title )
 							);
 						?>
 					</p>
 					<p><?php esc_html_e( 'Note: The header/footer builder will replace the existing header/footer settings in the customizer. This might make your header/footer look a bit different. You can configure header/footer builder settings from customizer to give it a nice look. You can always come back here and switch to your old header/footer. ', 'astra' ); ?></p>
-					
 					<div class="ast-actions-wrap" style="justify-content: space-between;display: flex;align-items: center;" >
 						<a href="<?php echo esc_url( admin_url( '/customize.php' ) ); ?>" class="ast-go-to-customizer"><?php esc_html_e( 'Go to Customizer', 'astra' ); ?></a>
 						<div class="ast-actions" style="display: inline-flex;">

--- a/inc/core/builder/class-astra-builder-admin.php
+++ b/inc/core/builder/class-astra-builder-admin.php
@@ -93,7 +93,17 @@ final class Astra_Builder_Admin {
 							);
 						?>
 					</p>
-					<p><?php esc_html_e( 'Note: The header/footer builder will replace the existing header/footer settings in the customizer. This might make your header/footer look a bit different. You can configure header/footer builder settings from customizer to give it a nice look. You can always come back here and switch to your old header/footer.', 'astra' ); ?></p>
+					<p>
+						<?php
+							printf(
+								/* translators: %1$s: Theme name. */
+								esc_html__( 'Latest features and options of %1$s customizer will no longer support to the old Header footer,we will disable this old header footer in the future release ', 'astra' ),
+								esc_html( $astra_theme_title )
+							);
+						?>
+					</p>
+					<p><?php esc_html_e( 'Note: The header/footer builder will replace the existing header/footer settings in the customizer. This might make your header/footer look a bit different. You can configure header/footer builder settings from customizer to give it a nice look. You can always come back here and switch to your old header/footer. ', 'astra' ); ?></p>
+					
 					<div class="ast-actions-wrap" style="justify-content: space-between;display: flex;align-items: center;" >
 						<a href="<?php echo esc_url( admin_url( '/customize.php' ) ); ?>" class="ast-go-to-customizer"><?php esc_html_e( 'Go to Customizer', 'astra' ); ?></a>
 						<div class="ast-actions" style="display: inline-flex;">

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1601,6 +1601,7 @@ function astra_check_is_structural_setup() {
 
 /**
  * Check if the user is old sidebar user.
+ *
  * @since x.x.x
  * @return bool true|false.
  */


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
currently, users need to understand, new features and options are no longer supported by the old header footer, They need to move on to new HF to use those option compatibility. so need to update the string on Astra setting page.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
