### PR TITLE
AST-2239 - fix: Elementor Global button style overwrites Astra submenu button style

### DIFF
--- a/inc/dynamic-css/container-layouts.php
+++ b/inc/dynamic-css/container-layouts.php
@@ -81,6 +81,10 @@ function astra_container_layout_css() {
 	$customizer_default_update = astra_check_is_structural_setup();
 	$page_title_header_padding = ( true === $customizer_default_update ) ? '2em' : '4em';
 
+	$page_container_css .= '#ast-mobile-header button.ast-menu-toggle {
+							color: unset !important;
+							background: unset !important;
+						}';
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	$tablet_breakpoint = (string) astra_get_tablet_breakpoint();
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

- Elementor site settings global button overwrites the Astra submenu mobile arrow icon style.

**Steps To Reproduce:** 

- You can follow this screencast: [Screen Recording 9-13-2022 at 3.52 PM](https://share.bsf.io/2Nu75koB).I have tried to replicate the issue, and it's replicable!


### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
