### PR TITLE
AST-2287 - fix: Disable the title from elementor setting is not working as expected

### DIFF
--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -1356,6 +1356,8 @@ if ( ! function_exists( 'astra_entry_header_class' ) ) {
 			$classes[] = 'ast-header-without-markup';
 		} elseif ( empty( $title_markup ) && empty( $thumb_markup ) && ( is_page() || empty( $post_meta_markup ) ) ) {
 			$classes[] = 'ast-header-without-markup';
+		} elseif ( is_page() || empty( $post_meta_markup ) ) {
+			$classes[] = 'ast-header-without-markup';
 		} else {
 
 			if ( empty( $title_markup ) ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
