### PR TITLE
AST-2352 - fix: spectra heading block padding issue when bg color applied

### DIFF
--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -561,6 +561,11 @@ class Astra_WP_Editor_CSS {
 			'padding-right'     => $page_title_internal_padding,
 		);
 
+		// Spectra heading blocks BG color padding.
+		$desktop_css['.wp-block-uagb-advanced-heading .uagb-heading-text'] = array(
+			"padding-bottom" => '15px',
+		);
+
 		$content_links_underline = astra_get_option( 'underline-content-links' );
 
 		if ( $content_links_underline ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
fix: padding issue with spectra heading when background color is applied
### Screenshots
<!-- if applicable -->
https://d.pr/i/GSzZg7
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
fix: padding issue with spectra heading when background color is applied
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Create a heading with Spectra Block
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
