### PR TITLE
refactor: As link attr added underline typography from core overriding that by theme.json provision

### DIFF
--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -712,13 +712,6 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 				);
 			}
 
-			// As WordPress added text-decoration: underline; directly in WP-6.1. Adding this compatibility CSS to override it.
-			if ( astra_wp_version_compare( '6.1', '>=' ) ) {
-				$css_output[ '.site a:where(:not(.wp-element-button))' ] = array(
-					'text-decoration' => 'inherit',
-				);
-			}
-
 			// Add underline to every link in content area.
 			$content_links_underline = astra_get_option( 'underline-content-links' );
 

--- a/theme.json
+++ b/theme.json
@@ -89,5 +89,14 @@
       "wideSize": "var(--wp--custom--ast-wide-width-size)",
       "fullSize": "none"
     }
+  },
+  "styles": {
+    "elements": {
+      "link": {
+          "typography": {
+            "textDecoration": "none"
+          }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description
- Text decoration underline being added for all site links
- https://wordpress.org/support/topic/wordpress-6-1-update-forces-underline-on-links/

### Screenshots
- https://share.bsf.io/geuyGn5N

### Types of changes
- Bug fix

### How has this been tested?
-Test with WP-6.1
- Make sure to test this option for content area links - https://share.bsf.io/eDu74AQN

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
