### PR TITLE
Fix: Updated site layout config & changed name of the NWL width slider

### DIFF
--- a/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
@@ -47,14 +47,6 @@ if ( ! class_exists( 'Astra_Site_Layout_Configs' ) ) {
 							'operator' => '==',
 							'value'    => 'ast-full-width-layout',
 						),
-						array(
-							Astra_Builder_Helper::$general_tab_config,
-							array(
-								'setting'  => ASTRA_THEME_SETTINGS . '[site-content-layout]',
-								'operator' => '!=',
-								'value'    => 'narrow-container',
-							),
-						)
 					) : array(
 						Astra_Builder_Helper::$general_tab_config,
 						array(

--- a/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Astra_Site_Layout_Configs' ) ) {
 					'default'     => astra_get_option( 'narrow-container-max-width' ),
 					'section'     => 'section-container-layout',
 					'priority'    => 10,
-					'title'       => __( 'Narrow Width', 'astra' ),
+					'title'       => __( 'Narrow Container Width', 'astra' ),
 					'context'     => array(
 						Astra_Builder_Helper::$general_tab_config,
 						array(

--- a/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-site-layout-configs.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Astra_Site_Layout_Configs' ) ) {
 					'default'     => astra_get_option( 'narrow-container-max-width' ),
 					'section'     => 'section-container-layout',
 					'priority'    => 10,
-					'title'       => __( 'Narrow Container Max Width', 'astra' ),
+					'title'       => __( 'Narrow Width', 'astra' ),
 					'context'     => array(
 						Astra_Builder_Helper::$general_tab_config,
 						array(


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Need to show both the sliders "Container Width" & "Narrow Width" Sliders when "Site Layout" is set to "Full Width"
- Updated name of the "Narrow Container Max Width"

### Screenshots
<!-- if applicable -->
https://d.pr/i/86PMu8

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- Updated configs for site layout global container settings
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check the Global > Container settings
### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
