### PR TITLE
AST-2286 - fix: blog archives layout 2 & 3 post title structure title & meta not…

### DIFF
--- a/inc/blog/blog.php
+++ b/inc/blog/blog.php
@@ -240,6 +240,7 @@ if ( ! function_exists( 'astra_get_blog_post_title_meta' ) ) {
 	function astra_get_blog_post_title_meta() {
 
 		// Blog Post Title and Blog Post Meta.
+		$blog_title_meta = astra_get_option( 'blog-post-structure' );
 		do_action( 'astra_archive_entry_header_before' );
 		?>
 		<header class="entry-header">
@@ -388,5 +389,24 @@ if ( ! function_exists( 'astra_get_video_from_post' ) ) {
 				return $embed;
 			}
 		}
+	}
+}
+/**
+ * Check whether blogs post structure title & meta is disabled or not
+ */
+if ( ! function_exists( 'astra_is_blog_title_meta_disabled' ) ) {
+
+	/**
+	 * Check whether blogs post structure title & meta is disabled or not.
+	 *
+	 * @since x.x.x
+	 * @return bool True if blogs post structure title & meta is disabled else false.
+	 */
+    function astra_is_blog_title_meta_disabled() {
+        $blog_title_meta = astra_get_option( 'blog-post-structure' );
+		if( is_array( $blog_title_meta ) && ! in_array( 'title-meta', $blog_title_meta ) )  {
+			return true;
+		}
+		return false;
 	}
 }

--- a/inc/blog/blog.php
+++ b/inc/blog/blog.php
@@ -240,7 +240,6 @@ if ( ! function_exists( 'astra_get_blog_post_title_meta' ) ) {
 	function astra_get_blog_post_title_meta() {
 
 		// Blog Post Title and Blog Post Meta.
-		$blog_title_meta = astra_get_option( 'blog-post-structure' );
 		do_action( 'astra_archive_entry_header_before' );
 		?>
 		<header class="entry-header">

--- a/inc/blog/blog.php
+++ b/inc/blog/blog.php
@@ -401,8 +401,8 @@ if ( ! function_exists( 'astra_is_blog_title_meta_disabled' ) ) {
 	 * @since x.x.x
 	 * @return bool True if blogs post structure title & meta is disabled else false.
 	 */
-    function astra_is_blog_title_meta_disabled() {
-        $blog_title_meta = astra_get_option( 'blog-post-structure' );
+	function astra_is_blog_title_meta_disabled() {
+		$blog_title_meta = astra_get_option( 'blog-post-structure' );
 		if( is_array( $blog_title_meta ) && ! in_array( 'title-meta', $blog_title_meta ) )  {
 			return true;
 		}

--- a/tests/php/static-analysis-stubs/astra-stubs.php
+++ b/tests/php/static-analysis-stubs/astra-stubs.php
@@ -16433,6 +16433,15 @@ namespace {
     {
     }
     /**
+     * Check whether blogs post structure title & meta is disabled or not.
+     *
+     * @since x.x.x
+     * @return bool True if blogs post structure title & meta is disabled else false.
+     */
+    function astra_is_blog_title_meta_disabled()
+    {
+    }
+    /**
      * Search Form for Astra theme.
      *
      * @package     Astra


### PR DESCRIPTION
… hiding

### Description
<!-- Please describe what you have changed or added -->
- Fix: blog archives layout 2 & 3 post title structure title & meta hide option not working.

### Screenshots
<!-- if applicable -->
https://share.getcloudapp.com/P8u76qo9
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Steps To Reproduce: 

Go to the customizer and set in the blog archive settings to Layout 2 or 3.

Uncheck the title in Post Structure.

Check the front end.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
