### PR TITLE
AST-2578 - fix: content background gets set to white for responsive devices

### DIFF
--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -627,6 +627,9 @@ class Astra_WP_Editor_CSS {
 			);
 		}
 
+        // Content background color fallback - inherit desktop bg color if tablet bg color not set.
+        $content_background = astra_responsive_bg_color_fallback( $content_background, 'tablet' );
+
 		$tablet_css = array(
 			':root, body .editor-styles-wrapper' => array(
 				'--wp--custom--ast-default-block-top-padding' => $tablet_top_spacing,
@@ -654,8 +657,11 @@ class Astra_WP_Editor_CSS {
 				'font-size' => astra_responsive_font( $heading_h6_font_size, 'tablet' ),
 			),
 			'#editor .edit-post-visual-editor'   => astra_get_responsive_background_obj( $site_background, 'tablet' ),
-			'.edit-post-visual-editor .editor-styles-wrapper' => astra_get_responsive_background_obj( $content_background, 'tablet' ),
+			'.editor-styles-wrapper'             => astra_get_responsive_background_obj( $content_background, 'tablet' ),
 		);
+
+        // Content background color fallback - inherit desktop bg color if mobile bg color not set.
+        $content_background = astra_responsive_bg_color_fallback( $content_background, 'mobile' );
 
 		$mobile_css = array(
 			':root, body .editor-styles-wrapper' => array(
@@ -684,7 +690,7 @@ class Astra_WP_Editor_CSS {
 				'font-size' => astra_responsive_font( $heading_h6_font_size, 'mobile' ),
 			),
 			'#editor .edit-post-visual-editor'   => astra_get_responsive_background_obj( $site_background, 'mobile' ),
-			'.edit-post-visual-editor .editor-styles-wrapper' => astra_get_responsive_background_obj( $content_background, 'mobile' ),
+			'.editor-styles-wrapper'             => astra_get_responsive_background_obj( $content_background, 'mobile' ),
 		);
 
 		$css .= astra_parse_css( $desktop_css );

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -1670,3 +1670,17 @@ function astra_narrow_container_width( $location, $narrow_container_max_width ) 
 		return '';
 	}
 }
+
+/**
+ * Set fallback css value for content background for responsive devices.
+ * @param  array  content_background background css properties.
+ * @param  string resp_device        tablet or mobile.
+ * @return array  content_background updated background css properties.
+ * @since x.x.x
+ */
+function astra_responsive_bg_color_fallback( $content_background, $resp_device ) {
+    if ( isset( $content_background[ $resp_device ][ 'background-color' ] ) && isset( $content_background[ 'desktop' ][ 'background-color' ] ) && '' === $content_background[ $resp_device ][ 'background-color' ] ) {
+        $content_background[ $resp_device ][ 'background-color' ] = $content_background[ 'desktop' ][ 'background-color' ];
+    }
+    return $content_background;
+}

--- a/tests/php/static-analysis-stubs/astra-stubs.php
+++ b/tests/php/static-analysis-stubs/astra-stubs.php
@@ -16756,6 +16756,16 @@ namespace {
     {
     }
     /**
+     * Set fallback css value for content background for responsive devices.
+     * @param  array  content_background background css properties.
+     * @param  string resp_device        tablet or mobile.
+     * @return array  content_background updated background css properties.
+     * @since x.x.x
+     */
+    function astra_responsive_bg_color_fallback( $content_background, $resp_device )
+    {
+    }
+    /**
      * Search Form for Astra theme.
      *
      * @package     Astra


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
When we set content background from customizer > global > colors > content background, in editor, in responsive view the content background color is explicitly set to white.

### Screenshots
<!-- if applicable -->
bug - https://share.getcloudapp.com/v1uEvjGz
fix - https://d.pr/v/iIWoon

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
When we set content background from customizer > global > colors > content background, in editor, in responsive view the content background color is explicitly set to white.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Test video - https://d.pr/v/iIWoon

Test Cases:
Global > Colors > Content Background
1. Select any color for desktop, now clear the color for tablet, in editor responsive view, the tablet content bg should be same as desktop.
2. Select any color for desktop, now select any color for tablet, in editor responsive view, the tablet content bg should be what is set in customizer for tablet.
3. Select any color for desktop, now clear the color for mobile, in editor responsive view, the mobile content bg should be same as desktop.
4. Select any color for desktop, now select any color for mobile, in editor responsive view, the mobile content bg should be what is set in customizer for tablet.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
