### PR TITLE
AST-2569 - Cherry Pick fix: Button background colour must be selected issue in the editor for specific templates - Cherry Pick

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v3.9.5
+- Fix: Block editor - Button background colour gets overridden by core styles for Legacy block editor setup.
+
 v3.9.4
 - New: WooCommerce Cart - "Cart Page" click action introduced to redirect the user to the cart page.
 - Improvement: Added Spectra plugin compatibility for a better experience.

--- a/inc/core/class-gutenberg-editor-css.php
+++ b/inc/core/class-gutenberg-editor-css.php
@@ -606,7 +606,7 @@ if ( ! class_exists( 'Gutenberg_Editor_CSS' ) ) :
 					/**
 					 * Gutenberg button compatibility for default styling.
 					 */
-					'.wp-block-button .wp-block-button__link' . $search_button_selector . $file_block_button_selector => array(
+					'.editor-styles-wrapper .wp-block-button .wp-block-button__link' . $search_button_selector . $file_block_button_selector => array(
 						'border-style'        => 'solid',
 						'border-top-width'    => $theme_btn_top_border,
 						'border-right-width'  => $theme_btn_right_border,


### PR DESCRIPTION
**Test Data: (If any)**  

The button background colour is not applied in the editor for specific templates. 

**Steps To Reproduce:** 

1. Install any e-commerce starter template.
2. Go to the editor, and add the normal button.
3. Check the button normal and hover the colour on frontend and backend.
4. In the frontend, it looks fine, but in the editor, its normal colour is not added to the button.

**Actual Result:**

The button background colour is not applying properly. 

**Expected Result:** 

The button background colour must be applied properly. .

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
