### PR TITLE
AST-2740 - fix: double underline issue when text & title text decoration is set …

### DIFF
--- a/inc/assets/css/wp-editor-styles-rtl.css
+++ b/inc/assets/css/wp-editor-styles-rtl.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {

--- a/inc/assets/css/wp-editor-styles.css
+++ b/inc/assets/css/wp-editor-styles.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -610,10 +610,6 @@ class Astra_WP_Editor_CSS {
 			'text-decoration' => esc_attr( $site_title_decoration ),
 		);
 
-		$desktop_css['.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper'] = array(
-			'text-decoration' => esc_attr( $site_text_decoration ),
-		);
-
 		/**
 		 * Block editor experience improvements & fixes introduced with v4.0.0.
 		 */

--- a/sass/admin/wp-editor-styles.scss
+++ b/sass/admin/wp-editor-styles.scss
@@ -73,7 +73,6 @@ html {
 		padding: 0 !important;
 		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 		transition: all 0.2s;
-		text-decoration: none;
 		&:before {
 			width: 100%;
 			height: 100%;


### PR DESCRIPTION
…for page post title

### Description
<!-- Please describe what you have changed or added -->
Double underline issue in editor

JIRA - https://brainstormforce.atlassian.net/browse/AST-2740
### Screenshots
<!-- if applicable -->
https://d.pr/i/S6mOlj
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Bugfix: Text-decoration is applied twice to post title in editor
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Apply text font text decoration as underline.
- Apply title font text decoration as linethrough.
- Only title font text decoration should be applied.
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
