### PR TITLE
AST-2744 - fix: only title font should override the post/page title font size

### DIFF
--- a/inc/assets/css/wp-editor-styles-rtl.css
+++ b/inc/assets/css/wp-editor-styles-rtl.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {

--- a/inc/assets/css/wp-editor-styles.css
+++ b/inc/assets/css/wp-editor-styles.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -334,9 +334,8 @@ class Astra_WP_Editor_CSS {
 		// Site title (Page Title) on Block Editor.
 		$post_type                           = strval( get_post_type() );
 		$site_title_font_family              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-family', astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-family' ) );
-		$site_title_font_weight              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-weight', astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-weight' ) );
-		$site_title_font_size                = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-size' );
-		$site_title_font_size_fallback       = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-size', Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-size' ) );
+		$site_title_font_weight              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-weight', Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-weight' ) );
+		$site_title_font_size                = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-size', Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-size' ) );
 		$site_title_color                    = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-banner-title-color', astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-banner-text-color' ) );
 		$site_title_font_extras              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-extras' );
 		$site_text_decoration                = astra_get_font_extras( $site_title_font_extras, 'text-decoration' );
@@ -361,9 +360,6 @@ class Astra_WP_Editor_CSS {
 		}
 		if ( '' == $site_title_font_size ) {
 			$site_title_font_size = $site_title_font_size_fallback;
-		}
-		if ( '' === $site_title_font_size['desktop'] ) {
-			$font_size_desktop_fallback = Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-size' );
 		}
 
 		// check the selection color in-case of empty/no theme color.
@@ -601,7 +597,7 @@ class Astra_WP_Editor_CSS {
 		 * Desktop site title.
 		 */
 		$desktop_css['.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper > h1'] = array(
-			'font-size'       => astra_responsive_font( isset( $font_size_desktop_fallback ) ? $font_size_desktop_fallback : $site_title_font_size, 'desktop' ),
+			'font-size'       => astra_responsive_font( $site_title_font_size, 'desktop' ),
 			'font-weight'     => astra_get_css_value( $site_title_font_weight, 'font' ),
 			'font-family'     => astra_get_css_value( $site_title_font_family, 'font', $body_font_family ),
 			'text-transform'  => esc_attr( $site_title_text_transform ),

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -358,9 +358,6 @@ class Astra_WP_Editor_CSS {
 		if ( 'inherit' == $site_title_font_weight || '' == $site_title_font_weight ) {
 			$site_title_font_weight = Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-weight' );
 		}
-		if ( '' == $site_title_font_size ) {
-			$site_title_font_size = $site_title_font_size_fallback;
-		}
 
 		// check the selection color in-case of empty/no theme color.
 		$selection_text_color = ( 'transparent' === $highlight_theme_color ) ? '' : $highlight_theme_color;

--- a/sass/admin/wp-editor-styles.scss
+++ b/sass/admin/wp-editor-styles.scss
@@ -73,7 +73,6 @@ html {
 		padding: 0 !important;
 		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 		transition: all 0.2s;
-		text-decoration: none;
 		&:before {
 			width: 100%;
 			height: 100%;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Default single post title should override in editor

JIRA - https://brainstormforce.atlassian.net/browse/AST-2744
### Screenshots
<!-- if applicable -->
https://d.pr/v/cQAWEo

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
fix: Default single post title should override in editor
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Apply text font size from dynamic page/post title customizer.
- In editor, only the default typography font size should apply 32px.
- Set title font size it should apply correctly in editor.
- Same tests apply for font weight.
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
