### PR TITLE
AST-2743 - Padding & margin issues related to quote block.

### DIFF
--- a/inc/assets/css/wp-editor-styles-rtl.css
+++ b/inc/assets/css/wp-editor-styles-rtl.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {
@@ -461,7 +460,7 @@ pre.wp-block.wp-block-code {
 }
 
 .editor-styles-wrapper blockquote {
-  padding: 1.2em 1.2em 1.2em;
+  padding: 20px 20px 20px;
   margin: 1.5em;
   border: none;
 }

--- a/inc/assets/css/wp-editor-styles.css
+++ b/inc/assets/css/wp-editor-styles.css
@@ -236,7 +236,6 @@ html {
   padding: 0 !important;
   box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
   transition: all 0.2s;
-  text-decoration: none;
 }
 
 .edit-post-visual-editor__post-title-wrapper .title-visibility:before {
@@ -461,7 +460,7 @@ pre.wp-block.wp-block-code {
 }
 
 .editor-styles-wrapper blockquote {
-  padding: 1.2em 1.2em 1.2em;
+  padding: 20px 20px 20px;
   margin: 1.5em;
   border: none;
 }

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -633,6 +633,9 @@ class Astra_WP_Editor_CSS {
 			'margin-top'    => '1.5em',
 			'margin-bottom' => '1.5em',
 		);
+		$desktop_css['.editor-styles-wrapper .is-root-container .wp-block-quote > p']            = array(
+			'margin-top'    => '0',
+		);
 		$desktop_css['.editor-styles-wrapper .is-root-container .wp-block-image']            = array(
 			'margin-bottom' => '1em',
 		);

--- a/sass/admin/wp-editor-styles.scss
+++ b/sass/admin/wp-editor-styles.scss
@@ -73,7 +73,6 @@ html {
 		padding: 0 !important;
 		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 		transition: all 0.2s;
-		text-decoration: none;
 		&:before {
 			width: 100%;
 			height: 100%;
@@ -251,7 +250,7 @@ pre.wp-block {
 }
 .editor-styles-wrapper {
 	blockquote {
-		padding: 1.2em 1.2em 1.2em;
+		padding: 20px 20px 20px;
 		margin: 1.5em;
 		border: none;
 	}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Padding and margin mismatched for quote, Pullquote and blockquote

JIRA - https://brainstormforce.atlassian.net/browse/AST-2743
### Screenshots
<!-- if applicable -->
Frontend: [Annotation on 2022-12-21 at 17-36-35.png](https://d.pr/i/JzkQyI), Editor: [Annotation on 2022-12-21 at 17-37-06.png](https://d.pr/i/WvXcDo)
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Fix: Padding and margin mismatched for quote, Pullquote and blockquote
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check padding & margin in editor & frontend for Quote block & pullquote.
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
