### PR TITLE
AST-2774 - fix: top spacing breaks UI, therefore needs to be removed.

### DIFF
--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -66,7 +66,7 @@ jobs:
             # Ref: https://github.com/WordPress/gutenberg/issues/32784#issuecomment-866711815 -
             # once this issue is fixed the docker-compose command can probably be replaced with `wp-env` command.
             - name: Install Theme Check package
-              run: docker-compose -f $HOME/wp-env/$CONFIG_MD5/docker-compose.yml run -e WP_CLI_PACKAGES_DIR=.wp-cli --rm cli wp package install anhskohbo/wp-cli-themecheck:dev-master#a53732bf056ee446a4b975d20914d0469e16ea59
+              run: docker-compose -f $HOME/wp-env/$CONFIG_MD5/docker-compose.yml run -e WP_CLI_PACKAGES_DIR=.wp-cli --rm cli wp package install imnavanath/wp-cli-themecheck:dev-master#f168950bafe8d50c000caff550373d812f9c7443
 
             # wp-ev currently ignores extra parameters passed to the commands, eg --version and --activate - https://github.com/WordPress/gutenberg/issues/32929
             # Latest version of themecheck action throws fatal errors with latest version of theme-check plugin - https://github.com/anhskohbo/wp-cli-themecheck/issues/6 - Once this is fixed the we can use latest version of the plugin.

--- a/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/woo-cart/dynamic-css/dynamic.css.php
@@ -275,7 +275,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 			$css_output_desktop['.ast-desktop .astra-cart-drawer.open-right']        = array(
 				'width' => astra_get_css_value( $flyout_cart_width_desktop, $flyout_cart_width_desktop_unit ),
 				'left'  => '-' . astra_get_css_value( $flyout_cart_width_desktop, $flyout_cart_width_desktop_unit ),
-			); 
+			);
 			$css_output_desktop['.ast-desktop .astra-cart-drawer.open-right.active'] = array(
 				'left' => astra_get_css_value( $flyout_cart_width_desktop, $flyout_cart_width_desktop_unit ),
 			);
@@ -411,7 +411,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 
 		/**
 		* Tablet flyout cart width.
-		*/      
+		*/
 		$responsive_selector . '.active'                   => array(
 			'width' => astra_get_css_value( $flyout_cart_width_tablet, $flyout_cart_width_tablet_unit ),
 		),
@@ -448,11 +448,11 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 
 	if ( 'none' !== $header_cart_icon_style ) {
 
-		
+
 		if ( ! astra_has_pro_woocommerce_addon() && 'outline' === $header_cart_icon_style && 'default' !== $header_woo_cart_list ) {
 
 			$border_width = astra_get_option( 'woo-header-cart-border-width' );
-			
+
 			$header_cart_icon_outline = array(
 				'.ast-menu-cart-outline .ast-cart-menu-wrap .count, .ast-menu-cart-outline .ast-addon-cart-wrap'  => array(
 					'border-style' => 'solid',
@@ -486,7 +486,7 @@ function astra_hb_woo_cart_dynamic_css( $dynamic_css, $dynamic_css_filtered = ''
 			),
 
 		);
-		
+
 		// We adding this conditional CSS only to maintain backwards. Remove this condition after 2-3 updates of add-on.
 		if ( defined( 'ASTRA_EXT_VER' ) && version_compare( ASTRA_EXT_VER, '3.4.2', '<' ) ) {
 			// Outline cart style border.

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -504,11 +504,6 @@ function astra_load_modern_block_editor_ui( $dynamic_css ) {
 	// Block editor experience improvements introduced with v4.0.0.
 	if ( $v4_block_editor_compat ) {
 		$dynamic_css .= '
-			@media(max-width: ' . $tablet_breakpoint . 'px) {	
-				.ast-plain-container .site-main .entry-header {
-					margin-top: 1.5em;
-				}
-			}
 			.entry-content ul, .entry-content ol {
 				padding: revert;
 				margin: revert;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Margin top for entry header breaks preview design on responsive screens. It was earlier introduced during block editor improvements fix to match tablet view header in editor. But due to the top spacing breaking design, we need to revert the fix.

JIRA - https://brainstormforce.atlassian.net/browse/AST-2774
### Screenshots
<!-- if applicable -->
https://share.bsf.io/llugNy8y
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- bugfix: remove CSS breaking UI
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Steps to replicate:
- Get site reset / fresh setup
- Will get wp-preview templates in customizer
- Make it active-n-publish
- Check on frontend with responsive view.


### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
