### PR TITLE
AST-2784 - fix: remove color dependency for page title

### DIFF
--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -335,7 +335,6 @@ class Astra_WP_Editor_CSS {
 		$site_title_font_weight              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-weight', astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-weight' ) );
 		$site_title_font_size                = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-size' );
 		$site_title_font_size_fallback       = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-size', Astra_Posts_Structure_Loader::get_customizer_default( 'title-font-size' ) );
-		$site_title_color                    = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-banner-title-color', astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-banner-text-color' ) );
 		$site_title_font_extras              = astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-text-font-extras' );
 		$site_text_decoration                = astra_get_font_extras( $site_title_font_extras, 'text-decoration' );
 		$site_title_text_transform           = astra_get_font_extras( astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras', $site_title_font_extras ), 'text-transform' );
@@ -597,7 +596,6 @@ class Astra_WP_Editor_CSS {
 			'font-weight'     => astra_get_css_value( $site_title_font_weight, 'font' ),
 			'font-family'     => astra_get_css_value( $site_title_font_family, 'font', $body_font_family ),
 			'text-transform'  => esc_attr( $site_title_text_transform ),
-			'color'           => esc_attr( $site_title_color ),
 			'letter-spacing'  => esc_attr( $site_title_spacing ),
 			'text-decoration' => esc_attr( $site_title_decoration ),
 		);


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Removing color dependency from editor page title.
- JIRA - https://brainstormforce.atlassian.net/browse/AST-2784
### Screenshots
<!-- if applicable -->
https://d.pr/v/nbWbAJ
### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
bugfix - Removing color dependency from editor page title.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Choose banner 2 in dynamic page title.
- Set bg color to any dark color.
- Choose white color for Title Color.
- Check in editor, color should be default (black) in all cases.
### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
