### PR TITLE
AST-2856 - Archive type title gets added as prefix on archive pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.0.1 (Unreleased)
+- Fix: Archive type title gets added as prefix on archive pages.
+
 v4.0.0
 - New: Redesigned the entire admin area with better user experience. ( https://wpastra.com/updates/astra-4 )
 - New: Narrow Width Container layout for Single Posts, Blogs/Archives & Pages. ( https://wpastra.com/docs/narrow-width-container-layout/ )

--- a/inc/core/common-functions.php
+++ b/inc/core/common-functions.php
@@ -947,7 +947,9 @@ function astra_get_taxonomy_banner_legacy_layout() {
 				switch ( $meta_key ) {
 					case 'archive-title':
 						do_action( 'astra_before_archive_title' );
+						add_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
 						the_archive_title( '<h1 class="page-title ast-archive-title">', '</h1>' );
+						remove_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
 						do_action( 'astra_after_archive_title' );
 						break;
 					case 'archive-breadcrumb':


### PR DESCRIPTION
### Description
- Category/Tag like archive titles gets added as prefix on archive page titles as used core function `the_archive_title` for that.

### Screenshots
- https://d.pr/i/RjFLPe

### Types of changes
- Bug fix (non-breaking change)

### How has this been tested?
- Switch to 3.9.4 version you will get only title of your taxonomy like this - https://share.getcloudapp.com/OAu22Egx
- Once switch to master (released version) will get this - https://share.getcloudapp.com/d5uyyxwE
- With this branch this should be resolve, there should not be any prefix.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
