### PR TITLE
AST-2863 - Deprecated: Filter 'astra_single_banner_post_meta' for single post meta markup has been deprecated instead use 'astra_single_post_meta'

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.0.2 (Unreleased)
+- Deprecated: Filter 'astra_single_banner_post_meta' for single post meta markup has been deprecated instead use 'astra_single_post_meta'.
+
 v4.0.1
 - Improvement: Introducing filter 'astra_dynamic_get_post_types_query_args' for getting post types list to load further dynamic sections in customizer.
 - Fix: Header Builder - Visibility control options missing from header sections & respective element sections.

--- a/inc/blog/blog.php
+++ b/inc/blog/blog.php
@@ -461,7 +461,7 @@ function astra_banner_elements_order( $structure = array() ) {
 				if ( ! empty( $post_meta ) ) {
 					$output_str = astra_get_post_meta( $post_meta );
 					if ( ! empty( $output_str ) ) {
-						$output = apply_filters( 'astra_single_banner_post_meta', '<div class="entry-meta">' . $output_str . '</div>' ); // WPCS: XSS OK.
+						$output = apply_filters( 'astra_single_post_meta', '<div class="entry-meta">' . $output_str . '</div>' ); // WPCS: XSS OK.
 					}
 				}
 				echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/blog/single-blog.php
+++ b/inc/blog/single-blog.php
@@ -73,40 +73,6 @@ if ( ! function_exists( 'astra_single_post_class' ) ) {
 add_filter( 'post_class', 'astra_single_post_class' );
 
 /**
- * Prints HTML with meta information for the current post-date/time and author.
- */
-if ( ! function_exists( 'astra_single_get_post_meta' ) ) {
-
-	/**
-	 * Prints HTML with meta information for the current post-date/time and author.
-	 *
-	 * @param boolean $echo   Output print or return.
-	 * @return string|void
-	 */
-	function astra_single_get_post_meta( $echo = true ) {
-
-		$enable_meta       = apply_filters( 'astra_single_post_meta_enabled', '__return_true' );
-		$current_post_type = strval( get_post_type() );
-		$post_meta         = astra_get_option( 'ast-dynamic-single-' . esc_attr( $current_post_type ) . '-metadata', array( 'comments', 'author', 'date' ) );
-		$post_type_array   = apply_filters( 'astra_single_post_type_meta', Astra_Posts_Structure_Loader::get_supported_post_types() );
-
-		$output = '';
-		if ( is_array( $post_meta ) && ( in_array( $current_post_type, $post_type_array ) || 'attachment' == $current_post_type ) && $enable_meta ) {
-
-			$output_str = astra_get_post_meta( $post_meta );
-			if ( ! empty( $output_str ) ) {
-				$output = apply_filters( 'astra_single_post_meta', '<div class="entry-meta">' . $output_str . '</div>', $output_str ); // WPCS: XSS OK.
-			}
-		}
-		if ( $echo ) {
-			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		} else {
-			return $output;
-		}
-	}
-}
-
-/**
  * Template for comments and pingbacks.
  */
 if ( ! function_exists( 'astra_theme_comment' ) ) {

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -186,8 +186,8 @@ add_filter( 'astra_single_post_meta', 'astra_deprecated_astra_single_banner_post
  * Single meta markup filter.
  *
  * @since x.x.x
- * @param string $meta_markup custom class assigned to primary submenu.
- * @return string  $meta_markup updated class selector.
+ * @param string $meta_markup Markup of meta.
+ * @return string  $meta_markup Markup of meta.
  */
 function astra_deprecated_astra_single_banner_post_meta_filter( $meta_markup ) {
 	$meta_markup = astra_apply_filters_deprecated( 'astra_single_banner_post_meta', array( $meta_markup ), 'x.x.x', 'astra_single_post_meta', '' );

--- a/inc/core/deprecated/deprecated-filters.php
+++ b/inc/core/deprecated/deprecated-filters.php
@@ -178,3 +178,18 @@ function astra_deprecated_primary_submenu_border_class_filter( $class_selector )
 
 	return $class_selector;
 }
+
+// Deprecating astra_single_banner_post_meta filter.
+add_filter( 'astra_single_post_meta', 'astra_deprecated_astra_single_banner_post_meta_filter', 10, 1 );
+
+/**
+ * Single meta markup filter.
+ *
+ * @since x.x.x
+ * @param string $meta_markup custom class assigned to primary submenu.
+ * @return string  $meta_markup updated class selector.
+ */
+function astra_deprecated_astra_single_banner_post_meta_filter( $meta_markup ) {
+	$meta_markup = astra_apply_filters_deprecated( 'astra_single_banner_post_meta', array( $meta_markup ), 'x.x.x', 'astra_single_post_meta', '' );
+	return $meta_markup;
+}

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -1357,7 +1357,7 @@ if ( ! function_exists( 'astra_entry_header_class' ) ) {
 		$classes          = array();
 		$title_markup     = astra_the_title( '', '', $post_id, false );
 		$thumb_markup     = astra_get_post_thumbnail( '', '', false );
-		$post_meta_markup = astra_single_get_post_meta( false );
+		$post_meta_markup = astra_get_post_meta( astra_get_option( 'ast-dynamic-single-' . $post_type . '-metadata', array( 'comments', 'author', 'date' ) ) );
 		$single_structure = 'page' === $post_type ? astra_get_option( 'ast-dynamic-single-page-structure', array( 'ast-dynamic-single-page-image', 'ast-dynamic-single-page-title' ) ) : astra_get_option( 'ast-dynamic-single-' . esc_attr( $post_type ) . '-structure', array( 'ast-dynamic-single-' . $post_type . '-title', 'ast-dynamic-single-' . $post_type . '-meta' ) );
 
 		if ( empty( $single_structure ) ) {


### PR DESCRIPTION
### Description
- Issue reported - https://wordpress.org/support/topic/replacement-for-astra_single_post_meta/

### Screenshots
<!-- if applicable -->

### Types of changes
- Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
