### PR TITLE
AST-2864 - Text transformed to 'capitalize' for single post titles & archive titles after 4.0.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.0.2(Unreleased)
+- Fix: Text transformed to 'capitalize' for single post titles & archive titles after 4.0.0.
+
 v4.0.1
 - Improvement: Introducing filter 'astra_dynamic_get_post_types_query_args' for getting post types list to load further dynamic sections in customizer.
 - Fix: Header Builder - Visibility control options missing from header sections & respective element sections.

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -876,7 +876,7 @@ function astra_theme_background_updater_4_0_0() {
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$archive_dynamic_text_transform = ! empty( $theme_options['text-transform-archive-summary-title'] ) ? $theme_options['text-transform-archive-summary-title'] : 'capitalize';
+			$archive_dynamic_text_transform = ! empty( $theme_options['text-transform-archive-summary-title'] ) ? $theme_options['text-transform-archive-summary-title'] : '';
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			$theme_options[ 'ast-dynamic-archive-' . esc_attr( $post_type ) . '-title-font-extras' ] = array(
@@ -920,7 +920,7 @@ function astra_theme_background_updater_4_0_0() {
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$single_dynamic_text_transform = ! empty( $theme_options['text-transform-entry-title'] ) ? $theme_options['text-transform-entry-title'] : 'capitalize';
+			$single_dynamic_text_transform = ! empty( $theme_options['text-transform-entry-title'] ) ? $theme_options['text-transform-entry-title'] : '';
 			/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			$theme_options[ 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras' ] = array(


### PR DESCRIPTION
### Description
- Text gets transforms after 4.0 for single title & archive title

### Screenshots
<!-- if applicable -->

### Types of changes
- Bug fix (non-breaking change)

### How has this been tested?
- v3.9.4 version https://share.getcloudapp.com/lluggqAz
- Reset the customizer, you will get above layout by default
- Now switched to master while processing batch the update it gets transformed to 'capitalize' - https://share.getcloudapp.com/yAuAAOep
- For already updated user they have option to make it disable from Title area as I suggested here - https://brainstormforce.slack.com/archives/CDS7TQ75Z/p1673844330438709?thread_ts=1673740912.844489&cid=CDS7TQ75Z
- But those who will update from v3.9.4 will not get this issue in this branch

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
