### PR TITLE
AST-2861 - exclude_from_search query param removed for getting post types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v4.0.2 (Unreleased)
+- Fix: exclude_from_search query parameter removed from get_post_types list to get CPTs under Customizer > Custom Post Types  section, case of CartFlows Step custom post type.
+- Fix: Archive - Title area 2 - Archive type title gets added as prefix on archive pages.
+
 v4.0.1
 - Improvement: Introducing filter 'astra_dynamic_get_post_types_query_args' for getting post types list to load further dynamic sections in customizer.
 - Fix: Header Builder - Visibility control options missing from header sections & respective element sections.

--- a/inc/blog/blog.php
+++ b/inc/blog/blog.php
@@ -480,11 +480,13 @@ function astra_banner_elements_order( $structure = array() ) {
 
 			case 'archive-title':
 				do_action( 'astra_blog_archive_title_before' );
+				add_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
 				if ( 'layout-1' === $layout_type ) {
 					astra_the_post_title( '<h1 class="page-title ast-archive-title">', '</h1>', 0, true );
 				} else {
 					astra_the_post_title( '<h1>', '</h1>', 0, true );
 				}
+				remove_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
 				do_action( 'astra_blog_archive_title_after' );
 				break;
 

--- a/inc/modules/posts-structures/class-astra-posts-structure-loader.php
+++ b/inc/modules/posts-structures/class-astra-posts-structure-loader.php
@@ -227,11 +227,10 @@ class Astra_Posts_Structure_Loader {
 				apply_filters(
 					'astra_dynamic_get_post_types_query_args',
 					array(
-						'public'              => true,
-						'_builtin'            => false,
-						'exclude_from_search' => false,
+						'public'   => true,
+						'_builtin' => false,
 					)
-				) 
+				)
 			)
 		);
 


### PR DESCRIPTION
### Description
- Case: cartflows_step CPT is not getting listed under custom post types in customizer
- Which leads in unable to handle title frontend for it

### Screenshots
- https://share.getcloudapp.com/lluggrbQ

### Types of changes
- Bug fix (non-breaking change)

### How has this been tested?
- As per listed data on card

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
