### PR TITLE
AST-2959 - Single post title transformed to capitalize after 4.0 update.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ v4.1.0 (Unreleased)
 - Fix: Footer Menu Alignment issue for responsive devices.
 - Fix: Inside container spacing for single posts affecting the related posts section.
 - Fix: PHP error 'Uncaught TypeError: ltrim()' for getting taxonomy term link.
+- Fix: Single post title transformed to capitalize after 4.0 update.
 
 v4.0.2
 - Deprecated: Filter 'astra_single_banner_post_meta' for single post meta markup has been deprecated instead use 'astra_single_post_meta'.

--- a/inc/blog/single-blog.php
+++ b/inc/blog/single-blog.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'astra_single_post_class' ) ) {
 		// Blog layout.
 		if ( is_singular() ) {
 
-			if ( !in_array('ast-related-post', $classes)) {
+			if ( ! in_array( 'ast-related-post', $classes ) ) {
 				$classes[] = 'ast-article-single';
 			}
 

--- a/inc/builder/type/footer/menu/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/menu/dynamic-css/dynamic.css.php
@@ -167,11 +167,11 @@ function astra_hb_footer_menu_dynamic_css( $dynamic_css, $dynamic_css_filtered =
 	$css_output_tablet = array(
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-tablet-horizontal-menu' => array(
 			'justify-content' => $tablet_alignment,
-			'display' => 'flex'
+			'display'         => 'flex',
 		),
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-tablet-vertical-menu' => array(
-			'display' => 'grid',
-			'justify-content'  => $tablet_alignment
+			'display'         => 'grid',
+			'justify-content' => $tablet_alignment,
 		),
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-tablet-vertical-menu .menu-item' => array(
 			'align-items' => $tablet_alignment,
@@ -209,11 +209,11 @@ function astra_hb_footer_menu_dynamic_css( $dynamic_css, $dynamic_css_filtered =
 		$selector                                       => astra_get_responsive_background_obj( $menu_resp_bg_color, 'mobile' ),
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-mobile-horizontal-menu' => array(
 			'justify-content' => $mobile_alignment,
-			'display' => 'flex'
+			'display'         => 'flex',
 		),
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-mobile-vertical-menu' => array(
-			'display' => 'grid',
-			'justify-content'  => $mobile_alignment
+			'display'         => 'grid',
+			'justify-content' => $mobile_alignment,
 		),
 		'.footer-widget-area[data-section="section-footer-menu"] .astra-footer-mobile-vertical-menu .menu-item' => array(
 			'align-items' => $mobile_alignment,

--- a/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/footer/widget/dynamic-css/dynamic.css.php
@@ -90,10 +90,10 @@ function astra_fb_widget_dynamic_css( $dynamic_css, $dynamic_css_filtered = '' )
 	if ( astra_support_footer_widget_right_margin() && ! is_customize_preview() ) {
 		$footer_area_css_output = array(
 			'.footer-widget-area.widget-area.site-footer-focus-item' => array(
-				'width' => 'auto'
+				'width' => 'auto',
 			),
 		);
-		$dynamic_css .= astra_parse_css( $footer_area_css_output );
+		$dynamic_css           .= astra_parse_css( $footer_area_css_output );
 	}
 
 	$dynamic_css .= Astra_Widget_Component_Dynamic_CSS::astra_widget_dynamic_css( 'footer' );

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -3268,7 +3268,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 		 * @since 3.9.0
 		 */
 		public function astra_update_flyout_cart_layout() {
-			if ( WC()->cart->is_empty() && 'flyout' === astra_get_option( 'woo-header-cart-click-action' ) ) {
+			if ( WC()->cart->is_empty() ) {
 				do_action( 'astra_empty_cart_before' );
 				?>
 					<div class="ast-mini-cart-empty">

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -616,7 +616,7 @@ class Astra_WP_Editor_CSS {
 		);
 
 		$desktop_css['.wp-block-table figcaption'] = array(
-			'text-align'   => esc_attr( $ltr_left ),
+			'text-align' => esc_attr( $ltr_left ),
 		);
 
 		$content_links_underline = astra_get_option( 'underline-content-links' );

--- a/inc/dynamic-css/block-editor-compatibility.php
+++ b/inc/dynamic-css/block-editor-compatibility.php
@@ -180,14 +180,14 @@ function astra_block_editor_compatibility_css( $dynamic_css ) {
  * @since 3.8.0
  */
 function astra_load_modern_block_editor_ui( $dynamic_css ) {
-	$dynamic_css                .= astra_get_block_editor_required_css();
-	$ltr_left                   = is_rtl() ? 'right' : 'left';
-	$ltr_right                  = is_rtl() ? 'left' : 'right';
-	$astra_block_editor_v2_ui   = astra_get_option( 'wp-blocks-v2-ui', true );
-	$ast_container_width        = astra_get_option( 'site-content-width', 1200 ) . 'px';
-	$blocks_spacings            = Astra_WP_Editor_CSS::astra_get_block_spacings();
-	$list_blocks_space          = astra_get_option( 'list-blocks-spacing', true );
-	$exclude_uagb_selector      = defined( 'UAGB_VER' ) ? ':not(.wp-block-uagb-container)' : '';
+	$dynamic_css             .= astra_get_block_editor_required_css();
+	$ltr_left                 = is_rtl() ? 'right' : 'left';
+	$ltr_right                = is_rtl() ? 'left' : 'right';
+	$astra_block_editor_v2_ui = astra_get_option( 'wp-blocks-v2-ui', true );
+	$ast_container_width      = astra_get_option( 'site-content-width', 1200 ) . 'px';
+	$blocks_spacings          = Astra_WP_Editor_CSS::astra_get_block_spacings();
+	$list_blocks_space        = astra_get_option( 'list-blocks-spacing', true );
+	$exclude_uagb_selector    = defined( 'UAGB_VER' ) ? ':not(.wp-block-uagb-container)' : '';
 
 	/** @psalm-suppress InvalidCast */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	$tablet_breakpoint = (string) astra_get_tablet_breakpoint();

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -1127,6 +1127,7 @@ function astra_theme_background_updater_4_1_0() {
 			foreach ( $post_types as $index => $post_type ) {
 				$theme_options[ 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras' ]['text-transform'] = '';
 			}
+			update_option( 'astra-settings', $theme_options );
 		}
 	}
 }

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -1021,103 +1021,112 @@ function astra_theme_background_updater_4_1_0() {
 
 	$theme_options = get_option( 'astra-settings', array() );
 
-	$current_payment_list = array();
-	$old_payment_list     = isset( $theme_options['single-product-payment-list']['items'] ) ? $theme_options['single-product-payment-list']['items'] : array();
+	if ( ! isset( $theme_options['v4-1-0-update-migration'] ) ) {
+		$theme_options['v4-1-0-update-migration'] = true;
+		$current_payment_list = array();
+		$old_payment_list     = isset( $theme_options['single-product-payment-list']['items'] ) ? $theme_options['single-product-payment-list']['items'] : array();
 
-	$visa_payment       = isset( $theme_options['single-product-payment-visa'] ) ? $theme_options['single-product-payment-visa'] : '';
-	$mastercard_payment = isset( $theme_options['single-product-payment-mastercard'] ) ? $theme_options['single-product-payment-mastercard'] : '';
-	$amex_payment       = isset( $theme_options['single-product-payment-amex'] ) ? $theme_options['single-product-payment-amex'] : '';
-	$discover_payment   = isset( $theme_options['single-product-payment-discover'] ) ? $theme_options['single-product-payment-discover'] : '';
-	$paypal_payment     = isset( $theme_options['single-product-payment-paypal'] ) ? $theme_options['single-product-payment-paypal'] : '';
-	$apple_pay_payment  = isset( $theme_options['single-product-payment-apple-pay'] ) ? $theme_options['single-product-payment-apple-pay'] : '';
+		$visa_payment       = isset( $theme_options['single-product-payment-visa'] ) ? $theme_options['single-product-payment-visa'] : '';
+		$mastercard_payment = isset( $theme_options['single-product-payment-mastercard'] ) ? $theme_options['single-product-payment-mastercard'] : '';
+		$discover_payment   = isset( $theme_options['single-product-payment-discover'] ) ? $theme_options['single-product-payment-discover'] : '';
+		$paypal_payment     = isset( $theme_options['single-product-payment-paypal'] ) ? $theme_options['single-product-payment-paypal'] : '';
+		$apple_pay_payment  = isset( $theme_options['single-product-payment-apple-pay'] ) ? $theme_options['single-product-payment-apple-pay'] : '';
 
-	false !== $visa_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-100',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-visa',
-			'image'   => '',
-			'label'   => __( 'Visa', 'astra' ),
-		)
-	) : '';
+		false !== $visa_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-100',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-visa',
+				'image'   => '',
+				'label'   => __( 'Visa', 'astra' ),
+			)
+		) : '';
 
-	false !== $mastercard_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-101',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-mastercard',
-			'image'   => '',
-			'label'   => __( 'Mastercard', 'astra' ),
-		)
-	) : '';
+		false !== $mastercard_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-101',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-mastercard',
+				'image'   => '',
+				'label'   => __( 'Mastercard', 'astra' ),
+			)
+		) : '';
 
-	false !== $mastercard_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-102',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-amex',
-			'image'   => '',
-			'label'   => __( 'Amex', 'astra' ),
-		)
-	) : '';
+		false !== $mastercard_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-102',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-amex',
+				'image'   => '',
+				'label'   => __( 'Amex', 'astra' ),
+			)
+		) : '';
 
-	false !== $discover_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-103',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-discover',
-			'image'   => '',
-			'label'   => __( 'Discover', 'astra' ),
-		)
-	) : '';
+		false !== $discover_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-103',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-discover',
+				'image'   => '',
+				'label'   => __( 'Discover', 'astra' ),
+			)
+		) : '';
 
-	$paypal_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-104',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-paypal',
-			'image'   => '',
-			'label'   => __( 'Paypal', 'astra' ),
-		)
-	) : '';
+		$paypal_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-104',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-paypal',
+				'image'   => '',
+				'label'   => __( 'Paypal', 'astra' ),
+			)
+		) : '';
 
-	$apple_pay_payment ? array_push(
-		$current_payment_list,
-		array(
-			'id'      => 'item-105',
-			'enabled' => true,
-			'source'  => 'icon',
-			'icon'    => 'cc-apple-pay',
-			'image'   => '',
-			'label'   => __( 'Apple Pay', 'astra' ),
-		)
-	) : '';
+		$apple_pay_payment ? array_push(
+			$current_payment_list,
+			array(
+				'id'      => 'item-105',
+				'enabled' => true,
+				'source'  => 'icon',
+				'icon'    => 'cc-apple-pay',
+				'image'   => '',
+				'label'   => __( 'Apple Pay', 'astra' ),
+			)
+		) : '';
 
-	if ( $current_payment_list ) {
-		$theme_options['single-product-payment-list'] =
-		array(
-			'items' =>
-				array_merge(
-					$current_payment_list,
-					$old_payment_list
-				),
-		);
+		if ( $current_payment_list ) {
+			$theme_options['single-product-payment-list'] =
+			array(
+				'items' =>
+					array_merge(
+						$current_payment_list,
+						$old_payment_list
+					),
+			);
 
-		update_option( 'astra-settings', $theme_options );
-	}
+			update_option( 'astra-settings', $theme_options );
+		}
 
-	if ( ! isset( $theme_options['woo-global-h2-flag'] ) ) {
-		$theme_options['woo-global-h2-flag'] = true;
-		update_option( 'astra-settings', $theme_options );
+		if ( ! isset( $theme_options['woo-global-h2-flag'] ) ) {
+			$theme_options['woo-global-h2-flag'] = true;
+			update_option( 'astra-settings', $theme_options );
+		}
+
+		if ( isset( $theme_options['theme-dynamic-customizer-support'] ) ) {
+			$post_types = Astra_Posts_Structure_Loader::get_supported_post_types();
+			foreach ( $post_types as $index => $post_type ) {
+				$theme_options[ 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras' ][ 'text-transform' ] = '';
+			}
+		}
 	}
 }

--- a/inc/theme-update/astra-update-functions.php
+++ b/inc/theme-update/astra-update-functions.php
@@ -1023,8 +1023,8 @@ function astra_theme_background_updater_4_1_0() {
 
 	if ( ! isset( $theme_options['v4-1-0-update-migration'] ) ) {
 		$theme_options['v4-1-0-update-migration'] = true;
-		$current_payment_list = array();
-		$old_payment_list     = isset( $theme_options['single-product-payment-list']['items'] ) ? $theme_options['single-product-payment-list']['items'] : array();
+		$current_payment_list                     = array();
+		$old_payment_list                         = isset( $theme_options['single-product-payment-list']['items'] ) ? $theme_options['single-product-payment-list']['items'] : array();
 
 		$visa_payment       = isset( $theme_options['single-product-payment-visa'] ) ? $theme_options['single-product-payment-visa'] : '';
 		$mastercard_payment = isset( $theme_options['single-product-payment-mastercard'] ) ? $theme_options['single-product-payment-mastercard'] : '';
@@ -1125,7 +1125,7 @@ function astra_theme_background_updater_4_1_0() {
 		if ( isset( $theme_options['theme-dynamic-customizer-support'] ) ) {
 			$post_types = Astra_Posts_Structure_Loader::get_supported_post_types();
 			foreach ( $post_types as $index => $post_type ) {
-				$theme_options[ 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras' ][ 'text-transform' ] = '';
+				$theme_options[ 'ast-dynamic-single-' . esc_attr( $post_type ) . '-title-font-extras' ]['text-transform'] = '';
 			}
 		}
 	}


### PR DESCRIPTION
### Description
- When we released 4.0 at that time users were faced this issue where post title case was switched to capitalize. 
- In 4.0.2 we fixed this issue but for users who will jump from 3.9.4 directly (by considering we are not getting much ticket, and users have option so they can adjust it)
- But as we are still getting those tickets planning to release patch for this.

### Screenshots
- https://share.getcloudapp.com/wbuvlXZ0

### Types of changes
- Bug fix

### How has this been tested?
- There should not be any change in font case

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
