### PR TITLE
AST-3015 - Toggle button radius not working for tablet

### DIFF
--- a/inc/builder/type/header/mobile-trigger/dynamic-css/dynamic.css.php
+++ b/inc/builder/type/header/mobile-trigger/dynamic-css/dynamic.css.php
@@ -179,7 +179,7 @@ function astra_mobile_trigger_row_setting( $dynamic_css, $dynamic_css_filtered =
 			);
 			$dynamic_css              .= astra_parse_css( $css_output_outline );
 			$dynamic_css              .= astra_parse_css( $css_output_outline_tablet, '', astra_get_tablet_breakpoint() );
-			$dynamic_css              .= astra_parse_css( $css_output_outline_mobile, '', astra_get_tablet_breakpoint() );
+			$dynamic_css              .= astra_parse_css( $css_output_outline_mobile, '', astra_get_mobile_breakpoint() );
 			if ( false === $is_customizer ) {
 				break;
 			}


### PR DESCRIPTION
### Description
- Toggle: border radius is not working on frontend for tablet

### Screenshots
- https://d.pr/i/EyhXu0

### Types of changes
- Bug fix

### How has this been tested?
- Header builder - Toggle
- Select outline style for toggle
- Assign border radius for all devices 
- Check the result on the frontend

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
