### PR TITLE
AST-2720 - Introduced new filter to remove gmpg link from link profile

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
-v4.1.1 (Unreleased)
+v4.2.0 (Unreleased)
+- Improvement: Introduced filter 'astra_show_header_profile_gmpg_link' to remove gmpg link from webpage for GDPR.
 - Fix: Customizer - Double border top applied on above footer preview.
 
 v4.1.0 (Unreleased)

--- a/header.php
+++ b/header.php
@@ -21,8 +21,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php astra_head_top(); ?>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="profile" href="https://gmpg.org/xfn/11">
-
+<?php if ( apply_filters( 'astra_header_profile_gmpg_link', true ) ) {
+	?> <link rel="profile" href="https://gmpg.org/xfn/11"> <?php
+} ?>
 <?php wp_head(); ?>
 <?php astra_head_bottom(); ?>
 </head>


### PR DESCRIPTION
### Description
- Introduced new filter to remove gmpg link from link profile
- GitHub reported issue - https://github.com/brainstormforce/astra/issues/4172

### Screenshots
- Without filter (normal webpage) - https://share.getcloudapp.com/5zuj7gA1
- With disabling filter - https://share.getcloudapp.com/eDurYW8P

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
```
add_filter( 'astra_header_profile_gmpg_link', '__return_false' );
```
- With this filter the link tag should disappear

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
