### PR TITLE
AST-3079 - fix: Related post title font size not working in mobile & tablet.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.1.1
+- Fix: Related Post Title Font Size Not Working in Responsive mode.
+
 v4.1.0
 - New: Accessibility options to change color and style of highlighted element. ( https://wpastra.com/docs/accessibility-controls/ )
 - New: WooCommerce - Shop - Introducing new redirect actions on add to cart click. ( https://wpastra.com/docs/introducing-new-add-to-cart-trigger-actions-for-shop-and-single-product-pages/ )

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 v4.1.1
-- Fix: Related Post Title Font Size Not Working in Responsive mode.
+- Fix: Single Post - Related Post Title Font Size is not working for responsive devices.
 
 v4.1.0
 - New: Accessibility options to change color and style of highlighted element. ( https://wpastra.com/docs/accessibility-controls/ )

--- a/inc/modules/related-posts/css/dynamic-css.php
+++ b/inc/modules/related-posts/css/dynamic-css.php
@@ -138,7 +138,7 @@ function astra_related_posts_css( $dynamic_css ) {
 			'.ast-single-related-posts-container .ast-related-posts-wrapper' => array(
 				'grid-template-columns' => Astra_Builder_Helper::$grid_size_mapping[ $tablet_grid ],
 			),
-			'.ast-related-post-content .ast-related-post-title' => array(
+			'.ast-related-post-content .entry-header .ast-related-post-title, .ast-related-post-content .entry-header .ast-related-post-title a' => array(
 				'font-size' => astra_responsive_font( $related_post_title_font_size, 'tablet' ),
 			),
 			'.ast-related-post-content .entry-meta *' => array(
@@ -168,7 +168,7 @@ function astra_related_posts_css( $dynamic_css ) {
 			'.ast-single-related-posts-container .ast-related-posts-wrapper' => array(
 				'grid-template-columns' => Astra_Builder_Helper::$grid_size_mapping[ $mobile_grid ],
 			),
-			'.ast-related-post-content .ast-related-post-title' => array(
+			'.ast-related-post-content .entry-header .ast-related-post-title, .ast-related-post-content .entry-header .ast-related-post-title a' => array(
 				'font-size' => astra_responsive_font( $related_post_title_font_size, 'mobile' ),
 			),
 			'.ast-related-post-content .entry-meta *' => array(


### PR DESCRIPTION
**Description** - 
The Related Post Title Font Size does not work in the responsive mode. It seems to be working in the customizer but nothing happens on the front end.

**How to reproduce:**
Enable the related posts
From the design tab, try changing the related posts title font for mobile/tablet devices.
Changes are reflected in the customizer
Publish the changes and check the frontend. Font size is not changed on the front.

**Refer to the screencast:** 
https://d.pr/v/RVvCwK

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
