### PR TITLE
AST-3116 - Fix: Dropdown arrow is disable when updated to latest version.

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -419,7 +419,7 @@ function astra_dropdown_icon_to_menu_link( $title, $item, $args, $depth ) {
 		$icon = Astra_Icons::get_icons( 'arrow' );
 	}
 	$custom_tabindex  = true === Astra_Builder_Helper::$is_header_footer_builder_active ? 'tabindex="0"' : '';
-	$astra_arrow_icon = ( ! defined( 'ASTRA_EXT_VER' ) && ( true === Astra_Builder_Helper::$is_header_footer_builder_active || Astra_Icons::is_svg_icons() ) ) ? '<span role="' . esc_attr( $role ) . '" class="dropdown-menu-toggle ast-header-navigation-arrow" ' . $custom_tabindex . ' aria-expanded="false" aria-label="' . esc_attr__( 'Menu Toggle', 'astra' ) . '" >' . $icon . '</span>' : '';
+	$astra_arrow_icon = ( ( true === Astra_Builder_Helper::$is_header_footer_builder_active || Astra_Icons::is_svg_icons() ) ) ? '<span role="' . esc_attr( $role ) . '" class="dropdown-menu-toggle ast-header-navigation-arrow" ' . $custom_tabindex . ' aria-expanded="false" aria-label="' . esc_attr__( 'Menu Toggle', 'astra' ) . '" >' . $icon . '</span>' : '';
 
 	foreach ( $item->classes as $value ) {
 		if ( 'menu-item-has-children' === $value ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Dropdown arrow is disable when updated to latest version

### Screenshots
<!-- if applicable -->
https://d.pr/v/azIGPp

**Discussed with @nathanrodrigues2111 & @neerajmasai and we found this case is a causing the problem.**

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
