### PR TITLE
AST-3129 - Fix: Conflict with bbpress plugin in topic tags.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v4.1.3 (Unreleased)
 - Fix: Container - Content Boxed layout removes Spectra column or container left padding.
 - Fix: Offcanvas - Due to clickable hidden area toggle buttons don't work in RTL mode.
+- Fix: Topic tags div visible multiple times and goes into infinite loop in case of BBPress.
 
 v4.1.2
 - Fix: Post content shrinks on one side for the blog archive.

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -1700,7 +1700,7 @@ add_action( 'activate_elementor/elementor.php', 'astra_skip_elementor_onboarding
 function astra_bbpress_issue( $value ) {
 	/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 	/** @psalm-suppress UndefinedFunction  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-	if ( class_exists( 'bbpress' ) && ( bbp_is_single_user() || bbp_is_search() ) ) {
+	if ( class_exists( 'bbpress' ) && ( bbp_is_single_user() || bbp_is_search() || bbp_is_topic_tag() ) ) {
 		/** @psalm-suppress UndefinedFunction  */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		/** @psalm-suppress InvalidArgument */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			return false;


### PR DESCRIPTION
**Test Data: (If any)**  

Conflict with bbpress plugin in topic tags.

**Steps To Reproduce:** 

1. Install Astra and Bbpress
2. Create a new topic tag.
3. Check the topic tag page on frontend, it’s goes in infinite loop.

**Screencast** - https://d.pr/v/vbaKLn 

Any Other details:

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
