### PR TITLE
AST-3131 - Fix: Widget's dropdown arrow is moving to top corner.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ v4.1.3 (Unreleased)
 - Fix: Offcanvas - Due to clickable hidden area toggle buttons don't work in RTL mode.
 - Fix: Header Builder - Cart - On adding product to cart, quantity plus & minus buttons gets disappear.
 - Fix: Topic tags div visible multiple times and goes into infinite loop in case of BBPress.
+- Fix: WooCommerce - Widget's dropdown arrow is moving to top corner.
 
 v4.1.2
 - Fix: Post content shrinks on one side for the blog archive.

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -2461,6 +2461,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 					'background-size'       => '.8em',
 					'background-repeat'     => 'no-repeat',
 					'background-position-x' => 'calc( 100% - 10px )',
+					'background-position-y' => 'center',
 					'-webkit-appearance'    => 'none',
 					'-moz-appearance'       => 'none',
 					'padding-right'         => '2em',


### PR DESCRIPTION
**Test Data: (If any)**  

When we add any multiple element widget which need a dropdown arrow like category with dropdown arrow so this arrow goes to top right corner which looks not good, need to be center like previous.

**Steps To Reproduce:** 

1. Install Astra then install any starter template 
2. Check on the any widget which is already added in sidebar
3. Dropdown arrow is showing in top right corner.

**Screenshot** - https://d.pr/i/YASDBo 

Any Other details:

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
