### PR TITLE
AST-3127 - Popup menu overlaps customizer controls section.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ v4.1.3 (Unreleased)
 - Fix: Offcanvas - Due to clickable hidden area toggle buttons don't work in RTL mode.
 - Fix: Header Builder - Cart - On adding product to cart, quantity plus & minus buttons gets disappear.
 - Fix: Topic tags div visible multiple times and goes into infinite loop in case of BBPress.
+- Fix: Offcanvas - Popup menu overlaps customizer controls section.
 
 v4.1.2
 - Fix: Post content shrinks on one side for the blog archive.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ v4.1.3 (Unreleased)
 - Fix: Offcanvas - Due to clickable hidden area toggle buttons don't work in RTL mode.
 - Fix: Header Builder - Cart - On adding product to cart, quantity plus & minus buttons gets disappear.
 - Fix: Topic tags div visible multiple times and goes into infinite loop in case of BBPress.
-- Fix: Offcanvas - Popup menu overlaps customizer controls section.
+- Fix: Offcanvas - Builder component popup overlaps on customizer controls section.
 
 v4.1.2
 - Fix: Post content shrinks on one side for the blog archive.

--- a/inc/customizer/class-astra-builder-customizer.php
+++ b/inc/customizer/class-astra-builder-customizer.php
@@ -164,7 +164,7 @@ final class Astra_Builder_Customizer {
 			}
 			if ( astra_wp_version_compare( '6.2', '>=' ) ) {
 				echo '<style type="text/css" class="astra-wp-6-2-builder-popover-compatibility">
-					.components-popover.ahfb-popover-add-builder {
+					.popup-vertical-group .components-popover.ahfb-popover-add-builder {
 						left: 18% !important;
 					}
 					</style>

--- a/inc/customizer/class-astra-builder-customizer.php
+++ b/inc/customizer/class-astra-builder-customizer.php
@@ -162,6 +162,14 @@ final class Astra_Builder_Customizer {
 					</style>
 				';
 			}
+			if ( astra_wp_version_compare( '6.1', '>' ) ) {
+				echo '<style type="text/css" class="astra-wp-6-2-builder-popover-compatibility">
+					.components-popover.ahfb-popover-add-builder {
+						left: 18% !important;
+					}
+					</style>
+				';
+			}
 		}
 	}
 

--- a/inc/customizer/class-astra-builder-customizer.php
+++ b/inc/customizer/class-astra-builder-customizer.php
@@ -162,7 +162,7 @@ final class Astra_Builder_Customizer {
 					</style>
 				';
 			}
-			if ( astra_wp_version_compare( '6.1', '>' ) ) {
+			if ( astra_wp_version_compare( '6.2', '>=' ) ) {
 				echo '<style type="text/css" class="astra-wp-6-2-builder-popover-compatibility">
 					.components-popover.ahfb-popover-add-builder {
 						left: 18% !important;


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Description: Off canvas widget section is overlapping on customizer
- Existing compatibility added previously during 6.0 compatibility breaks with following css added:
`translateX(-57px) translateY(-208px) translateY(0em) scale(1) translateZ(0px) `
- Updating the z-index does not solve the problem, as the stack context is different which does not have any effect to solve the overlap issue.
- Screenshot: [Annotation-Annotation on 2023-04-04 at 14-26-05.png.png](https://d.pr/i/2af2eF)
- JIRA - https://brainstormforce.atlassian.net/browse/AST-3127

### Screenshots
<!-- if applicable -->
- Bug Screenshot: [Annotation-Annotation on 2023-04-04 at 14-26-05.png.png](https://d.pr/i/2af2eF)
- Before 6.1 - https://d.pr/i/SXi5mW

### Types of changes
<!-- What types of changes does your code introduce?  -->
- Adjust position of popup to avoid overlap.
- Bug introduced with WordPress 6.1, popup positioning uses transform css rule which breaks the existing compatibility. 
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Add toggle menu to Header Builder.
- Click the + icon in offcanvas section.
- The Popup should not overlap the customizer controls.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
