### PR TITLE
AST-3125 - Fix: Quantity button caching issue while adding product to cart.

### DIFF
--- a/assets/js/unminified/add-to-cart-quantity-btn.js
+++ b/assets/js/unminified/add-to-cart-quantity-btn.js
@@ -9,8 +9,22 @@ window.addEventListener( "load", function(e) {
 });
 
 
-/**This comment explains that in order to refresh the wc_fragments_refreshed event when an AJAX call is made, jQuery is used to update the quantity button. 
- * Here plain JavaScript may not be able to trigger the wc_fragments_refreshed event in the same way, 
+// Here we are selecting the node that will be observed for mutations.
+const astraminiCarttargetNode = document.getElementById("ast-site-header-cart");
+
+if (astraminiCarttargetNode != null) {
+    const config = { attributes: false, childList: true, subtree: true };
+
+    const astraMinicartObserver = () => {
+        astrawpWooQuantityButtons();
+    };
+
+    const observer = new MutationObserver(astraMinicartObserver);
+    observer.observe(astraminiCarttargetNode, config);
+}
+
+/**This comment explains that in order to refresh the wc_fragments_refreshed event when an AJAX call is made, jQuery is used to update the quantity button.
+ * Here plain JavaScript may not be able to trigger the wc_fragments_refreshed event in the same way,
  * hence the need to use jQuery
 */
 jQuery( function( $ ) {


### PR DESCRIPTION
### Description

Quantity button caching issue while adding product to cart.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
