### PR TITLE
AST-3165 - Fix:Single Product Payment Icons  Incorrect display on Safari (mac and iOS both)

### DIFF
--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -2876,7 +2876,7 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 
 					.ast-single-product-payments ul {
 						display: flex;
-						flex-wrap: wrap;
+						flex-wrap: nowrap;
 						margin: 0;
 						padding: 0;
 						list-style: none;


### PR DESCRIPTION
**Test Data: (If any)**  

The payment icons in the single product appear incorrectly on the Safari browser. 

Fresh test site: https://d.pr/i/3Drrmy 

Starter Template: https://d.pr/i/FjYS0a 

On Windows and Android, they appear fine: https://d.pr/i/sHWNoM .

**Steps To Reproduce:** 

1. Enable the Payment in the single product meta from the customizer:  .
2. Publish the change and check the website on Safari. 
3. Tested with Safari 16, 15 and 14

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
