### PR TITLE
AST-3211 - Fix: Fatal error: Uncaught TypeError: Unsupported operand types: On frontend and customizer.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ v4.1.6 (Unreleased)
 - Improvement: Improved title area customizer control UI for better user experience.
 - Fix: Header Builder - Menu - Item Divider doesn't work on the last submenu item.
 - Fix: Author Link not working on layout 2 for single post title.
+- Fix: Fatal error: Uncaught TypeError: Unsupported operand types: On frontend and customizer.
 
 v4.1.5
 - Fix: Offcanvas Menu - Transparent empty canvas visible on expanding offcanvas toggle button.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3629,7 +3629,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			 *
 			 *   - Sidebar Positions CSS
 			 */
-			$secondary_width = astra_get_option( 'site-sidebar-width' );
+			$secondary_width = absint( astra_get_option( 'site-sidebar-width' ) );
 			$primary_width   = absint( 100 - $secondary_width );
 			$meta_style      = '';
 

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3664,7 +3664,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 						'width' => astra_get_css_value( $primary_width, '%' ),
 					),
 					'#secondary' => array(
-						'width' => astra_get_css_value( $secondary_width, '%' ), // phpcs:ignore Squiz.PHP.NonExecutableCode
+						'width' => astra_get_css_value( strval($secondary_width), '%' ),
 					),
 				);
 

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3664,9 +3664,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 						'width' => astra_get_css_value( $primary_width, '%' ),
 					),
 					'#secondary' => array(
-						// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
-						'width' => astra_get_css_value( $secondary_width, '%' ),
-						// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
+						'width' => astra_get_css_value( $secondary_width, '%' ), // phpcs:ignore Squiz.PHP.NonExecutableCode
 					),
 				);
 

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3631,9 +3631,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			 */
 			$secondary_width = absint( astra_get_option( 'site-sidebar-width' ) );
 			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
-			$primary_width   = absint( 100 - $secondary_width );
+			$primary_width = absint( 100 - $secondary_width );
 			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
-			$meta_style      = '';
+			$meta_style = '';
 
 			// Header Separator.
 			$header_separator       = astra_get_option( 'header-main-sep' );
@@ -3664,7 +3664,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 						'width' => astra_get_css_value( $primary_width, '%' ),
 					),
 					'#secondary' => array(
+						// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 						'width' => astra_get_css_value( $secondary_width, '%' ),
+						// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 					),
 				);
 

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3630,7 +3630,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			 *   - Sidebar Positions CSS
 			 */
 			$secondary_width = absint( astra_get_option( 'site-sidebar-width' ) );
-			$primary_width   = absint( 100 - $secondary_width );
+			$primary_width   = absint( 100 - $secondary_width ); // phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 			$meta_style      = '';
 
 			// Header Separator.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3630,9 +3630,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			 *   - Sidebar Positions CSS
 			 */
 			$secondary_width = absint( astra_get_option( 'site-sidebar-width' ) );
-			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 			$primary_width = absint( 100 - $secondary_width );
-			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 			$meta_style = '';
 
 			// Header Separator.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3630,7 +3630,9 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			 *   - Sidebar Positions CSS
 			 */
 			$secondary_width = absint( astra_get_option( 'site-sidebar-width' ) );
-			$primary_width   = absint( 100 - $secondary_width ); // phpcs:ignore WordPress.PHP.StrictlyTypedParameter
+			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
+			$primary_width   = absint( 100 - $secondary_width );
+			// phpcs:ignore WordPress.PHP.StrictlyTypedParameter
 			$meta_style      = '';
 
 			// Header Separator.


### PR DESCRIPTION
**Test Data: (If any)**  

We are getting some Fatal error: Uncaught TypeError: Unsupported operand types: On frontend and customizer .

**Screenshot** - https://d.pr/i/IURQeh 

**Steps To Reproduce:** 

Just import this customizer JSON file and you will noticed the error.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
