### PR TITLE
AST-3208 - New: Change surecart pages position & added condition to detect plugin.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ v4.1.6 (Unreleased)
 - Improvement: Improved title area customizer control UI for better user experience.
 - Fix: Header Builder - Menu - Item Divider doesn't work on the last submenu item.
 - Fix: Author Link not working on layout 2 for single post title.
+- Improvement: Rearrange surecart pages option in custmizer.
 
 v4.1.5
 - Fix: Offcanvas Menu - Transparent empty canvas visible on expanding offcanvas toggle button.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ v4.1.6 (Unreleased)
 - Improvement: Improved title area customizer control UI for better user experience.
 - Fix: Header Builder - Menu - Item Divider doesn't work on the last submenu item.
 - Fix: Author Link not working on layout 2 for single post title.
-- Improvement: Rearrange surecart pages option in custmizer.
+- Improvement: Rearrange surecart pages option in customizer.
 
 v4.1.5
 - Fix: Offcanvas Menu - Transparent empty canvas visible on expanding offcanvas toggle button.

--- a/inc/modules/posts-structures/customizer/class-astra-posts-structures-configs.php
+++ b/inc/modules/posts-structures/customizer/class-astra-posts-structures-configs.php
@@ -95,13 +95,19 @@ class Astra_Posts_Structures_Configs extends Astra_Customizer_Config_Base {
 
 				$section_title = self::astra_get_dynamic_section_title( $post_type_object, $label );
 
-				$_configs[] = array(
+				$configuration_args = array(
 					'name'     => 'section-posttype-' . $label,
 					'type'     => 'section',
 					'section'  => $parent_section,
 					'title'    => $section_title,
 					'priority' => 69,
 				);
+
+				if ( 'sc_product' === $label) {
+					unset($configuration_args['section']);
+				}
+
+				$_configs[] = $configuration_args;
 
 				if ( ! in_array( $label, $ignore_archive_for_posttypes ) ) {
 					$_configs[] = array(


### PR DESCRIPTION
**Details -** 
We detect SureCart pages under Custom Post Type but instead of that, can we detect the SureCart plugin and name it as SureCart or SureCart Options or SureCart Products?

**Please watch this video- https://d.pr/v/xPeo8F** 

**Slack discussion- https://brainstormforce.slack.com/archives/C5QL6NXEK/p1685047019576119**

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
