### PR TITLE
AST-3269 - Fix: Removed extra Read time option from theme which visible even after addon is disable.

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@v1.3
+      - uses: thehanimo/pr-title-checker@vv1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@vv1.4.0
+      - uses: thehanimo/pr-title-checker@v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false

--- a/inc/customizer/configurations/layout/class-astra-blog-layout-configs.php
+++ b/inc/customizer/configurations/layout/class-astra-blog-layout-configs.php
@@ -42,7 +42,6 @@ if ( ! class_exists( 'Astra_Blog_Layout_Configs' ) ) {
 					'title'       => __( 'Date', 'astra' ),
 				),
 				'tag'       => __( 'Tag', 'astra' ),
-				'read-time' => __( 'Read Time', 'astra' ),
 			);
 
 			/** @psalm-suppress UndefinedClass */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Removed extra Read time option from theme which visible even after addon is disable.

**Steps To Reproduce:** 

1. Keep only the Astra theme active
2. Navigate to Customize > Blog > Blog/Archive and enable the read time.
3. It does not have any effect.
4. If Astra Pro is activated with Blog Pro, then it has an effect and correctly appears.

### Screenshots
<!-- if applicable -->

- https://d.pr/v/9pNVsk

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
