### PR TITLE
AST-3272 - Added font-size support till 200px

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v4.1.6 (Unreleased)
 - Improvement: Rearranged SureCart dynamic CPT sections on top level in the customizer.
 - Improvement: Refactor duplication blocks of code found in navigation JS file.
 - Improvement: Added a new filter 'astra_font_line_height_unit' to adjust the unit for line height.
+- Improvement: Added font-size support till 200px.
 - Fix: Header Builder - Menu - Item Divider doesn't work on the last submenu item.
 - Fix: Author Link not working on layout 2 for single post title.
 - Fix: Fatal error: Uncaught TypeError: Unsupported operand types: On frontend and customizer.

--- a/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-typo-configs.php
+++ b/inc/addons/breadcrumbs/customizer/class-astra-breadcrumbs-typo-configs.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'Astra_Breadcrumbs_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/addons/heading-colors/customizer/class-astra-heading-colors-configs.php
+++ b/inc/addons/heading-colors/customizer/class-astra-heading-colors-configs.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Astra_Heading_Colors_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
+++ b/inc/customizer/configurations/builder/base/class-astra-button-component-configs.php
@@ -403,7 +403,7 @@ class Astra_Button_Component_Configs {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
+++ b/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
@@ -167,7 +167,7 @@ final class Astra_Builder_Base_Configuration {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -202,7 +202,7 @@ final class Astra_Builder_Base_Configuration {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -456,7 +456,7 @@ final class Astra_Builder_Base_Configuration {
 								'px' => array(
 									'min'  => 0,
 									'step' => 1,
-									'max'  => 100,
+									'max'  => 200,
 								),
 								'em' => array(
 									'min'  => 0,
@@ -498,7 +498,7 @@ final class Astra_Builder_Base_Configuration {
 								'px' => array(
 									'min'  => 0,
 									'step' => 1,
-									'max'  => 100,
+									'max'  => 200,
 								),
 								'em' => array(
 									'min'  => 0,

--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-menu-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-menu-configs.php
@@ -342,7 +342,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							'px' => array(
 								'min'  => 0,
 								'step' => 1,
-								'max'  => 100,
+								'max'  => 200,
 							),
 							'em' => array(
 								'min'  => 0,

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-mobile-trigger-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-mobile-trigger-configs.php
@@ -378,6 +378,7 @@ class Astra_Customizer_Mobile_Trigger_Configs extends Astra_Customizer_Config_Ba
 					'transport'   => 'postMessage',
 					'input_attrs' => array(
 						'min' => 0,
+						'max'  => 200,
 					),
 					'units'       => array(
 						'px' => 'px',
@@ -404,6 +405,7 @@ class Astra_Customizer_Mobile_Trigger_Configs extends Astra_Customizer_Config_Ba
 					'transport'   => 'postMessage',
 					'input_attrs' => array(
 						'min' => 0,
+						'max'  => 200,
 					),
 					'units'       => array(
 						'px' => 'px',

--- a/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-header-menu-component-configs.php
@@ -593,7 +593,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 							'px' => array(
 								'min'  => 0,
 								'step' => 1,
-								'max'  => 100,
+								'max'  => 200,
 							),
 							'em' => array(
 								'min'  => 0,

--- a/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-mobile-menu-component-configs.php
@@ -377,7 +377,7 @@ if ( class_exists( 'Astra_Customizer_Config_Base' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/customizer/configurations/buttons/class-astra-existing-button-configs.php
+++ b/inc/customizer/configurations/buttons/class-astra-existing-button-configs.php
@@ -245,7 +245,7 @@ if ( ! class_exists( 'Astra_Existing_Button_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/customizer/configurations/typography/class-astra-body-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-body-typo-configs.php
@@ -142,6 +142,7 @@ if ( ! class_exists( 'Astra_Body_Typo_Configs' ) ) {
 					'suffix'      => 'px',
 					'input_attrs' => array(
 						'min' => 0,
+						'max'  => 200,
 					),
 					'units'       => array(
 						'px' => 'px',

--- a/inc/customizer/configurations/typography/class-astra-content-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-content-typo-configs.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -102,7 +102,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -142,7 +142,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -182,7 +182,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -222,7 +222,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -262,7 +262,7 @@ if ( ! class_exists( 'Astra_Content_Typo_Configs' ) ) {
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-header-typo-configs.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							'px' => array(
 								'min'  => 0,
 								'step' => 1,
-								'max'  => 100,
+								'max'  => 200,
 							),
 							'em' => array(
 								'min'  => 0,
@@ -84,7 +84,7 @@ if ( ! class_exists( 'Astra_Header_Typo_Configs' ) ) {
 							'px' => array(
 								'min'  => 0,
 								'step' => 1,
-								'max'  => 100,
+								'max'  => 200,
 							),
 							'em' => array(
 								'min'  => 0,

--- a/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
+++ b/inc/customizer/configurations/typography/class-astra-headings-typo-configs.php
@@ -95,7 +95,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -176,7 +176,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -256,7 +256,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -336,7 +336,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -416,7 +416,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -495,7 +495,7 @@ class Astra_Headings_Typo_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,

--- a/inc/modules/posts-structures/customizer/class-astra-posts-archive-structures-configs.php
+++ b/inc/modules/posts-structures/customizer/class-astra-posts-archive-structures-configs.php
@@ -752,7 +752,7 @@ class Astra_Posts_Archive_Structures_Configs extends Astra_Customizer_Config_Bas
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -777,7 +777,7 @@ class Astra_Posts_Archive_Structures_Configs extends Astra_Customizer_Config_Bas
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -852,7 +852,7 @@ class Astra_Posts_Archive_Structures_Configs extends Astra_Customizer_Config_Bas
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/modules/posts-structures/customizer/class-astra-posts-single-structures-configs.php
+++ b/inc/modules/posts-structures/customizer/class-astra-posts-single-structures-configs.php
@@ -871,7 +871,7 @@ class Astra_Posts_Single_Structures_Configs extends Astra_Customizer_Config_Base
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -946,7 +946,7 @@ class Astra_Posts_Single_Structures_Configs extends Astra_Customizer_Config_Base
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,
@@ -1040,7 +1040,7 @@ class Astra_Posts_Single_Structures_Configs extends Astra_Customizer_Config_Base
 						'px' => array(
 							'min'  => 0,
 							'step' => 1,
-							'max'  => 100,
+							'max'  => 200,
 						),
 						'em' => array(
 							'min'  => 0,

--- a/inc/modules/related-posts/customizer/class-astra-related-posts-configs.php
+++ b/inc/modules/related-posts/customizer/class-astra-related-posts-configs.php
@@ -725,7 +725,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -801,7 +801,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -876,7 +876,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,
@@ -950,7 +950,7 @@ class Astra_Related_Posts_Configs extends Astra_Customizer_Config_Base {
 					'px' => array(
 						'min'  => 0,
 						'step' => 1,
-						'max'  => 100,
+						'max'  => 200,
 					),
 					'em' => array(
 						'min'  => 0,


### PR DESCRIPTION
### Description
- Updated font-size support till 200

### Screenshots
Before - https://share.getcloudapp.com/kpulwGBY
After - https://share.getcloudapp.com/ApugLdZK

### Types of changes
- New feature (non-breaking change)

### How has this been tested?
- Check any font-size control from customizer it has support till 200
- Also on frontend the size should apply

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
