### PR TITLE
AST-3189 - group container inner blocks option does not disable in the edi…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ v4.1.7 (Unreleased)
 - Fix: Single Product - alt tag absent while rendering images for the WooCommerce payments.
 - Fix: Customizer - Gradient picker shrink in size under color-group background controls.
 - Fix: Horizontal line (HR) is not inheriting the global text colors when Elementor is active
+- Fix: Group container inner blocks option does not disable in the editor.
 
 
 v4.1.6

--- a/inc/assets/js/column-block-compatibility.js
+++ b/inc/assets/js/column-block-compatibility.js
@@ -31,33 +31,6 @@ wp.hooks.addFilter(
 	20
 );
 
-wp.hooks.addFilter(
-	'blocks.getBlockAttributes',
-	'astra/groupBlockSetting/checkInheritOption',
-	(attributes, blockType) => {
-		if (!updatingBlock.includes(blockType.name)) {
-			return attributes;
-		}
-
-		if (blockType.name == 'core/group' && undefined != attributes.layout && 'flex' === attributes.layout.type) {
-			return attributes;
-		}
-
-		if (blockType.name == 'core/group' && undefined != attributes.layout && false == attributes.layout.inherit ) {
-			return attributes;
-		}
-
-		attributes = {
-			...attributes,
-			layout: {
-				inherit: true,
-			},
-		};
-
-		return attributes;
-	}
-);
-
 /**
  * Set "Inherit default layout" option enable by default for Group block.
  *


### PR DESCRIPTION
### Description
Jira : https://brainstormforce.atlassian.net/browse/AST-3189

### Screenshots
https://d.pr/v/3yw6zs

### Types of changes
 Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Checked if the 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
