### PR TITLE
Ast 3354 bugfix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,8 @@ v4.1.7 (Unreleased)
 - Fix: bbPress widget items loading in infinite loop while rendering banner layout.
 - Fix: Header Builder - Menu - Parsing duplicate ID error for 'primary-site-navigation' and 'art-hf-menu-x'.
 - Fix : Woocommerce - Swap Images feature shows uncropped image.
+- Fix : Editor - Applying Font Extras Customizer Settings to Paragraph Block ( Line-height, Text Transform, Text Decoration, Letter Spacing ).
+
 v4.1.6
 - Improvement: Header Footer Builder - Added new social profile "TikTok".
 - Improvement: Improved title area customizer control UI for better user experience.

--- a/inc/assets/css/wp-editor-styles-rtl.css
+++ b/inc/assets/css/wp-editor-styles-rtl.css
@@ -548,10 +548,6 @@ pre.wp-block code {
   word-break: normal;
 }
 
-.editor-styles-wrapper p {
-  line-height: 1.85714285714286;
-}
-
 .wp-block-quote.is-style-large cite {
   text-align: right;
 }

--- a/inc/assets/css/wp-editor-styles.css
+++ b/inc/assets/css/wp-editor-styles.css
@@ -548,10 +548,6 @@ pre.wp-block code {
   word-break: normal;
 }
 
-.editor-styles-wrapper p {
-  line-height: 1.85714285714286;
-}
-
 .wp-block-quote.is-style-large cite {
   text-align: left;
 }

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -130,11 +130,13 @@ class Astra_WP_Editor_CSS {
 
 		$highlight_theme_color = astra_get_foreground_color( $theme_color );
 
-		$body_font_weight    = astra_get_option( 'body-font-weight' );
-		$body_font_size      = astra_get_option( 'font-size-body' );
-		$body_line_height    = astra_get_option( 'body-line-height' );
-		$body_text_transform = astra_get_option( 'body-text-transform' );
-		$text_color          = astra_get_option( 'text-color' );
+		$body_font_weight     = astra_get_option( 'body-font-weight' );
+		$body_font_size       = astra_get_option( 'font-size-body' );
+		$body_line_height     = astra_get_font_extras( astra_get_option( 'body-font-extras' ), 'line-height', 'line-height-unit' );
+		$body_text_transform  = astra_get_font_extras( astra_get_option( 'body-font-extras' ), 'text-transform' );
+		$body_letter_spacing  = astra_get_font_extras( astra_get_option( 'body-font-extras' ), 'letter-spacing', 'letter-spacing-unit' );
+		$body_text_decoration = astra_get_font_extras( astra_get_option( 'body-font-extras' ), 'text-decoration' );
+		$text_color           = astra_get_option( 'text-color' );
 
 		$heading_h1_font_size = astra_get_option( 'font-size-h1' );
 		$heading_h2_font_size = astra_get_option( 'font-size-h2' );
@@ -449,11 +451,13 @@ class Astra_WP_Editor_CSS {
 			'.editor-styles-wrapper'           => astra_get_responsive_background_obj( $content_background, 'desktop' ),
 
 			'.editor-styles-wrapper, #customize-controls .editor-styles-wrapper' => array(
-				'font-family'    => astra_get_font_family( $body_font_family ),
-				'font-weight'    => esc_attr( $body_font_weight ),
-				'font-size'      => astra_responsive_font( $body_font_size, 'desktop' ),
-				'line-height'    => esc_attr( $body_line_height ),
-				'text-transform' => esc_attr( $body_text_transform ),
+				'font-family'     => astra_get_font_family( $body_font_family ),
+				'font-weight'     => esc_attr( $body_font_weight ),
+				'font-size'       => astra_responsive_font( $body_font_size, 'desktop' ),
+				'line-height'     => esc_attr( $body_line_height ),
+				'text-transform'  => esc_attr( $body_text_transform ),
+				'text-decoration' => esc_attr( $body_text_decoration ),
+				'letter-spacing'  => esc_attr( $body_letter_spacing ),
 			),
 			'.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6' => astra_get_font_array_css( astra_get_option( 'headings-font-family' ), astra_get_option( 'headings-font-weight' ), array(), 'headings-font-extras', $heading_base_color ),
 
@@ -567,6 +571,9 @@ class Astra_WP_Editor_CSS {
 			// Margin bottom same as applied on frontend.
 			'.editor-styles-wrapper .is-root-container.block-editor-block-list__layout > .wp-block-heading' => array(
 				'margin-bottom' => '20px',
+			),
+			'.editor-styles-wrapper p' => array(
+				'line-height' => esc_attr( $body_line_height ),
 			),
 		);
 

--- a/sass/admin/wp-editor-styles.scss
+++ b/sass/admin/wp-editor-styles.scss
@@ -336,9 +336,7 @@ pre.wp-block {
 		word-break: normal;
 	}
 }
-.editor-styles-wrapper p {
-	line-height: 1.85714285714286;
-}
+
 .wp-block-quote.is-style-large cite {
 	text-align: left;
 }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Fix : Editor - Applying Font Extras Customizer Settings to Paragraph Block ( Line-height, Text Transform, Text Decoration, Letter Spacing ).
- https://brainstormforce.atlassian.net/browse/AST-3354

### Screenshots
<!-- if applicable -->
- Frontend - https://share.getcloudapp.com/4guXNvY6 
- Editor - https://share.getcloudapp.com/NQupWmqg

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug Fixes

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Test by applying customizer font extras values and see if it applies correctly in editor and matches frontend.
- Test for default values when no customizer values applied manually.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
