### PR TITLE
AST-3375 - h1 tag assigned to site title on home & front page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ v4.1.7 (Unreleased)
 - Fix: Spectra Compatibility - Customizer spacing options overriding Spectra's block spacing.
 - Fix: Desktop and mobile header visible together at tablet_breakpoint (921px default) on scaled screen resolutions.
 - Fix: Block editor - Applying font-extras customizer settings to paragraph block (Line-height, Text Transform, Text Decoration, Letter Spacing).
+- Fix: On home page & front page there is h1 tag assigned for site title.
 - Fix: WooCommerce - Swap Images feature shows uncropped image.
 - Fix: WooCommerce - Widget title size and color issue on all woocommerce pages.
 - Fix: WooCommerce - Sub pages of My Account dashboard menu does not update page title according to set menu.

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -259,12 +259,7 @@ function astra_get_site_title_tagline( $display_site_title, $display_site_taglin
 	if ( ! apply_filters( 'astra_disable_site_identity', false ) ) {
 
 		// Site Title.
-		$tag = 'span';
-		if ( is_home() || is_front_page() ) {
-			if ( apply_filters( 'astra_show_site_title_h1_tag', true ) && 'desktop' === $device ) {
-				$tag = 'h1';
-			}
-		}
+		$tag = apply_filters( 'astra_show_site_title_h1_tag', false ) ? 'h1' : 'span';
 
 		/**
 		 * Filters the site title output.


### PR DESCRIPTION
### Description
- Site title comes with h1 tag on home page & front page.

### Screenshots
- https://d.pr/v/lFP6dV

### Types of changes
- Bug fix 

### How has this been tested?
- **Steps To Reproduce:** 
- 1. Enable site-title from the customizer
- 2. Check on the site frontend
- 3. Notice on home page & front page the h1 tag for site-title - [Astra 2023-08-01 at 11.04.44 AM](https://share.getcloudapp.com/8LuYly5p)  
- 4. Notice on other normal pages/posts there is span tag - [Shop – Astra 2023-08-01 at 11.05.53 AM](https://share.getcloudapp.com/6quJXkY1)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
