### PR TITLE
AST-3442 - Fix - Update default layout to Page Builder when using Elementor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ v4.2.3 (Unreleased)
 - Fix: Block Editor - Query Loop Block - Article inside aritcle getting extra spacing with Boxed layout.
 - Fix: WooCommerce - Default Customizer Layout setting not applied correctly for Single Product.
 - Fix: Block Editor - Title visibility eye meta option not appearing in Firefox browser.
+- Fix: Default layout should be Fullwidth (Previously Fullwidth Stretch) when creating a new Elementor Page.
 
 v4.2.2
 - New: Introduced new site logo color option.

--- a/inc/compatibility/class-astra-elementor.php
+++ b/inc/compatibility/class-astra-elementor.php
@@ -9,6 +9,7 @@ namespace Elementor;// phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_name
 
 // @codingStandardsIgnoreStart PHPCompatibility.Keywords.NewKeywords.t_useFound
 use Astra_Global_Palette;
+use Astra_Dynamic_CSS;
 use Elementor\Core\Settings\Manager as SettingsManager;
 // @codingStandardsIgnoreEnd PHPCompatibility.Keywords.NewKeywords.t_useFound
 
@@ -236,9 +237,19 @@ if ( ! class_exists( 'Astra_Elementor' ) ) :
 					update_post_meta( $id, 'ast-title-bar-display', 'disabled' );
 					update_post_meta( $id, 'ast-featured-img', 'disabled' );
 
-					$content_layout = get_post_meta( $id, 'site-content-layout', true );
+					// Compatibility with revamped layouts to update default layout to page builder.
+					$migrated_user = ( ! Astra_Dynamic_CSS::astra_fullwidth_sidebar_support() );
+					if ( $migrated_user ) {
+						$content_layout = get_post_meta( $id, 'site-content-layout', true );
+					} else {
+						$content_layout = get_post_meta( $id, 'ast-site-content-layout', true );
+					}
+
 					if ( empty( $content_layout ) || 'default' == $content_layout ) {
-						update_post_meta( $id, 'site-content-layout', 'page-builder' );
+						if ( $migrated_user ) {
+							update_post_meta( $id, 'site-content-layout', 'page-builder' );
+						}
+						update_post_meta( $id, 'ast-site-content-layout', 'full-width-container' );
 					}
 
 					$sidebar_layout = get_post_meta( $id, 'site-sidebar-layout', true );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Elementor Page by default should have Full-width layout selected.
- JIRA - https://brainstormforce.atlassian.net/browse/AST-3442

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
BugFixes

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check if Full-width layout is applied properly same as before for Elementor Pages.
- Check for new user case.
- Check for old users migrating to latest version.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
