### PR TITLE
AST-3463 - Fix: Text color not inheriting in block editor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.3.1 (Unreleased)
+- Fix: Block Editor - Text color not inheriting as per the settings saved in customizer.
+
 v4.3.0
 - New: Header-Footer Builder - Social - Enable Brand Color option on hover.
 - Improvement: Introducing new admin notice for incompatibility of Astra Pro.

--- a/inc/core/class-astra-wp-editor-css.php
+++ b/inc/core/class-astra-wp-editor-css.php
@@ -437,6 +437,9 @@ class Astra_WP_Editor_CSS {
 			'.editor-styles-wrapper a'         => array(
 				'color' => esc_attr( $link_color ),
 			),
+			'.block-editor-block-list__block'  => array(
+				'color' => esc_attr( $text_color ),
+			),
 			// Global selection CSS.
 			'.block-editor-block-list__layout .block-editor-block-list__block ::selection,.block-editor-block-list__layout .block-editor-block-list__block.is-multi-selected .editor-block-list__block-edit:before' => array(
 				'background-color' => esc_attr( $theme_color ),


### PR DESCRIPTION
### Description
- w.org reported issue - https://wordpress.org/support/topic/v4-3-0-breaks-global-color-settings-in-editor/
- Revert PR for this - https://github.com/brainstormforce/astra/pull/5287 

### Screenshots
- [Markup 2023-09-04 at 10.53.46.png](https://d.pr/i/rFBzbh)  → [Markup 2023-09-04 at 10.54.12.png](https://d.pr/i/wheerL)

### Types of changes
- Bug fix 

### How has this been tested?
- As per the test cases mentioned in the task

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
