### PR TITLE
AST-3365 - Widget section need to provide font color and font size options.

### DIFF
--- a/inc/addons/transparent-header/classes/sections/class-astra-customizer-transparent-header-configs.php
+++ b/inc/addons/transparent-header/classes/sections/class-astra-customizer-transparent-header-configs.php
@@ -874,7 +874,6 @@ if ( ! class_exists( 'Astra_Customizer_Transparent_Header_Configs' ) ) {
 					),
 				);
 
-				if ( ! astra_remove_widget_design_options() ) {
 					$widget_configs = array(
 						/**
 						 * Option: Transparent Header Builder - Widget Elements configs.
@@ -955,11 +954,6 @@ if ( ! class_exists( 'Astra_Customizer_Transparent_Header_Configs' ) ) {
 							'context'           => Astra_Builder_Helper::$general_tab,
 						),
 					);
-
-					$_hfb_configs = array_merge( $_hfb_configs, $widget_configs );
-				}
-
-				$_configs = array_merge( $_configs, $_hfb_configs );
 
 			} else {
 				$_old_content_configs = array(

--- a/inc/builder/type/base/assets/js/customizer-preview.js
+++ b/inc/builder/type/base/assets/js/customizer-preview.js
@@ -605,15 +605,29 @@ function astra_builder_widget_css( builder_type = 'header' ) {
 			builder_type + '-widget-' + index + '-title-color',
 			'astra-settings[' + builder_type + '-widget-' + index + '-title-color]',
 			'color',
-			selector + ' .widget-title'
+			selector + ' .widget-title, ' +
+			selector + ' .wp-block-heading, ' +
+			'h1, .entry-content h1, ' +
+			'h2, .entry-content h2, ' +
+			'h3, .entry-content h3, ' +
+			'h4, .entry-content h4, ' +
+			'h5, .entry-content h5, ' +
+			'h6, .entry-content h6'
 		);
 
 		// Widget Title Typography.
 		astra_responsive_font_size(
 			'astra-settings[' + builder_type + '-widget-' + index + '-font-size]',
-			selector + ' .widget-title'
+			selector + ' .widget-title, ' +
+			selector + ' .wp-block-heading, ' +
+			'h1, .entry-content h1, ' +
+			'h2, .entry-content h2, ' +
+			'h3, .entry-content h3, ' +
+			'h4, .entry-content h4, ' +
+			'h5, .entry-content h5, ' +
+			'h6, .entry-content h6'
 		);
-
+		
 		// Widget Content Typography.
 		astra_responsive_font_size(
 			'astra-settings[' + builder_type + '-widget-' + index + '-content-font-size]',

--- a/inc/builder/type/base/dynamic-css/widget/class-astra-widget-component-dynamic-css.php
+++ b/inc/builder/type/base/dynamic-css/widget/class-astra-widget-component-dynamic-css.php
@@ -56,7 +56,6 @@ class Astra_Widget_Component_Dynamic_CSS {
 				$builder_widget_selector = $selector . ' .' . $builder_type . '-widget-area-inner';
 			}
 
-			if ( ! astra_remove_widget_design_options() ) {
 
 				$title_font_size   = astra_get_option( $builder_type . '-widget-' . $index . '-font-size' );
 				$content_font_size = astra_get_option( $builder_type . '-widget-' . $index . '-content-font-size' );
@@ -89,11 +88,11 @@ class Astra_Widget_Component_Dynamic_CSS {
 					$builder_widget_selector . ' a:hover' => array(
 						'color' => $link_h_color_desktop,
 					),
-					$selector . ' .widget-title'          => array(
+					$selector . ' .widget-title, ' . $selector . ' .wp-block-heading, ' . 'h1, .entry-content h1, ' . 'h2, .entry-content h2, ' . 'h3, .entry-content h3, ' . 'h4, .entry-content h4, ' . 'h5, .entry-content h5, ' . 'h6, .entry-content h6' => array( 
 						'color'     => $title_color_desktop,
-						// Typography.
-						'font-size' => astra_responsive_font( $title_font_size, 'desktop' ),
+						'font-size' => astra_responsive_font($title_font_size, 'desktop'),
 					),
+					
 					$selector                             => array(
 						// Margin CSS.
 						'margin-top'    => astra_responsive_spacing( $margin, 'top', 'desktop' ),
@@ -109,10 +108,9 @@ class Astra_Widget_Component_Dynamic_CSS {
 						// Typography.
 						'font-size' => astra_responsive_font( $content_font_size, 'tablet' ),
 					),
-					$selector . ' .widget-title'          => array(
-						'color'     => $title_color_tablet,
-						// Typography.
-						'font-size' => astra_responsive_font( $title_font_size, 'tablet' ),
+					$selector . ' .widget-title, ' . $selector . ' .wp-block-heading, ' . 'h1, .entry-content h1, ' . 'h2, .entry-content h2, ' . 'h3, .entry-content h3, ' . 'h4, .entry-content h4, ' . 'h5, .entry-content h5, ' . 'h6, .entry-content h6' => array( 
+						'color'     =>  $title_color_tablet,
+						'font-size' => astra_responsive_font($title_font_size, 'desktop'),
 					),
 					$builder_widget_selector . ' a'       => array(
 						'color' => $link_color_tablet,
@@ -135,10 +133,9 @@ class Astra_Widget_Component_Dynamic_CSS {
 						// Typography.
 						'font-size' => astra_responsive_font( $content_font_size, 'mobile' ),
 					),
-					$selector . ' .widget-title'          => array(
+					$selector . ' .widget-title, ' . $selector . ' .wp-block-heading, ' . 'h1, .entry-content h1, ' . 'h2, .entry-content h2, ' . 'h3, .entry-content h3, ' . 'h4, .entry-content h4, ' . 'h5, .entry-content h5, ' . 'h6, .entry-content h6' => array( 
 						'color'     => $title_color_mobile,
-						// Typography.
-						'font-size' => astra_responsive_font( $title_font_size, 'mobile' ),
+						'font-size' => astra_responsive_font($title_font_size, 'desktop'),
 					),
 					$builder_widget_selector . ' a'       => array(
 						'color' => $link_color_mobile,
@@ -154,38 +151,6 @@ class Astra_Widget_Component_Dynamic_CSS {
 						'margin-right'  => astra_responsive_spacing( $margin, 'right', 'mobile' ),
 					),
 				);
-			} else {
-
-				$css_output_desktop = array(
-					$selector => array(
-						// Margin CSS.
-						'margin-top'    => astra_responsive_spacing( $margin, 'top', 'desktop' ),
-						'margin-bottom' => astra_responsive_spacing( $margin, 'bottom', 'desktop' ),
-						'margin-left'   => astra_responsive_spacing( $margin, 'left', 'desktop' ),
-						'margin-right'  => astra_responsive_spacing( $margin, 'right', 'desktop' ),
-					),
-				);
-
-				$css_output_tablet = array(
-					$selector => array(
-						// Margin CSS.
-						'margin-top'    => astra_responsive_spacing( $margin, 'top', 'tablet' ),
-						'margin-bottom' => astra_responsive_spacing( $margin, 'bottom', 'tablet' ),
-						'margin-left'   => astra_responsive_spacing( $margin, 'left', 'tablet' ),
-						'margin-right'  => astra_responsive_spacing( $margin, 'right', 'tablet' ),
-					),
-				);
-
-				$css_output_mobile = array(
-					$selector => array(
-						// Margin CSS.
-						'margin-top'    => astra_responsive_spacing( $margin, 'top', 'mobile' ),
-						'margin-bottom' => astra_responsive_spacing( $margin, 'bottom', 'mobile' ),
-						'margin-left'   => astra_responsive_spacing( $margin, 'left', 'mobile' ),
-						'margin-right'  => astra_responsive_spacing( $margin, 'right', 'mobile' ),
-					),
-				);
-			}
 
 			/* Parse CSS from array() */
 			$css_output  = astra_parse_css( $css_output_desktop );

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -3517,7 +3517,6 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 					),
 				);
 
-				if ( ! astra_remove_widget_design_options() ) {
 
 					$widget_title_color      = astra_get_option( 'transparent-header-widget-title-color' );
 					$widget_content_color    = astra_get_option( 'transparent-header-widget-content-color' );
@@ -3552,7 +3551,6 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 					$transparent_header_builder_desktop_css[ $transparent_header_widget_selector . ' a:hover' ] = array(
 						'color' => esc_attr( $widget_link_hover_color ),
 					);
-				}
 
 				if ( Astra_Builder_Helper::is_component_loaded( 'mobile-trigger', 'header', 'mobile' ) ) {
 

--- a/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
+++ b/inc/customizer/configurations/builder/class-astra-builder-base-configuration.php
@@ -336,8 +336,6 @@ final class Astra_Builder_Base_Configuration {
 				);
 			}
 
-			if ( ! astra_remove_widget_design_options() ) {
-
 				$html_config[] = array(
 
 					/**
@@ -346,7 +344,7 @@ final class Astra_Builder_Base_Configuration {
 					array(
 						'name'       => ASTRA_THEME_SETTINGS . '[' . $type . '-widget-' . $index . '-title-color]',
 						'default'    => astra_get_option( $type . '-widget-' . $index . '-title-color' ),
-						'title'      => __( 'Title Color', 'astra' ),
+						'title'      => __( 'Heading Color', 'astra' ),
 						'type'       => 'control',
 						'section'    => $_section,
 						'priority'   => 7,
@@ -382,7 +380,7 @@ final class Astra_Builder_Base_Configuration {
 						'transport'  => 'postMessage',
 						'priority'   => 7,
 						'responsive' => true,
-						'divider'    => array( 'ast_class' => 'ast-bottom-section-divider ast-section-spacing' ),
+						'divider'    => array( 'ast_class' => 'ast-bottom-divider' ),
 					),
 
 					/**
@@ -431,11 +429,12 @@ final class Astra_Builder_Base_Configuration {
 							'default'   => astra_get_option( $type . '-widget-' . $index . '-text-typography' ),
 							'type'      => 'control',
 							'control'   => 'ast-settings-group',
-							'title'     => __( 'Title Font', 'astra' ),
+							'title'     => __( 'Heading Font', 'astra' ),
 							'section'   => $_section,
 							'transport' => 'postMessage',
 							'priority'  => 90,
 							'divider'   => array( 'ast_class' => 'ast-bottom-divider' ),
+							'divider' => array( 'ast_class' => 'ast-bottom-divider' ),
 						),
 
 
@@ -567,7 +566,6 @@ final class Astra_Builder_Base_Configuration {
 						),
 					);
 				}
-			}
 
 			$html_config[] = self::prepare_visibility_tab( $_section, $type );
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -823,43 +823,6 @@ function astra_has_global_color_format_support() {
 }
 
 /**
- * Check whether widget specific config, dynamic CSS, preview JS needs to remove or not. Following cases considered while implementing this.
- *
- * 1. Is user is from old Astra setup.
- * 2. Check if user is new but on lesser WordPress 5.8 versions.
- * 3. User is new with block widget editor.
- *
- * @since 3.6.8
- * @return boolean
- */
-function astra_remove_widget_design_options() {
-	$astra_settings               = get_option( ASTRA_THEME_SETTINGS );
-	$remove_widget_design_options = isset( $astra_settings['remove-widget-design-options'] ) ? false : true;
-
-	// True -> Hide widget sections, False -> Display widget sections.
-	$is_widget_design_sections_hidden = true;
-
-	if ( ! $remove_widget_design_options ) {
-		// For old users we will show widget design options by anyways.
-		return apply_filters( 'astra_remove_widget_design_options', false );
-	}
-
-	// Considering the user is new now.
-	if ( isset( $astra_settings['remove-widget-design-options'] ) && $astra_settings['remove-widget-design-options'] ) {
-		// User was on WP-5.8 lesser version previously and he may update their WordPress to 5.8 in future. So we display the options in this case.
-		$is_widget_design_sections_hidden = false;
-	} elseif ( astra_has_widgets_block_editor() ) {
-		// User is new & having block widgets active. So we will hide those options.
-		$is_widget_design_sections_hidden = true;
-	} else {
-		// Setting up flag because user is on lesser WP versions and may update WP to 5.8.
-		astra_update_option( 'remove-widget-design-options', true );
-	}
-
-	return apply_filters( 'astra_remove_widget_design_options', $is_widget_design_sections_hidden );
-}
-
-/**
  * Get Global Color Palettes
  *
  * @return array color palettes array.

--- a/tests/php/static-analysis-stubs/astra-stubs.php
+++ b/tests/php/static-analysis-stubs/astra-stubs.php
@@ -15998,19 +15998,6 @@ namespace {
     {
     }
     /**
-     * Check whether widget specific config, dynamic CSS, preview JS needs to remove or not. Following cases considered while implementing this.
-     *
-     * 1. Is user is from old Astra setup.
-     * 2. Check if user is new but on lesser WordPress 5.8 versions.
-     * 3. User is new with block widget editor.
-     *
-     * @since 3.6.8
-     * @return boolean
-     */
-    function astra_remove_widget_design_options()
-    {
-    }
-    /**
      * Get Global Color Palettes
      *
      * @return array color palettes array.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Added Widget design options as a default.

### Screenshots
<!-- if applicable -->

- https://d.pr/v/5zn66E

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
1. Check the footer widget design option - It should be visible and working for respective blocks like the navigation menu, normal paragraph, heading

2. Check the same above case with the Addon module activated - 
A. When the Addon module is activated that time more typography options should be visible like font size font selection, and decoration option.
B. When Addon is not activated then for typography just the font size option should be visible.

3. Check the above same for the header by adding widgets.

4. After enabling the Addon module sticky header widget design option should be visible.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
