### PR TITLE
AST-3456 - Blog Archive - Read More CTA not appearing when the Left Sidebar layout is active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ v4.3.2 (Unreleased)
 - Fix: Site Identity - Logo Width sizes not working as expected in the customizer preview.
 - Fix: Duplicate dotted outlines are visible on focus of the close-menu toggle icon when accessibility is enabled.
 - Fix: Above Header - Left & Right spacing does not apply on frontend & in the customizer preview.
+- Fix: Blog Archive - Read More button not working with the excerpt when the Left Sidebar layout is active.
 
 v4.3.1
 - Fix: Block - Lists block style type updated to "disc" after v4.3.0 update.

--- a/inc/blog/blog-config.php
+++ b/inc/blog/blog-config.php
@@ -330,7 +330,7 @@ if ( ! function_exists( 'astra_post_link' ) ) {
 		return apply_filters( 'astra_post_link', $output, $output_filter );
 	}
 }
-add_filter( 'excerpt_more', 'astra_post_link', 1 );
+add_filter( 'excerpt_more', 'astra_post_link', 20 );
 
 /**
  * Function to get Number of Comments of Post


### PR DESCRIPTION
### Description
- "Read More" CTA does not appear with excerpt when left sidebar layout is active

### Screenshots
Issue - https://d.pr/i/qbwBS3
Fix - https://d.pr/i/KTOGso

### Types of changes
- Bug fix

### How has this been tested?
- With free theme 
-  - With left-right-none sidebar layouts
- - Check with the other some archives like search/category archive/blog etc
- With pro addon
- - With left-right-none sidebar layouts
- - Check with+without the "Read More as Button" setting enabled

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards 
- [x] My code has proper inline documentation 
- [x] I've included any necessary tests 
- [x] I've included developer documentation 
- [x] I've added proper labels to this pull request 
