### PR TITLE
AST-3458 - Custom Layout - Embed/YouTube block not working inside nested blocks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ v4.3.2 (Unreleased)
 - Fix: Above Header - Left & Right spacing does not apply on frontend & in the customizer preview.
 - Fix: Blog Archive - Read More button not working with the excerpt when the Left Sidebar layout is active.
 - Fix: Customizer - Blog - Design tab section seems blank when Astra Pro is active and all pro addons are disabled.
+- Fix: Block - Embed/YouTube block not working inside nested blocks from Custom Layouts.
 
 v4.3.1
 - Fix: Block - Lists block style type updated to "disc" after v4.3.0 update.

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -239,11 +239,11 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 		 * @param  string $html The oEmbed markup.
 		 * @param  string $url The URL being embedded.
 		 * @param  array  $attr An array of attributes.
+		 * @param  bool   $core_yt_block Whether the oEmbed is being rendered by the core YouTube block.
 		 *
 		 * @return string       Updated embed markup.
 		 */
-		public function responsive_oembed_wrapper( $html, $url, $attr ) {
-
+		public function responsive_oembed_wrapper( $html, $url, $attr, $core_yt_block = false ) {
 			$add_astra_oembed_wrapper = apply_filters( 'astra_responsive_oembed_wrapper_enable', true );
 
 			$allowed_providers = apply_filters(
@@ -257,8 +257,13 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 				)
 			);
 
-			if ( astra_strposa( $url, $allowed_providers ) ) {
-				if ( $add_astra_oembed_wrapper ) {
+			if ( $core_yt_block ) {
+				if ( astra_strposa( $url, $allowed_providers ) && $add_astra_oembed_wrapper ) {
+					$embed_html = wp_oembed_get( $url );
+					$html = '<div class="wp-block-embed__wrapper"> <div class="ast-oembed-container" style="height: 100%;">' . $embed_html . '</div> </div>';
+				}
+			} else {
+				if ( astra_strposa( $url, $allowed_providers ) && $add_astra_oembed_wrapper ) {
 					$html = ( '' !== $html ) ? '<div class="ast-oembed-container" style="height: 100%;">' . $html . '</div>' : '';
 				}
 			}

--- a/inc/compatibility/class-astra-gutenberg.php
+++ b/inc/compatibility/class-astra-gutenberg.php
@@ -24,6 +24,7 @@ class Astra_Gutenberg {
 		}
 
 		add_filter( 'render_block_core/group', array( $this, 'add_inherit_width_group_class' ), 10, 2 );
+		add_filter( 'render_block', array( $this, 'add_iframe_wrapper' ), 10, 2 );
 	}
 
 	/**
@@ -121,9 +122,6 @@ class Astra_Gutenberg {
 		if (
 			isset( $block['blockName'] ) && isset( $block['attrs']['layout']['inherit'] ) && $block['attrs']['layout']['inherit']
 		) {
-			$block_classgroups    = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
-			$processed_classnmaes = $block_classgroups . ' inherit-container-width';
-
 			$block_content = preg_replace(
 				'/' . preg_quote( 'class="', '/' ) . '/',
 				'class="inherit-container-width ',
@@ -149,6 +147,47 @@ class Astra_Gutenberg {
 		return $matches[1] . '<div class="wp-block-group__inner-container">' . $matches[2] . '</div>' . $matches[3];
 	}
 
+	/**
+	 * Add iframe wrapper for videos.
+	 *
+	 * @since x.x.x
+	 * @access public
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Block object.
+	 *
+	 * @return string Filtered block content.
+	 */
+	public function add_iframe_wrapper( $block_content, $block ) {
+		$yt_wrapper_with_inner_iframe_regex = '/(ast-oembed-container)/';
+
+		if ( isset( $block['blockName'] ) && 'core/embed' !== $block['blockName'] && 'core/youtube' !== $block['blockName'] ) {
+			return $block_content;
+		}
+
+		/** @psalm-suppress PossiblyUndefinedStringArrayOffset */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		if ( ( ! empty( $block['blockName'] ) && ( 'core/embed' === $block['blockName'] || 'core/youtube' === $block['blockName'] ) ) && ! empty( $block['attrs'] ) && empty( $block['attrs']['url'] ) ) {
+			return $block_content;
+		}
+
+		if ( 1 === preg_match( $yt_wrapper_with_inner_iframe_regex, $block_content ) ) {
+			return $block_content;
+		}
+
+		$video_url = ! empty( $block['attrs']['url'] ) ? esc_url( $block['attrs']['url'] ) : '';
+		$replace_regex = '/<div\s+class="wp-block-embed__wrapper">(.*?)<\/div>/s';
+
+		$updated_content = preg_replace_callback(
+			$replace_regex,
+			function ( $matches ) use ( $video_url, $block_content, $block ) {
+				return Astra_After_Setup_Theme::get_instance()->responsive_oembed_wrapper( '', $video_url, array(), true );
+				// return $matches[1] . '<div class="wp-block-group__inner-container">' . $matches[2] . '</div>' . $matches[3];
+			},
+			$block_content
+		);
+
+		return $updated_content;
+	}
 }
 
 /**


### PR DESCRIPTION
### Description
- It is embedded fine if used directly but does not work if the YouTube block is added in the container/column or even the cover block. It simply shows the video URL.

### Screenshots
- Edit CL - https://d.pr/i/Ul2Ux6
- Frontend (bug) - https://d.pr/i/xYa7wJ
- Frontend (fix) - https://d.pr/i/9FvBF7 

### Types of changes
- Bug fix 

### How has this been tested?
- Create a custom layout
- Add YouTube / Embed block within it 
- Wrap this block with 2/3 level like inside column/group etc
- Check on the frontend
- Also check these blocks in widget areas / entry content / sidebar / footer / etc (in any case this should fix)
- On sidnote - Here this PR this reverted - https://github.com/brainstormforce/astra-addon/pull/1671 so check the AST-1970 issue as well

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
