### PR TITLE
Fix: Added the text domain to two strings in UpgradeToPro.js

### DIFF
--- a/admin/assets/src/dashboard-app/pages/docs/Docs.js
+++ b/admin/assets/src/dashboard-app/pages/docs/Docs.js
@@ -54,7 +54,7 @@ const Docs = ({ setOpen }) => {
 					<div className="max-w-5xl mx-auto w-full relative">
 						<input
 							type="search"
-							placeholder="Search"
+							placeholder={__("Search", "astra")}
 							className="w-full ast-docs-search-fields text-base"
 							onChange={(e) => setSearchKeyword(e.target.value)}
 						/>

--- a/admin/assets/src/dashboard-app/pages/docs/UpgradeToPro.js
+++ b/admin/assets/src/dashboard-app/pages/docs/UpgradeToPro.js
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 const UpgradeToPro = () => {
 
 	const getAstraProTitle = () => {
-		return astra_admin.pro_installed_status ? __( 'Activate Now →' ) : __( 'Upgrade Now →' );
+		return astra_admin.pro_installed_status ? __( 'Activate Now →', 'astra' ) : __( 'Upgrade Now →', 'astra' );
 	}
 
 	const onUpgradeProTrigger = ( e ) => {


### PR DESCRIPTION
### Description
Fix: Added the text domain to two strings in UpgradeToPro.js and Docs.js

### Screenshots
<!-- if applicable -->

### Types of changes
Fix: Added the text domain to two strings in UpgradeToPro.js

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
