### PR TITLE
AST-3616 - Fix: astra_responsive_oembed_wrapper_enable filter

### DIFF
--- a/inc/compatibility/class-astra-gutenberg.php
+++ b/inc/compatibility/class-astra-gutenberg.php
@@ -184,7 +184,7 @@ class Astra_Gutenberg {
 			 * @return mixed          Updated content.
 			 */
 			function ( $matches ) use ( $video_url, $block_content, $block ) {
-				return Astra_After_Setup_Theme::get_instance()->responsive_oembed_wrapper( '', $video_url, array(), true );
+				return Astra_After_Setup_Theme::get_instance()->responsive_oembed_wrapper( $matches[1], $video_url, array(), true );
 			},
 			$block_content
 		);


### PR DESCRIPTION
the first parameter for the `responsive_oembed_wrapper` method should be `$matches[1]` but it is `''`. That renders the `astra_responsive_oembed_wrapper_enable` Filter in [/inc/class-astra-after-setup-theme.php](https://github.com/brainstormforce/astra/blob/v4.4.0/inc/class-astra-after-setup-theme.php#L247) useless.

