### PR TITLE
AST-3653 - Fix: Added old select2 dropdown arrow icon.

### DIFF
--- a/inc/customizer/custom-controls/assets/js/unminified/custom-controls-plain.js
+++ b/inc/customizer/custom-controls/assets/js/unminified/custom-controls-plain.js
@@ -1747,20 +1747,20 @@
 
 	Utils.Extend(SingleSelection, BaseSelection);
 
-	SingleSelection.prototype.render = function () {
-	  var $selection = SingleSelection.__super__.render.call(this);
+    SingleSelection.prototype.render = function () {
+      var $selection = SingleSelection.__super__.render.call(this);
 
-	  $selection.addClass('select2-selection--single');
+      $selection.addClass('select2-selection--single');
 
-    $selection.html(
-      '<span class="select2-selection__rendered"></span>' +
-      '<span class="select2-selection__arrow" role="presentation">' +
-	  	'<span class="dashicons dashicons-arrow-down-alt2"></span>' +
-	  '</span>'
-    );
+      $selection.html(
+        '<span class="select2-selection__rendered"></span>' +
+        '<span class="select2-selection__arrow" role="presentation">' +
+        '<span class="dashicons dashicons-arrow-down-alt2"></span>' +
+        '</span>'
+      );
 
-	  return $selection;
-	};
+      return $selection;
+    };
 
 	SingleSelection.prototype.bind = function (container, $container) {
 	  var self = this;

--- a/inc/customizer/custom-controls/assets/js/unminified/custom-controls-plain.js
+++ b/inc/customizer/custom-controls/assets/js/unminified/custom-controls-plain.js
@@ -1752,12 +1752,12 @@
 
 	  $selection.addClass('select2-selection--single');
 
-	  $selection.html(
-		'<span class="select2-selection__rendered"></span>' +
-		'<span class="select2-selection__arrow" role="presentation">' +
-		  '<b role="presentation"></b>' +
-		'</span>'
-	  );
+    $selection.html(
+      '<span class="select2-selection__rendered"></span>' +
+      '<span class="select2-selection__arrow" role="presentation">' +
+	  	'<span class="dashicons dashicons-arrow-down-alt2"></span>' +
+	  '</span>'
+    );
 
 	  return $selection;
 	};

--- a/inc/customizer/custom-controls/typography/selectWoo.css
+++ b/inc/customizer/custom-controls/typography/selectWoo.css
@@ -127,11 +127,11 @@
 
   .select2-container--default .select2-selection--single {
 	background-color: #fff;
-	border: 1px solid #aaa;
+	border: 1px solid #ddd;
 	border-radius: 4px; }
 	.select2-container--default .select2-selection--single .select2-selection__rendered {
 	  color: #444;
-	  line-height: 28px; }
+	  line-height: 2; }
 	.select2-container--default .select2-selection--single .select2-selection__clear {
 	  cursor: pointer;
 	  float: right;

--- a/inc/customizer/custom-controls/typography/selectWoo.css
+++ b/inc/customizer/custom-controls/typography/selectWoo.css
@@ -1,4 +1,5 @@
 .select2-container {
+	font-size: 14px;
 	box-sizing: border-box;
 	display: inline-block;
 	margin: 0;
@@ -8,7 +9,9 @@
 	  box-sizing: border-box;
 	  cursor: pointer;
 	  display: block;
-	  height: 28px;
+	  min-height: 32px;
+	  padding-top: 1px;
+	  padding-bottom: 1px;
 	  user-select: none;
 	  -webkit-user-select: none; }
 	  .select2-container .select2-selection--single .select2-selection__rendered {

--- a/inc/customizer/custom-controls/typography/selectWoo.css
+++ b/inc/customizer/custom-controls/typography/selectWoo.css
@@ -141,9 +141,9 @@
 	.select2-container--default .select2-selection--single .select2-selection__arrow {
 	  position: absolute;
     top: 50%;
-	transform: translateY(-50%);
-	display: flex;
-	justify-content: center;
+	  transform: translateY(-50%);
+	  display: flex;
+	  justify-content: center;
     right: 1px;
     width: 24px; }
    	.select2-container--default .select2-selection--single .select2-selection__arrow .dashicons {

--- a/inc/customizer/custom-controls/typography/selectWoo.css
+++ b/inc/customizer/custom-controls/typography/selectWoo.css
@@ -139,22 +139,30 @@
 	.select2-container--default .select2-selection--single .select2-selection__placeholder {
 	  color: #999; }
 	.select2-container--default .select2-selection--single .select2-selection__arrow {
-	  height: 26px;
 	  position: absolute;
-	  top: 1px;
-	  right: 1px;
-	  width: 20px; }
-	  .select2-container--default .select2-selection--single .select2-selection__arrow b {
-		border-color: #888 transparent transparent transparent;
-		border-style: solid;
-		border-width: 5px 4px 0 4px;
-		height: 0;
-		left: 50%;
-		margin-left: -4px;
-		margin-top: -2px;
-		position: absolute;
-		top: 50%;
-		width: 0; }
+    top: 50%;
+	transform: translateY(-50%);
+	display: flex;
+	justify-content: center;
+    right: 1px;
+    width: 24px; }
+   	.select2-container--default .select2-selection--single .select2-selection__arrow .dashicons {
+		font-size: 16px;
+		width: 16px;
+		height: 16px;
+		color: #4B5563;
+	}
+    .select2-container--default .select2-selection--single .select2-selection__arrow b {
+      border-color: #888 transparent transparent transparent;
+      border-style: solid;
+      border-width: 5px 4px 0 4px;
+      height: 0;
+      left: 50%;
+      margin-left: -4px;
+      margin-top: -2px;
+      position: absolute;
+      top: 50%;
+      width: 0; }
 
   .select2-container--default[dir="rtl"] .select2-selection--single .select2-selection__clear {
 	float: left; }

--- a/inc/customizer/custom-controls/typography/selectWoo.js
+++ b/inc/customizer/custom-controls/typography/selectWoo.js
@@ -1530,12 +1530,12 @@
 
 	  $selection.addClass('select2-selection--single');
 
-	  $selection.html(
-		'<span class="select2-selection__rendered"></span>' +
-		'<span class="select2-selection__arrow" role="presentation">' +
-		  '<b role="presentation"></b>' +
-		'</span>'
-	  );
+    $selection.html(
+      '<span class="select2-selection__rendered"></span>' +
+      '<span class="select2-selection__arrow" role="presentation">' +
+	  	'<span class="dashicons dashicons-arrow-down-alt2"></span>' +
+	  '</span>'
+    );
 
 	  return $selection;
 	};

--- a/inc/customizer/custom-controls/typography/selectWoo.js
+++ b/inc/customizer/custom-controls/typography/selectWoo.js
@@ -1525,20 +1525,20 @@
 
 	Utils.Extend(SingleSelection, BaseSelection);
 
-	SingleSelection.prototype.render = function () {
-	  var $selection = SingleSelection.__super__.render.call(this);
+    SingleSelection.prototype.render = function () {
+      var $selection = SingleSelection.__super__.render.call(this);
 
-	  $selection.addClass('select2-selection--single');
+      $selection.addClass('select2-selection--single');
 
-    $selection.html(
-      '<span class="select2-selection__rendered"></span>' +
-      '<span class="select2-selection__arrow" role="presentation">' +
-	  	'<span class="dashicons dashicons-arrow-down-alt2"></span>' +
-	  '</span>'
-    );
+      $selection.html(
+        '<span class="select2-selection__rendered"></span>' +
+        '<span class="select2-selection__arrow" role="presentation">' +
+        '<span class="dashicons dashicons-arrow-down-alt2"></span>' +
+        '</span>'
+      );
 
-	  return $selection;
-	};
+      return $selection;
+    };
 
 	SingleSelection.prototype.bind = function (container, $container) {
 	  var self = this;


### PR DESCRIPTION
**Description**: In typography font family and font-weight dropdowns are not matching

**Current Behavior:**

- https://d.pr/i/35Lj0N 

**Expected Result:** 

- https://d.pr/i/mxZESl

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

- Minor Styling change - Non-breaking change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

- Test cases mention in the [task](https://brainstormforce.atlassian.net/browse/AST-3653)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
