### PR TITLE
AST-3658 - Fix: WooCommerce - Boxed Style Option not working on WooCommerce Cart & Checkout Pages.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.1 (Unreleased)
+- Fix: WooCommerce - Boxed Page Setting Option not working on Cart & Checkout Page.
+
 v4.5.0 (Unreleased)
 - New: Site Builder Free Version Preview.
 - New: Introducing fresh color presets to supercharge your site design.

--- a/inc/markup-extras.php
+++ b/inc/markup-extras.php
@@ -195,7 +195,7 @@ function astra_is_content_style_boxed( $post_id = false ) {
 		$global_content_style = ( 'default' === $third_party_content_style || empty( $third_party_content_style ) ) ? $global_content_style : $third_party_content_style;
 
 		// Woo Cart & Checkout Page
-		if ( 'woocommerce' === $third_party && ( is_cart() || is_checkout() ) ) {
+		if ( 'woocommerce' === $third_party && ( is_cart() || is_checkout() ) && empty( $meta_content_style ) ) {
 			return ( 'boxed' === $global_content_style );
 		}
 
@@ -300,7 +300,7 @@ function astra_is_sidebar_style_boxed( $post_id = false ) {
 		$global_sidebar_style = ( 'default' === $third_party_sidebar_style || empty( $third_party_sidebar_style ) ) ? $global_sidebar_style : $third_party_sidebar_style;
 
 		// Woo Cart & Checkout Page
-		if ( 'woocommerce' === $third_party && ( is_cart() || is_checkout() ) ) {
+		if ( 'woocommerce' === $third_party && ( is_cart() || is_checkout() ) && empty( $meta_sidebar_style ) ) {
 			return ( 'boxed' === $global_sidebar_style );
 		}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- The Boxed Option for Container Style is not working for WooCommerce Cart & Checkout Pages.
- JIRA - https://brainstormforce.atlassian.net/browse/AST-3658

### Screenshots
<!-- if applicable -->
https://d.pr/i/tulLJ4

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- WooCommerce Cart Page Meta Setting for Boxed should Override WooCommerce General Settings for Container Style.
- WooCommerce Checkout Page Meta Setting for Boxed should Override WooCommerce General Settings for Container Style.
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
