### PR TITLE
AST-3669 - Fix: menu section configurations missing under customizer

### DIFF
--- a/inc/customizer/configurations/builder/header/configs/menu.php
+++ b/inc/customizer/configurations/builder/header/configs/menu.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array Astra Customizer Configurations with updated configurations.
  */
 function astra_header_menu_configuration() {
-	$_configs = array();
+	$menu_configs = array();
 
 	$component_limit = defined( 'ASTRA_EXT_VER' ) ? Astra_Builder_Helper::$component_limit : Astra_Builder_Helper::$num_of_header_menu;
 
@@ -646,17 +646,17 @@ function astra_header_menu_configuration() {
 			),
 		);
 
-		$_configs[] = Astra_Builder_Base_Configuration::prepare_visibility_tab( $_section );
-		$_configs[] = $_configs;
+		$menu_configs[] = Astra_Builder_Base_Configuration::prepare_visibility_tab( $_section );
+		$menu_configs[] = $_configs;
 	}
 
-	$_configs = call_user_func_array( 'array_merge', $_configs + array( array() ) );
+	$menu_configs = call_user_func_array( 'array_merge', $menu_configs + array( array() ) );
 
 	if ( Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
-		array_map( 'astra_save_header_customizer_configs', $_configs );
+		array_map( 'astra_save_header_customizer_configs', $menu_configs );
 	}
 
-	return $_configs;
+	return $menu_configs;
 }
 
 if ( Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {


### PR DESCRIPTION
### Description
- Menu section from customizer is not opening 
- Configurations got missed through looping

### Screenshots
- https://d.pr/v/ATbbb5

### Types of changes
- Bug fix 

### How has this been tested?
- Check the menu section (exact fix)
- Check other element sections under header-footer builder
- Check some cloned element section (html / button / any)

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
