### PR TITLE
AST-3688 - Fix: footer builder panel missing in customizer

### DIFF
--- a/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-builder-configs.php
+++ b/inc/customizer/configurations/builder/footer/class-astra-customizer-footer-builder-configs.php
@@ -35,8 +35,8 @@ class Astra_Customizer_Footer_Builder_Configs extends Astra_Customizer_Config_Ba
 	 * @return Array Astra Customizer Configurations with updated configurations.
 	 */
 	public function register_configuration( $configurations, $wp_customize ) {
-		$configurations = astra_builder_footer_configuration( $configurations );
-		return $configurations;
+		$_configs = astra_builder_footer_configuration();
+		return array_merge( $configurations, $_configs );
 	}
 }
 

--- a/inc/customizer/configurations/builder/footer/configs/footer-builder.php
+++ b/inc/customizer/configurations/builder/footer/configs/footer-builder.php
@@ -16,10 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Register builder footer builder Customizer Configurations.
  *
+ * @param array $configurations Astra Customizer Configurations.
  * @since x.x.x
  * @return array Astra Customizer Configurations with updated configurations.
  */
-function astra_builder_footer_configuration() {
+function astra_builder_footer_configuration( $configurations = array() ) {
 	$cloned_component_track         = Astra_Builder_Helper::$component_count_array;
 	$widget_config                  = array();
 	$astra_has_widgets_block_editor = astra_has_widgets_block_editor();

--- a/inc/customizer/configurations/builder/footer/configs/footer-builder.php
+++ b/inc/customizer/configurations/builder/footer/configs/footer-builder.php
@@ -16,11 +16,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Register builder footer builder Customizer Configurations.
  *
- * @param Array $configurations Astra Customizer Configurations.
  * @since x.x.x
  * @return array Astra Customizer Configurations with updated configurations.
  */
-function astra_builder_footer_configuration( $configurations = array() ) {
+function astra_builder_footer_configuration() {
 	$cloned_component_track         = Astra_Builder_Helper::$component_count_array;
 	$widget_config                  = array();
 	$astra_has_widgets_block_editor = astra_has_widgets_block_editor();


### PR DESCRIPTION
### Description
- Fix: footer builder not opening under customizer

### Screenshots
- https://d.pr/i/X5IlDG

### Types of changes
- Bug fix

### How has this been tested?
- Check footer builder panel (main bug)
- Check some other builder sections

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
