### PR TITLE
AST-3607 - Fix:Border focus color not inherited correct input focus styling.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ v4.6.0 (Unreleased)
 - Fix: Kadence Tabs Block scrolling issue with Astra.
 - Fix: WooCommerce - Inside dropdown cart buttons are not aligned properly on WooCommerce pages.
 - Fix: WooCommerce - Shop card structure gets broken if the Add To Cart button is kept just below the title.
+- Fix: Input fields border focus did not consistently inherit the correct styling in certain scenarios.
 
 v4.5.1
 - Improvement: Compatibility with WooCommerce 8.3.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -873,7 +873,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 					'outline-style' => $outline_style ? $outline_style : 'inherit',
 					'outline-color' => $outline_color ? $outline_color : 'inherit',
 					'outline-width' => 'thin',
-					'border-color'  => 'transparent',
+					'border-color'  => astra_get_option( 'site-accessibility-highlight-input-color' ),
 				);
 
 				if ( 'disable' !== $outline_input_style ) {
@@ -881,16 +881,20 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 						'border-style'  => $outline_input_style ? $outline_input_style : 'inherit',
 						'border-color'  => $outline_input_color ? $outline_input_color : 'inherit',
 						'border-width'  => 'thin',
-						'outline-color' => 'transparent',
+						'outline-color' => astra_get_option( 'site-accessibility-highlight-input-color' ),
 					);
 				} else {
 					$css_output[ $html_selectors_focus_only_inputs ] = array(
 						'border-style'  => $outline_style ? $outline_style : 'inherit',
 						'border-color'  => $outline_color ? $outline_color : 'inherit',
 						'border-width'  => 'thin',
-						'outline-color' => 'transparent',
+						'outline-color' => astra_get_option( 'site-accessibility-highlight-input-color' ),
 					);
 				}
+
+				$css_output['input'] = array(
+					'outline' => 'none',
+				);
 			}
 
 			if ( false === $enable_site_accessibility ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
