### PR TITLE
AST-3715 - Fix: Woo 8.4 compatibility with Astra

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.2 (Unreleased)
+- Fix: WooCommerce - Version 8.4 compatibility.
+
 v4.5.1
 - Improvement: Compatibility with WooCommerce 8.3.
 - Improvement: Introducing a new filter 'astra_embed_wrapper_class' to add a class to the iframe wrapper for embed blocks.

--- a/inc/class-astra-after-setup-theme.php
+++ b/inc/class-astra-after-setup-theme.php
@@ -189,6 +189,9 @@ if ( ! class_exists( 'Astra_After_Setup_Theme' ) ) {
 			// Remove Template Editor support until WP 5.9 since more Theme Blocks are going to be introduced.
 			remove_theme_support( 'block-templates' );
 
+			// Let WooCommerce know, Astra is not compatible with New Product Editor.
+			add_filter( 'option_woocommerce_feature_product_block_editor_enabled', '__return_false' );
+
 			add_filter( 'woocommerce_create_pages', array( $this, 'astra_enforce_woo_shortcode_pages' ), 99 );
 		}
 


### PR DESCRIPTION
### Description
- New product editor not working with the classic Astra theme, so restricting it as incompatibility.

### Screenshots
<!-- if applicable -->

### Types of changes
- Bug fix

### How has this been tested?
- Check the new product editor

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
