### PR TITLE
AST-3710 - Fix: PHP deprecated notices with php 8 and above when activa…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ v4.6.0 (Unreleased)
 - Fix: WooCommerce - Inside dropdown cart buttons are not aligned properly on WooCommerce pages.
 - Fix: WooCommerce - Shop card structure gets broken if the Add To Cart button is kept just below the title.
 - Fix: Input fields border focus did not consistently inherit the correct styling in certain scenarios.
+- Fix: PHP deprecated notices with PHP 8.0 and above when activating the theme.
 
 v4.5.1
 - Improvement: Compatibility with WooCommerce 8.3.

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -5362,7 +5362,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 		 * @return boolean false if it is an existing user, true if not.
 		 */
 		public static function astra_4_4_0_compatibility() {
-			$astra_settings                           = get_option( ASTRA_THEME_SETTINGS );
+			$astra_settings                           = get_option( ASTRA_THEME_SETTINGS, array() );
 			$astra_settings['v4-4-0-backward-option'] = isset( $astra_settings['v4-4-0-backward-option'] ) ? false : true;
 			return apply_filters( 'astra_addon_upgrade_fullscreen_search_submit_style', $astra_settings['v4-4-0-backward-option'] );
 		}
@@ -5374,7 +5374,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 		 * @return boolean false if it is an existing user, true if not.
 		 */
 		public static function astra_4_5_0_compatibility() {
-			$astra_settings                           = get_option( ASTRA_THEME_SETTINGS );
+			$astra_settings                           = get_option( ASTRA_THEME_SETTINGS, array() );
 			$astra_settings['v4-5-0-backward-option'] = isset( $astra_settings['v4-5-0-backward-option'] ) ? false : true;
 			return apply_filters( 'astra_upgrade_color_styles', $astra_settings['v4-5-0-backward-option'] );
 		}
@@ -5386,7 +5386,7 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 		 * @return boolean false if it is an existing user, true if not.
 		 */
 		public static function astra_forms_default_style_update() {
-			$astra_settings                                   = get_option( ASTRA_THEME_SETTINGS );
+			$astra_settings                                   = get_option( ASTRA_THEME_SETTINGS, array() );
 			$astra_settings['ast-forms-default-style-update'] = isset( $astra_settings['ast-forms-default-style-update'] ) ? false : true;
 			return apply_filters( 'astra_forms_default_style_update', $astra_settings['ast-forms-default-style-update'] );
 		}

--- a/inc/class-astra-dynamic-css.php
+++ b/inc/class-astra-dynamic-css.php
@@ -5292,17 +5292,5 @@ if ( ! class_exists( 'Astra_Dynamic_CSS' ) ) {
 			$astra_settings['v4-5-0-backward-option'] = isset( $astra_settings['v4-5-0-backward-option'] ) ? false : true;
 			return apply_filters( 'astra_upgrade_color_styles', $astra_settings['v4-5-0-backward-option'] );
 		}
-
-		/**
-		 * Astra Forms default style update.
-		 *
-		 * @since x.x.x
-		 * @return boolean false if it is an existing user, true if not.
-		 */
-		public static function astra_forms_default_style_update() {
-			$astra_settings                                   = get_option( ASTRA_THEME_SETTINGS, array() );
-			$astra_settings['ast-forms-default-style-update'] = isset( $astra_settings['ast-forms-default-style-update'] ) ? false : true;
-			return apply_filters( 'astra_forms_default_style_update', $astra_settings['ast-forms-default-style-update'] );
-		}
 	}
 }


### PR DESCRIPTION
Description: Showing deprecated notice when we activate theme by using 8.x php version

Screenshot: [Annotation on 2023-12-07 at 11-27-12.png](https://bsf.d.pr/i/JxH6il)

### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->
Notice: https://bsf.d.pr/i/JxH6il

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
