### PR TITLE
AST-3721 - fix: PHP fatal error 'Uncaught Error: Call to a member function get_cart_contents_total() on null'

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ v4.5.2 (Unreleased)
 - Fix: WooCommerce - Inside dropdown cart buttons are not aligned properly on WooCommerce pages.
 - Fix: WooCommerce - Shop card structure gets broken if the Add To Cart button is kept just below the title.
 - Fix: Input fields border focus did not consistently inherit the correct styling in certain scenarios.
+- Fix: WooCommerce - PHP fatal error 'Uncaught Error: Call to a member function get_cart_contents_total() on null' when cart element is added in the header and "Hide Cart Total Label" option is enabled.
 
 v4.5.1
 - Improvement: Compatibility with WooCommerce 8.3.

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -538,7 +538,9 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			$cart_total_markup         = '';
 			$cart_total_only_markup    = '';
 
+			/** @psalm-suppress RedundantConditionGivenDocblockType */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$cart_check_total          = astra_get_option( 'woo-header-cart-total-label' ) && null !== WC()->cart ? intval( WC()->cart->get_cart_contents_total() ) > 0 : true;
+			/** @psalm-suppress RedundantConditionGivenDocblockType */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 
 			if ( null !== WC()->cart ) {
 				if ( $cart_check_total ) {
@@ -3307,7 +3309,9 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 
 			$view_shopping_cart = apply_filters( 'astra_woo_view_shopping_cart_title', __( 'View your shopping cart', 'astra' ) );
 			$woo_cart_link      = wc_get_cart_url();
+			/** @psalm-suppress RedundantConditionGivenDocblockType */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$cart_count         = null !== WC()->cart ? WC()->cart->get_cart_contents_count() : 0;
+			/** @psalm-suppress RedundantConditionGivenDocblockType */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$aria_label         = $cart_count > 0 ? "View Shopping Cart, {$cart_count} items" : 'View Shopping Cart, empty';
 
 			// Do not redirect to Cart Page in Customizer Preview & when 'Cart Page' option is not selected.

--- a/inc/compatibility/woocommerce/class-astra-woocommerce.php
+++ b/inc/compatibility/woocommerce/class-astra-woocommerce.php
@@ -537,8 +537,8 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 			$cart_total_label_position = astra_get_option( 'woo-header-cart-icon-total-label-position' );
 			$cart_total_markup         = '';
 			$cart_total_only_markup    = '';
-			$cart_check_total          = astra_get_option( 'woo-header-cart-total-label' ) ? intval( WC()->cart->get_cart_contents_total() ) > 0 : true;
 
+			$cart_check_total          = astra_get_option( 'woo-header-cart-total-label' ) && null !== WC()->cart ? intval( WC()->cart->get_cart_contents_total() ) > 0 : true;
 
 			if ( null !== WC()->cart ) {
 				if ( $cart_check_total ) {
@@ -3307,9 +3307,9 @@ if ( ! class_exists( 'Astra_Woocommerce' ) ) :
 
 			$view_shopping_cart = apply_filters( 'astra_woo_view_shopping_cart_title', __( 'View your shopping cart', 'astra' ) );
 			$woo_cart_link      = wc_get_cart_url();
-			$cart_count         = WC()->cart->get_cart_contents_count();
+			$cart_count         = null !== WC()->cart ? WC()->cart->get_cart_contents_count() : 0;
 			$aria_label         = $cart_count > 0 ? "View Shopping Cart, {$cart_count} items" : 'View Shopping Cart, empty';
-		
+
 			// Do not redirect to Cart Page in Customizer Preview & when 'Cart Page' option is not selected.
 			if ( is_customize_preview() && 'redirect' !== astra_get_option( 'woo-header-cart-click-action' ) ) {
 				$woo_cart_link = '#';


### PR DESCRIPTION
### Description
- Cart with "Hide Cart Total Label" throwing fatal error in editor with Starter Template

### Screenshots
- https://d.pr/v/pZddub

### Types of changes
- Bug fix 

### How has this been tested?
- Test data added in the cart

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
