### PR TITLE
AST-3722 - improvememt: added compatibility for header-footer dynamic CSS fetching for template blocks

### DIFF
--- a/inc/builder/type/footer/above-footer/class-astra-above-footer.php
+++ b/inc/builder/type/footer/above-footer/class-astra-above-footer.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Above_Footer' ) ) {
 			require_once ASTRA_BUILDER_FOOTER_ABOVE_FOOTER_DIR . '/class-astra-above-footer-component-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_BUILDER_FOOTER_ABOVE_FOOTER_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/below-footer/class-astra-below-footer.php
+++ b/inc/builder/type/footer/below-footer/class-astra-below-footer.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Below_Footer' ) ) {
 			require_once ASTRA_BUILDER_FOOTER_BELOW_FOOTER_DIR . '/class-astra-below-footer-component-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_BUILDER_FOOTER_BELOW_FOOTER_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/button/class-astra-footer-button-component.php
+++ b/inc/builder/type/footer/button/class-astra-footer-button-component.php
@@ -33,7 +33,7 @@ class Astra_Footer_Button_Component {
 		require_once ASTRA_FOOTER_BUTTON_DIR . '/class-astra-footer-button-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_FOOTER_BUTTON_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/copyright/class-astra-footer-copyright-component.php
+++ b/inc/builder/type/footer/copyright/class-astra-footer-copyright-component.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Footer_Copyright_Component' ) ) {
 			require_once ASTRA_BUILDER_FOOTER_COPYRIGHT_DIR . '/class-astra-footer-copyright-component-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_BUILDER_FOOTER_COPYRIGHT_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/html/class-astra-footer-html-component.php
+++ b/inc/builder/type/footer/html/class-astra-footer-html-component.php
@@ -32,7 +32,7 @@ class Astra_Footer_Html_Component {
 		require_once ASTRA_BUILDER_FOOTER_HTML_DIR . '/class-astra-footer-html-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_FOOTER_HTML_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/menu/class-astra-footer-menu-component.php
+++ b/inc/builder/type/footer/menu/class-astra-footer-menu-component.php
@@ -32,7 +32,7 @@ class Astra_Footer_Menu_Component {
 		require_once ASTRA_BUILDER_FOOTER_MENU_DIR . '/class-astra-footer-menu-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_FOOTER_MENU_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/primary-footer/class-astra-primary-footer.php
+++ b/inc/builder/type/footer/primary-footer/class-astra-primary-footer.php
@@ -34,8 +34,7 @@ if ( ! class_exists( 'Astra_Primary_Footer' ) ) {
 			require_once ASTRA_BUILDER_FOOTER_PRIMARY_FOOTER_DIR . '/class-astra-primary-footer-component-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
-
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_BUILDER_FOOTER_PRIMARY_FOOTER_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/social-icon/class-astra-footer-social-icons-component.php
+++ b/inc/builder/type/footer/social-icon/class-astra-footer-social-icons-component.php
@@ -32,7 +32,7 @@ class Astra_Footer_Social_Icons_Component {
 		require_once ASTRA_BUILDER_FOOTER_SOCIAL_ICONS_DIR . '/class-astra-footer-social-icons-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_FOOTER_SOCIAL_ICONS_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/footer/widget/class-astra-footer-widget-component.php
+++ b/inc/builder/type/footer/widget/class-astra-footer-widget-component.php
@@ -32,7 +32,7 @@ class Astra_Footer_Widget_Component {
 		require_once ASTRA_BUILDER_FOOTER_WIDGET_DIR . '/class-astra-footer-widget-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_FOOTER_WIDGET_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/above-header/class-astra-above-header.php
+++ b/inc/builder/type/header/above-header/class-astra-above-header.php
@@ -31,7 +31,7 @@ class Astra_Above_Header {
 		require_once ASTRA_ABOVE_HEADER_DIR . '/class-astra-above-header-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_ABOVE_HEADER_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/account/class-astra-header-account-component.php
+++ b/inc/builder/type/header/account/class-astra-header-account-component.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Header_Account_Component' ) ) {
 			require_once ASTRA_HEADER_ACCOUNT_DIR . '/class-astra-header-account-component-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_HEADER_ACCOUNT_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/below-header/class-astra-below-header.php
+++ b/inc/builder/type/header/below-header/class-astra-below-header.php
@@ -32,7 +32,7 @@ class Astra_Below_Header {
 		require_once ASTRA_BELOW_HEADER_DIR . '/class-astra-below-header-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BELOW_HEADER_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/button/class-astra-header-button-component.php
+++ b/inc/builder/type/header/button/class-astra-header-button-component.php
@@ -33,7 +33,7 @@ class Astra_Header_Button_Component {
 		require_once ASTRA_HEADER_BUTTON_DIR . '/class-astra-header-button-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_BUTTON_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/edd-cart/class-astra-header-edd-cart-component.php
+++ b/inc/builder/type/header/edd-cart/class-astra-header-edd-cart-component.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Header_Edd_Cart_Component' ) ) {
 			require_once ASTRA_HEADER_EDD_CART_DIR . '/class-astra-header-edd-cart-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_HEADER_EDD_CART_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/html/class-astra-header-html-component.php
+++ b/inc/builder/type/header/html/class-astra-header-html-component.php
@@ -32,7 +32,7 @@ class Astra_Header_Html_Component {
 		require_once ASTRA_HEADER_HTML_DIR . '/class-astra-header-html-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_HTML_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/menu/class-astra-header-menu-component.php
+++ b/inc/builder/type/header/menu/class-astra-header-menu-component.php
@@ -31,7 +31,7 @@ class Astra_Header_Menu_Component {
 		require_once ASTRA_HEADER_MENU_DIR . '/class-astra-header-menu-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_MENU_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/mobile-menu/class-astra-mobile-menu-component.php
+++ b/inc/builder/type/header/mobile-menu/class-astra-mobile-menu-component.php
@@ -32,7 +32,7 @@ class Astra_Mobile_Menu_Component {
 		require_once ASTRA_BUILDER_MOBILE_MENU_DIR . '/class-astra-mobile-menu-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_MOBILE_MENU_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/mobile-trigger/class-astra-mobile-trigger.php
+++ b/inc/builder/type/header/mobile-trigger/class-astra-mobile-trigger.php
@@ -31,7 +31,7 @@ class Astra_Mobile_Trigger {
 		require_once ASTRA_MOBILE_TRIGGER_DIR . '/class-astra-mobile-trigger-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_MOBILE_TRIGGER_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/off-canvas/class-astra-off-canvas.php
+++ b/inc/builder/type/header/off-canvas/class-astra-off-canvas.php
@@ -32,7 +32,7 @@ class Astra_Off_Canvas {
 		require_once ASTRA_OFF_CANVAS_DIR . '/class-astra-off-canvas-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_OFF_CANVAS_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/primary-header/class-astra-primary-header.php
+++ b/inc/builder/type/header/primary-header/class-astra-primary-header.php
@@ -31,7 +31,7 @@ class Astra_Primary_Header {
 		require_once ASTRA_PRIMARY_HEADER_DIR . '/class-astra-primary-header-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_PRIMARY_HEADER_DIR . '/dynamic-css/dynamic.css.php';
 			remove_filter( 'astra_dynamic_theme_css', 'astra_header_breakpoint_style' );
 		}

--- a/inc/builder/type/header/search/class-astra-header-search-component.php
+++ b/inc/builder/type/header/search/class-astra-header-search-component.php
@@ -32,7 +32,7 @@ class Astra_Header_Search_Component {
 		require_once ASTRA_HEADER_SEARCH_DIR . '/class-astra-header-search-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_SEARCH_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/site-identity/class-astra-header-site-identity-component.php
+++ b/inc/builder/type/header/site-identity/class-astra-header-site-identity-component.php
@@ -31,7 +31,7 @@ class Astra_Header_Site_Identity_Component {
 		require_once ASTRA_HEADER_SITE_IDENTITY_DIR . '/class-astra-header-site-identity-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_SITE_IDENTITY_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/social-icon/class-astra-header-social-icon-component.php
+++ b/inc/builder/type/header/social-icon/class-astra-header-social-icon-component.php
@@ -32,7 +32,7 @@ class Astra_Header_Social_Icon_Component {
 		require_once ASTRA_HEADER_SOCIAL_ICON_DIR . '/class-astra-header-social-icon-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_HEADER_SOCIAL_ICON_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/widget/class-astra-header-widget-component.php
+++ b/inc/builder/type/header/widget/class-astra-header-widget-component.php
@@ -32,7 +32,7 @@ class Astra_Header_Widget_Component {
 		require_once ASTRA_BUILDER_HEADER_WIDGET_DIR . '/class-astra-header-widget-component-loader.php';
 
 		// Include front end files.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 			require_once ASTRA_BUILDER_HEADER_WIDGET_DIR . '/dynamic-css/dynamic.css.php';
 		}
 		// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/builder/type/header/woo-cart/class-astra-header-woo-cart-component.php
+++ b/inc/builder/type/header/woo-cart/class-astra-header-woo-cart-component.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Astra_Header_Woo_Cart_Component' ) ) {
 			require_once ASTRA_HEADER_WOO_CART_DIR . '/class-astra-header-woo-cart-loader.php';
 
 			// Include front end files.
-			if ( ! is_admin() ) {
+			if ( ! is_admin() || Astra_Builder_Customizer::astra_collect_customizer_builder_data() ) {
 				require_once ASTRA_HEADER_WOO_CART_DIR . '/dynamic-css/dynamic.css.php';
 			}
 			// @codingStandardsIgnoreEnd WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound

--- a/inc/metabox/class-astra-meta-boxes.php
+++ b/inc/metabox/class-astra-meta-boxes.php
@@ -238,7 +238,7 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 					'sfwd-lessons',
 					'sfwd-topic',
 					'groups',
-				) 
+				)
 			) : '';
 			$show_meta_field         = ! self::is_bb_themer_layout();
 			$old_meta_layout         = isset( $meta['site-content-layout']['default'] ) ? $meta['site-content-layout']['default'] : '';
@@ -282,7 +282,7 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 						break;
 				}
 			}
-				
+
 			/**
 			 * Option: Content Layout.
 			 */
@@ -539,13 +539,13 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 				if ( $meta_value ) {
 					update_post_meta( $post_id, $key, $meta_value );
 
-					// Update meta key (flag) as old user migration is already completed at this point. 
+					// Update meta key (flag) as old user migration is already completed at this point.
 					update_post_meta( $post_id, 'astra-migrate-meta-layouts', 'set' );
 				} else {
 
 					/** @psalm-suppress InvalidArgument */
 					delete_post_meta( $post_id, $key );
-				}           
+				}
 			}
 
 		}
@@ -777,7 +777,7 @@ if ( ! class_exists( 'Astra_Meta_Boxes' ) ) {
 					'sfwd-lessons',
 					'sfwd-topic',
 					'groups',
-				) 
+				)
 			);
 			if ( astra_with_third_party() || $exclude_cpt ) {
 				return array(


### PR DESCRIPTION
### Description
- AI Template Blocks: Requirement of a endpoint to fetch header-footer customizer's dynamic CSS in editor

### Screenshots
<!-- if applicable -->

### Types of changes
- New feature (non-breaking change)

### How has this been tested?
- As per the test cases added in the card

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
