### PR TITLE
AST-3728 - Fix: Site crashing issue for old header builder user due to recent update.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v4.5.3 (Unreleased)
 - Fix: Logo color not working in FireFox browser.
 - Fix: Site title, tagline font-sizes are not part of export-import header settings.
+- Fix: WooCommerce - PHP fatal error for old header footer builder users 'Call to undefined function astra_header_woo_cart_configuration' when WooCommerce is enable.
 
 v4.5.2
 - New: Compatibility to Import Export header-footer builder customizer layouts with the "Astra Import Export" plugin.

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
@@ -38,7 +38,7 @@ class Astra_Customizer_Woo_Cart_Configs extends Astra_Customizer_Config_Base {
 		if ( is_callable( 'astra_header_woo_cart_configuration' ) ) {
 			$configurations = astra_header_woo_cart_configuration( $configurations );
 		}
-			return $configurations;
+		return $configurations;
 	}
 }
 

--- a/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
+++ b/inc/customizer/configurations/builder/header/class-astra-customizer-woo-cart-configs.php
@@ -35,8 +35,10 @@ class Astra_Customizer_Woo_Cart_Configs extends Astra_Customizer_Config_Base {
 	 * @return Array Astra Customizer Configurations with updated configurations.
 	 */
 	public function register_configuration( $configurations, $wp_customize ) {
-		$configurations = astra_header_woo_cart_configuration( $configurations );
-		return $configurations;
+		if ( is_callable( 'astra_header_woo_cart_configuration' ) ) {
+			$configurations = astra_header_woo_cart_configuration( $configurations );
+		}
+			return $configurations;
 	}
 }
 


### PR DESCRIPTION
Site crashing issue for old header builders user due to recent update.

**Steps To Reproduce:** 

1. Switch to old header builder - Use filter - add_filter( 'astra_is_header_footer_builder_active', '__return_false' );
2. Make sure WooCommerce is Installed.
3. Check inside the customiser, you will see the error.

**Thread** - https://brainstormforce.slack.com/archives/CDS7TQ75Z/p1702471401993739

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
